### PR TITLE
Add gru review command with delegation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,11 @@ enum Commands {
         #[arg(help = "Issue number or URL to fix")]
         issue: String,
     },
+    #[command(about = "Review a GitHub pull request")]
+    Review {
+        #[arg(help = "PR number or URL to review")]
+        pr: String,
+    },
 }
 
 fn handle_fix(issue: &str) -> ! {
@@ -40,10 +45,32 @@ fn handle_fix(issue: &str) -> ! {
     }
 }
 
+fn handle_review(pr: &str) -> ! {
+    let result = Command::new("claude")
+        .arg(format!("/pr_review {}", pr))
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status();
+
+    match result {
+        Ok(status) => std::process::exit(status.code().unwrap_or(128)),
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                eprintln!("Error: 'claude' command not found. Please install Claude CLI first.");
+            } else {
+                eprintln!("Error launching claude: {}", e);
+            }
+            std::process::exit(1);
+        }
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
     match cli.command {
         Commands::Fix { issue } => handle_fix(&issue),
+        Commands::Review { pr } => handle_review(&pr),
     }
 }


### PR DESCRIPTION
## Summary

Implements the `gru review` command that delegates to the `/pr_review` command, following the same pattern as the `fix` command.

## Changes

- Added `Review` subcommand to `Commands` enum with PR argument
- Implemented `handle_review` function with identical error handling to `handle_fix`
- Passes through stdin/stdout/stderr for interactive session
- Exits with Claude's exit code
- Reuses same error handling pattern

## Acceptance Criteria

- ✅ `gru review 123` launches Claude with `/pr_review 123`
- ✅ `gru review https://github.com/owner/repo/pull/456` works with full URLs
- ✅ User sees Claude's output in real-time
- ✅ Can interact with Claude normally
- ✅ Exit code matches Claude's exit code
- ✅ Uses same error handling as `fix` command

## Testing

Built successfully with `cargo build` and passed `cargo clippy` with no warnings.

Fixes #28