### PR TITLE
Fix panic in output buffer trimming due to UTF-8 boundary issue

### DIFF
--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -399,8 +399,13 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
                         raw_output_buffer.push_str(line);
                         // Keep buffer size reasonable
                         if raw_output_buffer.len() > MAX_OUTPUT_BUFFER_SIZE {
-                            raw_output_buffer =
-                                raw_output_buffer.split_off(TRIM_OUTPUT_BUFFER_SIZE);
+                            // Ensure we split at a valid UTF-8 character boundary to avoid panics
+                            // Find the largest valid UTF-8 boundary at or before TRIM_OUTPUT_BUFFER_SIZE
+                            let mut trim_pos = TRIM_OUTPUT_BUFFER_SIZE;
+                            while trim_pos > 0 && !raw_output_buffer.is_char_boundary(trim_pos) {
+                                trim_pos -= 1;
+                            }
+                            raw_output_buffer = raw_output_buffer.split_off(trim_pos);
                         }
                     }
 


### PR DESCRIPTION
## Summary

Fixes #117

This PR fixes a panic that occurred when trimming the output buffer in `src/commands/fix.rs`. The code was splitting the buffer at a fixed byte position without checking if it was a valid UTF-8 character boundary, causing `split_off()` to panic when multi-byte characters (emojis, Unicode symbols, etc.) from the agent's output landed at the split position.

## Changes

- Added UTF-8 boundary checking before splitting the buffer
- Walks backward from the trim position to find the nearest valid character boundary
- Implementation is compatible with Rust 1.70+ (the project's MSRV)

## Test Plan

- All existing tests pass
- Clippy checks pass with no warnings
- Code formatting verified
- Pre-commit hooks pass successfully

The fix ensures that when Claude's output contains multi-byte UTF-8 characters, the buffer trimming operation will never panic.