### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "cargo-deps"
+
+      - name: Install Just
+        uses: extractions/setup-just@v2
+
+      - name: Run checks
+        run: just check


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow that validates pull requests and commits using Justfile recipes, ensuring consistency between local development and CI.

## Changes

- Created `.github/workflows/ci.yml` with the following features:
  - Triggers on pull requests and pushes to main branch
  - Sets up Rust toolchain with rustfmt and clippy components
  - Installs Just command runner
  - Implements cargo dependency caching using `rust-cache@v2` for faster builds
  - Runs all checks via `just check` (format check, lint, test, build)

## Implementation Details

The workflow uses modern, maintained GitHub Actions:
- `actions/checkout@v4` - Code checkout
- `dtolnay/rust-toolchain@stable` - Rust toolchain setup
- `Swatinem/rust-cache@v2` - Efficient cargo caching
- `extractions/setup-just@v2` - Just installation

## Test Plan

- [x] Verified `just check` passes locally
- [x] All checks completed successfully (fmt, clippy, test, build)
- [ ] Workflow will be tested automatically when PR is created

Fixes #24