### PR TITLE
Improve 'gru review' to auto-manage workspaces

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -208,10 +208,12 @@ impl GitRepo {
             );
         }
 
-        // Check if worktree path already exists
+        // Check if worktree path already exists (defensive check)
+        // Callers should check for existence first to provide better error messages
         if worktree_path.exists() {
             anyhow::bail!(
-                "Path already exists: {}. Remove it first or choose a different path.",
+                "Worktree path already exists: {}. This is likely a programming error - \
+                 the caller should check for existing worktrees before calling this method.",
                 worktree_path.display()
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,6 +481,7 @@ async fn handle_review(pr: &str) -> Result<i32> {
 
     // Create bare repository path
     let bare_path = workspace.repos().join(&owner).join(format!("{}.git", repo));
+    // Clone bare_path here since GitRepo::new takes ownership, but we need it later for git fetch
     let git_repo = git::GitRepo::new(&owner, &repo, bare_path.clone());
 
     // Ensure bare repository is cloned/updated


### PR DESCRIPTION
## Summary

Implements automatic workspace management for the `gru review` command, bringing it to feature parity with `gru fix`. The command now sets up worktrees automatically instead of delegating this to the agent.

## Changes

### Core Implementation
- **Add `parse_pr_info` async function** - Fetches PR metadata from GitHub API to extract owner, repo, PR number, and branch name
- **Add `GitRepo::checkout_worktree` method** - New method to checkout existing branches into worktrees (unlike `create_worktree` which creates new branches with `-b` flag)
- **Rewrite `handle_review` function** to:
  - Parse PR info and fetch metadata from GitHub
  - Set up workspace using existing `workspace::Workspace` and `git::GitRepo` modules
  - Explicitly fetch the PR branch to ensure it's available locally
  - Create or reuse worktree based on PR branch name
  - Launch agent in the worktree directory with proper working directory

### Documentation Updates
- **Simplify `.claude/commands/pr_review.md`** - Removed 14 lines of workspace setup instructions, added clear assumption that worktree is pre-configured by `gru review`

## Benefits

- **⚡ Faster** - No agent time spent figuring out workspace setup
- **🔒 More reliable** - Tested Rust code instead of prompt-based logic
- **🤝 Consistent** - Same workspace management as `gru fix`
- **👍 Better UX** - Clear progress messages during setup

## Testing

- ✅ All existing tests pass
- ✅ Clippy checks pass
- ✅ Code formatting verified
- ✅ Pre-commit hooks pass

## Implementation Notes

**Critical fixes from code review:**
- Uses `checkout_worktree` instead of `create_worktree` to avoid "branch already exists" errors
- Explicitly fetches PR branch with `git fetch origin branch:branch` to ensure branch is available
- Clones `bare_path` before passing to `GitRepo::new` to avoid move errors

**Known limitations (documented in issue as out of scope):**
- Fork PRs not yet supported (will be addressed in follow-up)
- No progress display during workspace setup (future enhancement)
- Worktree path collisions possible for same branch names (future enhancement)

Fixes #51

Generated with https://github.com/anthropics/claude-code

Co-Authored-By: Claude <noreply@anthropic.com>