### PR TITLE
Improve gru clean to auto-force remove worktrees with only ephemeral files

### DIFF
--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -168,7 +168,24 @@ pub async fn handle_clean(dry_run: bool, force: bool, base_branch: &str) -> Resu
         };
         println!("  {} ({})", wt.path.display(), reason);
         println!("    Branch: {}", wt.branch);
-        println!("    Repo: {}\n", wt.repo);
+        println!("    Repo: {}", wt.repo);
+
+        // Check worktree dirty status to inform user what will happen
+        match check_worktree_files(&wt.path) {
+            Ok((has_modified, only_ephemeral)) => {
+                if !has_modified {
+                    println!("    Status: clean");
+                } else if only_ephemeral {
+                    println!("    Status: dirty (ephemeral files only - will auto-force)");
+                } else {
+                    println!("    Status: dirty (important files - requires --force)");
+                }
+            }
+            Err(_) => {
+                println!("    Status: unknown (unable to check)");
+            }
+        }
+        println!();
     }
 
     if dry_run {


### PR DESCRIPTION
## Summary
Enhances the `gru clean` command to automatically handle worktrees containing only ephemeral files (logs, build artifacts, IDE configs) without requiring manual force-removal, while still protecting against accidental loss of important uncommitted work.

## Changes

### Core Implementation
- **Smart file categorization**: Added `is_ephemeral_file()` helper that categorizes files as safe-to-discard
  - Ephemeral files: `events.jsonl`, `Cargo.lock` (for binary projects), `.DS_Store`, `Thumbs.db`, `*.log`
  - Ephemeral directories: `target/`, `.vscode/`, `.idea/`, `.vs/`, `node_modules/`, `.next/`, `dist/`, `build/`, `.cache/`
- **Worktree inspection**: Added `check_worktree_files()` that parses `git status --porcelain` output
- **Auto-force logic**: Worktree removal automatically applies `--force` flag when only ephemeral files are present
- **User feedback**: Clear indication when auto-forcing: `✓ (auto-forced for ephemeral files)`
- **Helpful error messages**: When removal fails due to important files, provides guidance on next steps

### Edge Case Handling
- **Path component matching**: Uses proper path component comparison instead of string prefix matching
  - Prevents false positives like "target_backup/" matching "target/"
- **Git porcelain format**: Handles quoted filenames with special characters and renamed files
- **Conservative approach**: Only auto-forces when ALL modified/untracked files are ephemeral

### Testing
- Added 15 unit tests covering:
  - Ephemeral file detection (specific files, directories, log files)
  - Important file protection (source code, config files, documentation)
  - Edge cases (false positive prevention, nested ephemeral paths)

## Benefits
- **Smoother UX**: Common case where minions leave logs/artifacts "just works"
- **Reduced manual steps**: No more `git worktree remove --force` for every cleanup
- **Safety maintained**: Still protects against accidentally losing important uncommitted work
- **Better error messages**: Users get actionable guidance when manual intervention is needed

## Test Plan
- [x] All existing tests pass
- [x] New tests verify file categorization logic
- [x] Edge cases tested (false positives, nested paths)
- [x] Code passes linting and formatting checks

Fixes #110