### PR TITLE
Display abbreviated tool results instead of raw conversation JSON

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -13,6 +13,10 @@ const MAX_RECENT_EVENTS: usize = 4;
 /// 200 characters allows ~3-4 lines of text to display coherently.
 const MAX_DISPLAY_CHARS: usize = 200;
 
+/// Maximum characters for raw lines (JSON and other verbose content).
+/// Raw lines are more aggressively truncated than buffered text to reduce clutter.
+const MAX_RAW_LINE_CHARS: usize = 80;
+
 /// Configuration for the progress display
 pub struct ProgressConfig {
     pub minion_id: String,
@@ -182,15 +186,15 @@ impl ProgressDisplay {
             if json.is_object() {
                 // For now, just truncate JSON objects
                 let preview = format!("{}", json);
-                if preview.len() > 80 {
-                    return format!("{}\n", Self::truncate_string(&preview, 80));
+                if preview.len() > MAX_RAW_LINE_CHARS {
+                    return format!("{}\n", Self::truncate_string(&preview, MAX_RAW_LINE_CHARS));
                 }
             }
         }
 
         // If not JSON or too short to worry about, truncate to single line
-        if trimmed.len() > 80 {
-            format!("{}\n", Self::truncate_string(trimmed, 80))
+        if trimmed.len() > MAX_RAW_LINE_CHARS {
+            format!("{}\n", Self::truncate_string(trimmed, MAX_RAW_LINE_CHARS))
         } else {
             line.to_string()
         }
@@ -202,9 +206,15 @@ impl ProgressDisplay {
 
         let formatted = if tool_result.is_error {
             // Format error tool results
-            let error_msg = tool_result.content.as_str().unwrap_or("Unknown error");
+            let error_msg = match tool_result.content.as_str() {
+                Some(s) => s.to_string(),
+                None => format!(
+                    "Tool failed with non-string error content: {}",
+                    tool_result.content
+                ),
+            };
             // Show first line of error
-            let first_line = error_msg.lines().next().unwrap_or(error_msg);
+            let first_line = error_msg.lines().next().unwrap_or(&error_msg);
             let truncated = Self::truncate_string(first_line, 60);
             format!("[{}] ✗ Tool failed: {}", timestamp, truncated)
         } else {
@@ -684,7 +694,7 @@ mod tests {
     fn test_abbreviate_raw_line_long() {
         let line = "This is a very long message that exceeds the maximum character limit and should be truncated to fit within the display";
         let result = ProgressDisplay::abbreviate_raw_line(line);
-        assert!(result.len() <= 84); // 80 chars + "..." + "\n"
+        assert!(result.len() <= 84); // MAX_RAW_LINE_CHARS + "..." + "\n"
         assert!(result.ends_with("...\n"));
     }
 
@@ -699,7 +709,7 @@ mod tests {
     fn test_abbreviate_raw_line_json_long() {
         let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_123","content":"very long content here"}]}}"#;
         let result = ProgressDisplay::abbreviate_raw_line(line);
-        assert!(result.len() <= 84); // 80 chars + "..." + "\n"
+        assert!(result.len() <= 84); // MAX_RAW_LINE_CHARS + "..." + "\n"
         assert!(result.ends_with("...\n"));
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -166,6 +166,7 @@ impl<R: tokio::io::AsyncRead + Unpin> EventStream<R> {
         if let Ok(conv_msg) = serde_json::from_str::<ConversationMessage>(trimmed) {
             if conv_msg.message_type == "user" && !conv_msg.message.content.is_empty() {
                 // Return the first tool result (typically there's only one per message)
+                // The is_empty() guard above ensures that direct indexing is safe here.
                 return Ok(Some(StreamOutput::ToolResult(
                     conv_msg.message.content[0].clone(),
                 )));


### PR DESCRIPTION
## Summary

Fixes #115

This PR improves the progress display by parsing and abbreviating tool result messages from Claude Code's verbose output, replacing multi-line raw JSON blobs with clean, concise status messages.

### Changes

**Stream Parsing (src/stream.rs):**
- Added data structures for parsing Messages API conversation format:
  - `ToolResult`: Represents a tool result with content, tool_use_id, and error flag
  - `ConversationMessage` and `MessageContent`: Wrapper structures for parsing verbose output
- Extended `StreamOutput` enum with new `ToolResult` variant
- Parser now detects and extracts tool results from conversation JSON

**Progress Display (src/progress.rs):**
- Added `handle_tool_result()` to format tool results:
  - Success: `✓ Tool completed (N bytes)`
  - Error: `✗ Tool failed: [first line of error]`
- Added `abbreviate_raw_line()` to handle unrecognized output:
  - JSON objects truncated to 80 chars if too long
  - Non-JSON text truncated to single line (max 80 chars)
- Full JSON still logged to `events.jsonl` for debugging

**Tests:**
- Added unit tests for parsing tool result messages (both success and error)
- Added unit tests for raw line abbreviation logic
- Added unit tests for tool result display formatting

### Example Output

**Before:**
```
⠇ 🤖 Minion M018 | Issue 112 | ⏱️  1m 54s

Status: 🔧 Using tool: Grep
Recent:
  [14:15:09] Text: Let me check if there's a tests directory:
  [14:15:10] Run: ls -la
  {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01176LsJT59DzhvEuwcYHuTH","type":"tool_result","content":"total 4296\ndrwxr-xr-x@ 16 sspalding  staff      512 Dec 10 14:13 .\ndrwxr-xr-x  19 sspalding  staff      608 Dec 10 14:13 ..\n..."
```

**After:**
```
⠇ 🤖 Minion M018 | Issue 112 | ⏱️  1m 54s

Status: 🔧 Using tool: Grep
Recent:
  [14:15:09] Text: Let me check if there's a tests directory:
  [14:15:10] Run: ls -la
  [14:15:10] ✓ Tool completed (387 bytes)
```

## Test plan

- [x] All existing tests pass
- [x] New unit tests for tool result parsing and abbreviation
- [x] Linter passes without warnings
- [x] Pre-commit hooks pass (format, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)