### PR TITLE
Fix worktree directory naming to match branch name

### DIFF
--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -118,15 +118,15 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
         .ensure_bare_clone()
         .context("Failed to clone or update repository")?;
 
-    // Create worktree path
-    let repo_name = format!("{}/{}", owner, repo);
-    let worktree_path = workspace
-        .work_dir(&repo_name, &minion_id)
-        .context("Failed to compute worktree path")?;
-
-    // Create worktree with branch name: minion/issue-<num>-<id>
+    // Create branch name first: minion/issue-<num>-<id>
     let branch_name = format!("minion/issue-{}-{}", issue_num, minion_id);
     println!("🌿 Creating worktree with branch: {}", branch_name);
+
+    // Create worktree path using branch name
+    let repo_name = format!("{}/{}", owner, repo);
+    let worktree_path = workspace
+        .work_dir(&repo_name, &branch_name)
+        .context("Failed to compute worktree path")?;
 
     git_repo
         .create_worktree(&branch_name, &worktree_path)


### PR DESCRIPTION
## Summary
Fixes worktree directory naming bug where directories were created using minion ID instead of branch name. The fix reorders code to create the branch name before computing the worktree path.

**Before:**
- Branch: `minion/issue-42-M007`
- Worktree: `~/.gru/work/owner/repo/M007/` ❌

**After:**
- Branch: `minion/issue-42-M007`  
- Worktree: `~/.gru/work/owner/repo/minion/issue-42-M007/` ✅

## Changes
- Reordered code in `src/commands/fix.rs` (lines 121-130) to create `branch_name` before calling `workspace.work_dir()`
- Changed `work_dir()` second parameter from `&minion_id` to `&branch_name`
- Maintains all existing functionality, error handling, and output

## Testing
- ✅ All unit tests pass
- ✅ Code compiles and passes clippy lints
- ✅ Pre-commit hooks pass
- ✅ Code review completed - no issues found

## Impact
This ensures the universal rule "worktree path always matches branch name exactly" (from CLAUDE.md) is properly followed by the `gru fix` command.

Fixes #96