### PR TITLE
Add gru resume command to resume Minion Claude sessions

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod clean;
 pub mod fix;
 pub mod path;
+pub mod resume;
 pub mod review;
 pub mod status;

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -1,0 +1,82 @@
+use crate::minion_resolver;
+use anyhow::{Context, Result};
+
+/// Handles the resume command to resume a Minion's Claude session
+/// Returns 0 on success, 1 on error
+///
+/// This command is a convenience wrapper equivalent to:
+/// ```bash
+/// cd $(gru path <id>) && claude -r
+/// ```
+///
+/// The ID argument supports smart resolution (same as gru path):
+/// 1. Try as exact minion ID (e.g., M0tk)
+/// 2. Try with M prefix (e.g., 12 -> M12)
+/// 3. Parse as number, search local minions by issue number
+/// 4. Fallback to GitHub API for PRs (if online)
+///
+/// On Unix systems, this command replaces the current process with claude.
+/// On Windows, it spawns claude and waits for completion.
+pub async fn handle_resume(id: String) -> Result<i32> {
+    // Reuse exact same resolution as gru path
+    let minion = minion_resolver::resolve_minion(&id).await?;
+
+    // Verify worktree still exists
+    if !minion.worktree_path.exists() {
+        anyhow::bail!(
+            "Worktree directory no longer exists: {}\n\
+             The worktree may have been removed. Try 'gru status' to see active minions.",
+            minion.worktree_path.display()
+        );
+    }
+
+    // Unix: exec() replaces the current process
+    // Windows: spawn() creates a new process and waits for it
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = std::process::Command::new("claude")
+            .arg("-r")
+            .current_dir(&minion.worktree_path)
+            .exec(); // Replaces current process
+
+        // If we reach here, exec failed
+        Err(err).context(
+            "Failed to exec claude. Is Claude CLI installed and in your PATH?\n\
+             See: https://claude.com/claude-code",
+        )
+    }
+
+    #[cfg(not(unix))]
+    {
+        // On Windows, spawn the process and wait for it to complete
+        let status = std::process::Command::new("claude")
+            .arg("-r")
+            .current_dir(&minion.worktree_path)
+            .status()
+            .context(
+                "Failed to run claude. Is Claude CLI installed and in your PATH?\n\
+                 See: https://claude.com/claude-code",
+            )?;
+
+        Ok(if status.success() { 0 } else { 1 })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_handle_resume_with_invalid_id() {
+        // Test that handle_resume returns an error for an invalid ID
+        // This verifies the minion_resolver integration works correctly
+        let result = handle_resume("nonexistent-minion-xyz".to_string()).await;
+        assert!(result.is_err());
+
+        // Verify the error message suggests using gru status
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(err_msg.contains("Could not resolve ID"));
+        assert!(err_msg.contains("gru status"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ mod workspace;
 mod worktree_scanner;
 
 use clap::{Parser, Subcommand};
-use commands::{clean, fix, path, review, status};
+use commands::{clean, fix, path, resume, review, status};
 
 /// CLI structure for the Gru agent orchestrator
 #[derive(Parser)]
@@ -61,6 +61,11 @@ enum Commands {
         #[arg(long, help = "[DEPRECATED] Resolve from PR number")]
         pr: Option<u64>,
     },
+    #[command(about = "Resume a Minion's Claude session")]
+    Resume {
+        #[arg(help = "Minion ID, issue number, or PR number (e.g., M0tk, 42)")]
+        id: String,
+    },
     #[command(about = "Clean up merged/closed worktrees")]
     Clean {
         #[arg(long, help = "Show what would be cleaned without removing")]
@@ -85,6 +90,7 @@ async fn main() {
         Commands::Fix { issue, timeout } => fix::handle_fix(&issue, timeout, cli.quiet).await,
         Commands::Review { pr } => review::handle_review(&pr).await,
         Commands::Path { id, issue, pr } => path::handle_path(id, issue, pr).await,
+        Commands::Resume { id } => resume::handle_resume(id).await,
         Commands::Clean {
             dry_run,
             force,


### PR DESCRIPTION
## Summary
- Adds new `gru resume <id>` command for resuming Minion Claude sessions
- Reuses existing minion_resolver logic for smart ID resolution (Minion ID, issue number, or PR number)
- Cross-platform implementation: uses `exec()` on Unix, `spawn()` on Windows
- Validates worktree directory exists before attempting resume
- Provides helpful error messages with links to documentation

## Implementation Details
The command is essentially a convenience wrapper for `cd $(gru path <id>) && claude -r`, eliminating the need for manual navigation.

**Key features:**
- Smart ID resolution supports: M0tk, 42 (issue), 103 (PR)
- Unix: `exec()` replaces current process with Claude CLI
- Windows: `spawn()` creates new process and waits for completion
- Validates worktree path exists before execution
- Clear error messages suggest `gru status` if ID not found
- Links to Claude Code docs if Claude CLI not installed

## Test Plan
- [x] Unit test for error case (invalid ID)
- [x] All existing tests pass
- [x] Format and lint checks pass
- [x] Cross-platform compatibility via `#[cfg(unix)]` and `#[cfg(not(unix))]`
- [x] Pre-commit hooks pass (format, lint, tests)

## Acceptance Criteria from Issue #112
- [x] Given Minion M0tk exists, when I run `gru resume M0tk`, then Claude resumes the session in that worktree
- [x] Given Minion M0tk is working on issue 42, when I run `gru resume 42`, then Claude resumes M0tk's session
- [x] Given PR 103 links to issue 42 (via "Fixes #42"), when I run `gru resume 103`, then Claude resumes the correct Minion's session
- [x] Given no Minion is working on issue 99, when I run `gru resume 99`, then I see a helpful error suggesting `gru status`
- [x] All ID resolution works exactly like `gru path` (same code path)

Fixes #112