### PR TITLE
Implement gru fix command with delegation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn handle_fix(issue: &str) -> ! {
         .status();
 
     match result {
-        Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+        Ok(status) => std::process::exit(status.code().unwrap_or(128)),
         Err(e) => {
             if e.kind() == std::io::ErrorKind::NotFound {
                 eprintln!("Error: 'claude' command not found. Please install Claude CLI first.");


### PR DESCRIPTION
## Summary

Implements the MVP `gru fix` subcommand that delegates to the Claude CLI's `/fix` command.

## Changes

- Updated issue argument to accept `String` (handles both issue numbers and URLs)
- Implemented `handle_fix` function that spawns `claude` CLI as a subprocess
- Properly inherits stdin/stdout/stderr for real-time interaction with Claude
- Passes `/fix` and issue as separate arguments to Claude
- Returns never type (`-> !`) for correct control flow
- Clear error message when `claude` command is not found
- Exit with Claude's exit code for proper shell integration

## Test Plan

- ✅ `cargo build` succeeds
- ✅ `cargo clippy` passes with no warnings
- ✅ `gru fix --help` shows correct usage
- ✅ Error handling tested with `PATH="" gru fix 123`
- Ready for integration testing with actual Claude CLI

## Acceptance Criteria

All requirements from issue #2 are met:

- ✅ Parse issue argument (number or URL)
- ✅ Launch `claude` CLI with `/fix <issue>` command
- ✅ Pass through stdin/stdout/stderr (user sees Claude directly)
- ✅ Exit with Claude's exit code
- ✅ Handle case where `claude` command not found

Fixes #2