### PR TITLE
Implement in-progress label for active Minions

### DIFF
--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -369,24 +369,29 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
 
     // Claim the issue by adding in-progress label (fire-and-forget)
     if let Some(ref client) = github_client {
-        let issue_number = issue_num.parse::<u64>().unwrap_or(0);
-        if issue_number > 0 {
+        if let Ok(issue_number) = issue_num.parse::<u64>() {
             match client.claim_issue(&owner, &repo, issue_number).await {
                 Ok(true) => {
                     println!("🏷️  Added 'in-progress' label to issue #{}", issue_num);
                 }
                 Ok(false) => {
-                    println!(
+                    eprintln!(
                         "⚠️  Issue #{} is already claimed by another Minion",
                         issue_num
                     );
-                    println!("   Continuing anyway (this Minion will also work on it)");
+                    eprintln!("   This may indicate a race condition or multiple gru instances.");
+                    eprintln!("   Continuing anyway (worktree already created)...");
                 }
                 Err(e) => {
                     eprintln!("⚠️  Failed to add label to issue: {}", e);
                     eprintln!("   Continuing anyway...");
                 }
             }
+        } else {
+            eprintln!(
+                "⚠️  Invalid issue number '{}', cannot update labels",
+                issue_num
+            );
         }
     }
 
@@ -628,8 +633,7 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
 
                     // Mark issue as done (fire-and-forget)
                     if let Some(ref client) = github_client {
-                        let issue_number = issue_num.parse::<u64>().unwrap_or(0);
-                        if issue_number > 0 {
+                        if let Ok(issue_number) = issue_num.parse::<u64>() {
                             match client.mark_issue_done(&owner, &repo, issue_number).await {
                                 Ok(()) => {
                                     println!("🏷️  Updated issue label to 'minion:done'");
@@ -638,6 +642,11 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
                                     eprintln!("⚠️  Failed to update issue label: {}", e);
                                 }
                             }
+                        } else {
+                            eprintln!(
+                                "⚠️  Invalid issue number '{}', cannot update labels",
+                                issue_num
+                            );
                         }
                     }
 
@@ -687,8 +696,7 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
 
         // Mark issue as failed (fire-and-forget)
         if let Some(ref client) = github_client {
-            let issue_number = issue_num.parse::<u64>().unwrap_or(0);
-            if issue_number > 0 {
+            if let Ok(issue_number) = issue_num.parse::<u64>() {
                 match client.mark_issue_failed(&owner, &repo, issue_number).await {
                     Ok(()) => {
                         println!("🏷️  Updated issue label to 'minion:failed'");
@@ -697,6 +705,11 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
                         eprintln!("⚠️  Failed to update issue label: {}", e);
                     }
                 }
+            } else {
+                eprintln!(
+                    "⚠️  Invalid issue number '{}', cannot update labels",
+                    issue_num
+                );
             }
         }
     }

--- a/src/github.rs
+++ b/src/github.rs
@@ -151,13 +151,25 @@ impl GitHubClient {
 
     /// Claim an issue by transitioning from ready-for-minion to in-progress
     ///
+    /// This operation is designed for fire-and-forget usage. While it returns a Result,
+    /// callers typically log errors but don't block the main workflow.
+    ///
+    /// # Race Conditions
+    /// This method attempts to detect if another Minion already claimed the issue
+    /// by checking for the `in-progress` label. However, there is a TOCTOU window
+    /// between the check and the label addition. Multiple Minions could pass the
+    /// check simultaneously and both claim the issue. In V1, we accept this limitation.
+    /// For V2+, consider using GitHub issue assignment or comment-based coordination.
+    ///
     /// # Arguments
     /// * `owner` - Repository owner
     /// * `repo` - Repository name
     /// * `issue` - Issue number
     ///
-    /// Returns `Ok(true)` if the issue was successfully claimed, `Ok(false)` if
-    /// another Minion already claimed it (race condition), or `Err` on failure.
+    /// # Returns
+    /// * `Ok(true)` - Successfully claimed (no race detected)
+    /// * `Ok(false)` - Already claimed by another Minion (race detected)
+    /// * `Err(_)` - API call failed (network error, auth error, etc.)
     pub async fn claim_issue(&self, owner: &str, repo: &str, issue: u64) -> Result<bool> {
         // First, check current labels to detect race conditions
         let issue_info = self.get_issue(owner, repo, issue).await?;


### PR DESCRIPTION
Implements label-based state machine to track issue lifecycle as documented in `docs/DESIGN.md:700-728`.

## Summary
- ✅ Add `in-progress` label when Minion claims issue
- ✅ Add `minion:done` label after successful PR creation
- ✅ Add `minion:failed` label on task failure
- ✅ Handle race conditions (detect if another Minion already claimed issue)

## Changes
1. **GitHubClient methods** (`src/github.rs`):
   - `claim_issue()` - Transitions `ready-for-minion` → `in-progress`, checks for race conditions
   - `mark_issue_done()` - Transitions `in-progress` → `minion:done`
   - `mark_issue_failed()` - Transitions `in-progress` → `minion:failed`

2. **Fix command updates** (`src/commands/fix.rs`):
   - Claim issue with label when Minion starts work
   - Mark as done after successful PR creation
   - Mark as failed when task fails

## Implementation Notes
- All label updates are fire-and-forget to avoid blocking Minion execution
- Race condition detection: checks if issue already has `in-progress` label
  - **Known limitation:** TOCTOU window exists between check and label addition
  - V1 accepts this; V2 will use GitHub issue assignment or comment-based coordination
- Gracefully handles missing labels (e.g., removing `ready-for-minion` when it doesn't exist)
- Uses GitHub API via octocrab for label management
- Proper error handling: invalid issue numbers are logged instead of silently ignored

## Code Review
- Addressed feedback from code-reviewer agent
- Enhanced documentation for race condition behavior
- Improved error messages for edge cases
- Fixed issue number parsing to avoid silent failures

## Testing
- All existing tests pass (146 tests)
- Formatting and lint checks pass
- Pre-commit hooks verified

Fixes #120