### PR TITLE
Auto-trigger PR review after fix command creates PR

### DIFF
--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -254,18 +254,23 @@ async fn trigger_pr_review(
         })?;
 
     // Wait for the process with timeout
-    let status = timeout(timeout_duration, child.wait())
-        .await
-        .map_err(|_| {
-            anyhow::anyhow!(
+    match timeout(timeout_duration, child.wait()).await {
+        Ok(status) => {
+            let status = status.with_context(|| {
+                format!("Failed to wait for review process for PR #{}", pr_number)
+            })?;
+            Ok(status.code().unwrap_or(EXIT_CODE_SIGNAL_TERMINATED))
+        }
+        Err(_) => {
+            // Timeout occurred - kill the child process to prevent orphaned process
+            let _ = child.kill().await; // Ignore kill errors, already timing out
+            Err(anyhow::anyhow!(
                 "Review process timed out after {} minutes. PR #{} review may be stuck.",
                 timeout_duration.as_secs() / 60,
                 pr_number
-            )
-        })?
-        .with_context(|| format!("Failed to wait for review process for PR #{}", pr_number))?;
-
-    Ok(status.code().unwrap_or(EXIT_CODE_SIGNAL_TERMINATED))
+            ))
+        }
+    }
 }
 
 /// Helper function to post a progress comment to a GitHub issue


### PR DESCRIPTION
## Summary

Implements automatic PR review triggering after successful PR creation in the fix command. When `gru fix <issue>` creates a PR, it now automatically spawns `gru review <pr>` to review the PR and post findings as comments.

This completes the autonomous workflow for issue #100, eliminating the manual step of running `gru review` after `gru fix`.

## Changes

### Core Implementation
- **Added `trigger_pr_review()` function**: Spawns `gru review` as a separate process with fresh Claude session context for unbiased review
- **Integrated review trigger**: After successful PR creation in `handle_fix()`, automatically triggers review
- **Validation**: Added PR number format validation (defense in depth)
- **Error handling**: Informational error messages with manual command suggestions

### Design Decisions
- Review runs as **completely separate process** with fresh Claude session (ensures unbiased review)
- Review failures are **informational only** - don't fail the entire fix command (fix work already succeeded)
- Fix command **waits for review to complete** before exiting
- Review only triggered for **Minion-created PRs** after successful PR creation

## Edge Cases Handled

✅ **PR creation failure**: No review triggered (existing behavior maintained)
✅ **Branch not pushed**: No review triggered (existing behavior maintained)
✅ **Review spawn failure**: Error message with manual `gru review` command suggestion
✅ **Review process failure**: Exit code logged, but doesn't fail fix command

## Test Results

- ✅ All 146 tests pass
- ✅ No clippy warnings
- ✅ Pre-commit hooks pass

## Example Output

After successful PR creation:
```
✅ Draft PR created: #42
🔗 View PR at: https://github.com/owner/repo/pull/42

🔍 Starting automated PR review...
[... review output ...]
✅ PR review completed successfully
```

## Acceptance Criteria Met

- [x] When `gru fix <issue>` creates a PR, it automatically triggers review
- [x] Review runs as a separate Claude session (fresh context)
- [x] Review findings are posted as PR comments (existing behavior)
- [x] Fix command waits for review to complete before exiting
- [x] If PR creation fails or is not detected, command exits normally without review
- [x] Review is only triggered for Minion-created PRs, not manual PRs

Fixes #100