### PR TITLE
Parse and display verbose tool output cleanly in progress display

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -293,9 +293,14 @@ impl ProgressDisplay {
                             self.update_header(&format!("🔧 Using tool: {}", tool_name));
 
                             // Start tracking this tool's input
-                            if let Ok(mut tracker) = self.tool_tracker.lock() {
-                                tracker.start_tool(tool_name.to_string());
-                            }
+                            let mut tracker = match self.tool_tracker.lock() {
+                                Ok(guard) => guard,
+                                Err(poisoned) => {
+                                    eprintln!("Warning: Tool tracker mutex poisoned, recovering");
+                                    poisoned.into_inner()
+                                }
+                            };
+                            tracker.start_tool(tool_name.to_string());
                         }
                         "text" => {
                             self.update_header("📝 Responding...");
@@ -324,9 +329,16 @@ impl ProgressDisplay {
                             if let Some(partial_json) =
                                 delta.get("partial_json").and_then(|p| p.as_str())
                             {
-                                if let Ok(mut tracker) = self.tool_tracker.lock() {
-                                    tracker.add_input_chunk(partial_json);
-                                }
+                                let mut tracker = match self.tool_tracker.lock() {
+                                    Ok(guard) => guard,
+                                    Err(poisoned) => {
+                                        eprintln!(
+                                            "Warning: Tool tracker mutex poisoned, recovering"
+                                        );
+                                        poisoned.into_inner()
+                                    }
+                                };
+                                tracker.add_input_chunk(partial_json);
                             }
                         }
                         _ => {}
@@ -337,11 +349,14 @@ impl ProgressDisplay {
                 // Content block finished - handle both text and tool blocks
 
                 // First, check if we have a tool to format
-                let tool_info = if let Ok(mut tracker) = self.tool_tracker.lock() {
-                    tracker.take()
-                } else {
-                    None
+                let mut tracker = match self.tool_tracker.lock() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => {
+                        eprintln!("Warning: Tool tracker mutex poisoned, recovering");
+                        poisoned.into_inner()
+                    }
                 };
+                let tool_info = tracker.take();
 
                 if let Some((tool_name, input_json)) = tool_info {
                     // Format and display tool information


### PR DESCRIPTION
## Summary

Fixes #107

This PR implements clean, human-readable display of verbose tool output in the progress display instead of showing raw JSON blobs.

### Changes Made

1. **Tool Input Tracking**: Added `ToolInputTracker` to accumulate tool input JSON from streaming `content_block_delta` events with `partial_json` chunks

2. **Formatted Tool Display**: Implemented `format_tool_info()` that extracts and formats key information for common tools:
   - **Bash**: Shows truncated command (e.g., "Run: git status")
   - **Read/Write/Edit**: Shows shortened file path (e.g., "Read: .../src/progress.rs")
   - **Grep**: Shows search pattern (e.g., "Search: TODO")
   - **Glob**: Shows glob pattern (e.g., "Find: **/*.rs")
   - **Task**: Shows task description (e.g., "Task: Explore codebase")
   - **TodoWrite**: Shows "Update todos"
   - **AskUserQuestion**: Shows "Asking question..."
   - **Other tools**: Shows "Tool: {name}"

3. **Path Shortening**: Long file paths are shortened to show only the last 3 components with ".../" prefix

4. **Text Truncation**: Long commands and patterns are truncated to prevent display clutter

### Benefits

- ✅ **Better UX**: Users can see what's happening at a glance
- ✅ **Reduced noise**: No more JSON clutter in the terminal
- ✅ **Keep logs**: Full verbose output still available in `events.jsonl` for debugging
- ✅ **Debugging**: `--verbose` flag continues to provide detailed logs

### Testing

- Added 13 new unit tests covering tool formatting, path shortening, and tracker logic
- All existing tests continue to pass
- Clippy and formatting checks pass

### Code References

- `src/progress.rs:23-48` - ToolInputTracker implementation
- `src/progress.rs:177-273` - Tool formatting logic  
- `src/progress.rs:295-298` - Tool tracking initialization on ContentBlockStart
- `src/progress.rs:322-331` - Tool input accumulation on ContentBlockDelta
- `src/progress.rs:336-357` - Tool formatting on ContentBlockStop

🤖 Generated with [Claude Code](https://claude.com/claude-code)