### PR TITLE
Support ad-hoc prompts with gru prompt command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod clean;
 pub mod fix;
 pub mod path;
+pub mod prompt;
 pub mod resume;
 pub mod review;
 pub mod status;

--- a/src/commands/prompt.rs
+++ b/src/commands/prompt.rs
@@ -1,0 +1,352 @@
+use crate::minion;
+use crate::progress::{ProgressConfig, ProgressDisplay};
+use crate::stream::{self, EventStream};
+use crate::workspace;
+use anyhow::{Context, Result};
+use std::path::Path;
+use std::time::Instant;
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command as TokioCommand;
+use tokio::time::{timeout, Duration};
+
+/// Timeout in seconds for each line read from Claude's output stream
+/// Set to 5 minutes to accommodate long-running LLM operations
+const STREAM_TIMEOUT_SECS: u64 = 300;
+
+/// Duration of inactivity before warning the user
+const INACTIVITY_WARNING_SECS: u64 = 300; // 5 minutes
+
+/// Duration of inactivity before considering the task stuck
+const INACTIVITY_STUCK_SECS: u64 = 900; // 15 minutes
+
+/// Exit code returned when a process is terminated by a signal (shell convention)
+const EXIT_CODE_SIGNAL_TERMINATED: i32 = 128;
+
+/// Logs an event to events.jsonl in the workspace directory
+async fn log_event(workspace_path: &Path, event: &stream::StreamOutput) -> Result<()> {
+    let events_file = workspace_path.join("events.jsonl");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&events_file)
+        .await
+        .context("Failed to open events.jsonl")?;
+
+    // Only log actual events, not raw lines
+    if let stream::StreamOutput::Event(claude_event) = event {
+        let json = serde_json::to_string(claude_event)?;
+        file.write_all(json.as_bytes()).await?;
+        file.write_all(b"\n").await?;
+        file.flush().await?;
+    }
+    Ok(())
+}
+
+/// Parses a timeout string into a Duration
+/// Supports formats like "10s", "5m", "1h", "30"
+fn parse_timeout(timeout_str: &str) -> Result<Duration> {
+    let timeout_str = timeout_str.trim();
+
+    // Try to parse as plain seconds first
+    if let Ok(secs) = timeout_str.parse::<u64>() {
+        return Ok(Duration::from_secs(secs));
+    }
+
+    // Parse with unit suffix
+    if timeout_str.len() < 2 {
+        anyhow::bail!(
+            "Invalid timeout format: '{}'. Expected format: <number>[s|m|h]",
+            timeout_str
+        );
+    }
+
+    let (num_str, unit) = timeout_str.split_at(timeout_str.len() - 1);
+    let num: u64 = num_str.parse().map_err(|_| {
+        anyhow::anyhow!(
+            "Invalid timeout format: '{}'. Expected format: <number>[s|m|h]",
+            timeout_str
+        )
+    })?;
+
+    match unit {
+        "s" => Ok(Duration::from_secs(num)),
+        "m" => {
+            let secs = num
+                .checked_mul(60)
+                .ok_or_else(|| anyhow::anyhow!("Timeout value too large"))?;
+            Ok(Duration::from_secs(secs))
+        }
+        "h" => {
+            let secs = num
+                .checked_mul(3600)
+                .ok_or_else(|| anyhow::anyhow!("Timeout value too large"))?;
+            Ok(Duration::from_secs(secs))
+        }
+        _ => anyhow::bail!(
+            "Invalid timeout unit: '{}'. Supported units: s (seconds), m (minutes), h (hours)",
+            unit
+        ),
+    }
+}
+
+/// Handles the prompt command by launching Claude with an ad-hoc prompt
+/// Returns the exit code from the claude process
+pub async fn handle_prompt(prompt: &str, timeout_opt: Option<String>, quiet: bool) -> Result<i32> {
+    // Validate prompt doesn't start with flags (security check)
+    let trimmed_prompt = prompt.trim();
+    if trimmed_prompt.starts_with('-') {
+        anyhow::bail!(
+            "Prompt cannot start with '-' (looks like a command flag). \
+             Use quotes around your prompt: gru prompt \"your prompt here\""
+        );
+    }
+
+    if trimmed_prompt.is_empty() {
+        anyhow::bail!("Prompt cannot be empty");
+    }
+
+    // Generate a unique minion ID for session tracking
+    let minion_id = minion::generate_minion_id().context("Failed to generate Minion ID")?;
+    println!("🆔 Session: {}", minion_id);
+
+    // Initialize workspace
+    let workspace = workspace::Workspace::new().context("Failed to initialize Gru workspace")?;
+
+    // Create workspace path for ad-hoc prompts: ~/.gru/work/ad-hoc/<minion-id>/
+    // Note: We use "ad-hoc" as a pseudo-repo name and minion_id as the branch name
+    // to leverage the existing work_dir validation (path traversal protection, etc.)
+    let workspace_path = workspace
+        .work_dir("ad-hoc", &minion_id)
+        .context("Failed to compute workspace path")?;
+
+    // Create the workspace directory
+    tokio::fs::create_dir_all(&workspace_path)
+        .await
+        .context("Failed to create workspace directory")?;
+
+    // Save prompt to file for debugging and audit trail
+    let prompt_file = workspace_path.join("prompt.txt");
+    tokio::fs::write(&prompt_file, prompt)
+        .await
+        .context("Failed to save prompt to workspace")?;
+
+    println!("📂 Workspace: {}", workspace_path.display());
+    println!("🤖 Launching Claude...\n");
+
+    // Create progress display
+    let config = ProgressConfig {
+        minion_id: minion_id.clone(),
+        issue: format!("ad-hoc: {}", prompt),
+        quiet,
+    };
+    let progress = ProgressDisplay::new(config);
+
+    // Get current working directory to pass to Claude
+    let cwd = std::env::current_dir().context("Failed to get current working directory")?;
+
+    // Build the command with flags for non-interactive stream-json output
+    let mut cmd = TokioCommand::new("claude");
+    cmd.arg("--print")
+        .arg("--verbose")
+        .arg("--session-id")
+        .arg(&minion_id) // Enable session persistence
+        .arg("--output-format")
+        .arg("stream-json")
+        .arg("--include-partial-messages")
+        .arg("--dangerously-skip-permissions")
+        .arg(prompt)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .current_dir(&cwd) // Run in user's current directory, not workspace
+        .env("GRU_WORKSPACE", &minion_id);
+
+    // Spawn the command
+    let mut child = cmd.spawn().context(
+        "claude command not found. Install from: https://github.com/anthropics/claude-code",
+    )?;
+
+    // Get the stdout handle
+    let stdout = child
+        .stdout
+        .take()
+        .context("Failed to capture stdout from claude process")?;
+
+    // Create event stream reader
+    let mut stream = EventStream::from_stdout(stdout);
+
+    // Parse timeout if provided
+    let max_timeout = if let Some(ref timeout_str) = timeout_opt {
+        Some(parse_timeout(timeout_str)?)
+    } else {
+        None
+    };
+
+    // Track task start time for overall timeout
+    let task_start = Instant::now();
+
+    // Process stream output asynchronously with timeout and error handling
+    let stream_result = async {
+        let mut last_event_time = Instant::now();
+        let mut warned_at_5min = false;
+
+        loop {
+            // Check overall task timeout
+            if let Some(max_duration) = max_timeout {
+                let elapsed = task_start.elapsed();
+                if elapsed >= max_duration {
+                    eprintln!("⏱️  Task timeout reached ({:?})", max_duration);
+                    eprintln!("📝 Events saved to events.jsonl");
+                    return Err(anyhow::anyhow!(
+                        "Task exceeded maximum timeout of {:?}",
+                        max_duration
+                    ));
+                }
+            }
+
+            // Check inactivity - time since last event
+            let inactivity = last_event_time.elapsed();
+
+            if inactivity.as_secs() >= INACTIVITY_STUCK_SECS {
+                eprintln!(
+                    "❌ Task appears stuck (no activity for {} minutes)",
+                    INACTIVITY_STUCK_SECS / 60
+                );
+                eprintln!("📝 Events saved to events.jsonl");
+                return Err(anyhow::anyhow!(
+                    "No activity for {} minutes - task appears stuck",
+                    INACTIVITY_STUCK_SECS / 60
+                ));
+            } else if inactivity.as_secs() >= INACTIVITY_WARNING_SECS && !warned_at_5min {
+                eprintln!(
+                    "⚠️  No activity for {} minutes",
+                    INACTIVITY_WARNING_SECS / 60
+                );
+                warned_at_5min = true;
+            }
+
+            // Handle timeout first, then flatten the stream result
+            let line_result = timeout(Duration::from_secs(STREAM_TIMEOUT_SECS), stream.next_line())
+                .await
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "Timeout: Claude process hasn't produced output in {} seconds",
+                        STREAM_TIMEOUT_SECS
+                    )
+                })?;
+
+            // Now handle the stream result
+            match line_result? {
+                Some(output) => {
+                    // Log the event to events.jsonl in workspace
+                    log_event(&workspace_path, &output).await?;
+
+                    // Update last event time for any output
+                    last_event_time = Instant::now();
+
+                    // Reset warning flag only on actual events
+                    if matches!(output, stream::StreamOutput::Event(_)) {
+                        warned_at_5min = false;
+                    }
+
+                    // Display progress
+                    progress.handle_output(&output);
+                }
+                None => break, // Stream ended normally
+            }
+        }
+        Ok::<_, anyhow::Error>(())
+    }
+    .await;
+
+    // Always wait for the process, regardless of stream errors
+    let status = child.wait().await?;
+
+    // Now check if there was a stream error
+    stream_result?;
+
+    // Finish the progress display and return appropriate exit code
+    if status.success() {
+        progress.finish_with_message("✅ Task completed");
+        println!("\n📁 Session workspace: {}", workspace_path.display());
+        println!("💡 To resume this session, use: gru resume {}", minion_id);
+        Ok(0)
+    } else {
+        let exit_code = status.code().unwrap_or(EXIT_CODE_SIGNAL_TERMINATED);
+        progress.finish_with_message(&format!("❌ Task failed (exit code: {})", exit_code));
+        println!(
+            "\n📝 Events saved to: {}",
+            workspace_path.join("events.jsonl").display()
+        );
+        println!(
+            "📄 Prompt saved to: {}",
+            workspace_path.join("prompt.txt").display()
+        );
+        Ok(exit_code)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_timeout_with_seconds() {
+        assert_eq!(parse_timeout("10s").unwrap(), Duration::from_secs(10));
+        assert_eq!(parse_timeout("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_timeout("1s").unwrap(), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_parse_timeout_with_minutes() {
+        assert_eq!(parse_timeout("5m").unwrap(), Duration::from_secs(300));
+        assert_eq!(parse_timeout("1m").unwrap(), Duration::from_secs(60));
+        assert_eq!(parse_timeout("15m").unwrap(), Duration::from_secs(900));
+    }
+
+    #[test]
+    fn test_parse_timeout_with_hours() {
+        assert_eq!(parse_timeout("1h").unwrap(), Duration::from_secs(3600));
+        assert_eq!(parse_timeout("2h").unwrap(), Duration::from_secs(7200));
+    }
+
+    #[test]
+    fn test_parse_timeout_with_plain_number() {
+        assert_eq!(parse_timeout("30").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_timeout("300").unwrap(), Duration::from_secs(300));
+    }
+
+    #[test]
+    fn test_parse_timeout_invalid_unit() {
+        assert!(parse_timeout("10x").is_err());
+        assert!(parse_timeout("10d").is_err());
+    }
+
+    #[test]
+    fn test_parse_timeout_invalid_number() {
+        assert!(parse_timeout("abc").is_err());
+        assert!(parse_timeout("12.5m").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_handle_prompt_rejects_flag_like_input() {
+        let result = handle_prompt("--help", None, false).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("cannot start with '-'"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_prompt_rejects_empty_input() {
+        let result = handle_prompt("", None, false).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
+
+        let result = handle_prompt("   ", None, false).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ mod workspace;
 mod worktree_scanner;
 
 use clap::{Parser, Subcommand};
-use commands::{clean, fix, path, resume, review, status};
+use commands::{clean, fix, path, prompt, resume, review, status};
 
 /// CLI structure for the Gru agent orchestrator
 #[derive(Parser)]
@@ -82,6 +82,18 @@ enum Commands {
         #[arg(help = "Optional ID to filter by (minion ID, issue number, or PR number)")]
         id: Option<String>,
     },
+    #[command(about = "Run an ad-hoc prompt with Claude")]
+    Prompt {
+        #[arg(help = "Prompt text to send to Claude")]
+        prompt: String,
+
+        #[arg(
+            short,
+            long,
+            help = "Maximum duration for the task (e.g., '10s', '5m', '1h'). Exits with error if exceeded."
+        )]
+        timeout: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -99,6 +111,9 @@ async fn main() {
             base_branch,
         } => clean::handle_clean(dry_run, force, &base_branch).await,
         Commands::Status { id } => status::handle_status(id).await,
+        Commands::Prompt { prompt, timeout } => {
+            prompt::handle_prompt(&prompt, timeout, cli.quiet).await
+        }
     };
 
     // Handle any errors that occurred


### PR DESCRIPTION
## Summary

Implements issue #74 to enable users to run Claude sessions with quick prompts without creating GitHub issues.

## Changes

- ✅ Added new `gru prompt` command to CLI
- ✅ Create persistent minion sessions in `~/.gru/work/ad-hoc/<minion-id>/`
- ✅ Support session persistence via `--session-id` flag
- ✅ Run Claude in user's current working directory
- ✅ Log events and save prompt for debugging
- ✅ Add input validation to prevent flag injection
- ✅ Support timeout options (`--timeout 5m`)
- ✅ Include tests for prompt validation and timeout parsing

## Security

- Validates prompts don't start with '-' to prevent flag injection
- Reuses `workspace.work_dir()` validation for path traversal protection
- Saves prompt content to file for audit trail

## Usage

```bash
# Run an ad-hoc prompt
gru prompt "analyze this error"

# With timeout
gru prompt "help me debug this function" --timeout 10m

# Resume a previous session
gru resume M042
```

## Implementation Details

Sessions are tracked with auto-generated IDs (M042, M043, etc.) and persist across restarts via the `--session-id` flag. Events are logged to `events.jsonl` and the prompt is saved to `prompt.txt` in the workspace for debugging.

The implementation follows the existing patterns from the `fix` command, reusing:
- Minion ID generation system
- Stream JSON parsing and progress display
- Workspace management with path validation
- Timeout handling and error reporting

## Testing

- All existing tests pass (148 tests)
- Added new tests for prompt validation (reject flags, empty input)
- Verified timeout parsing works correctly
- Pre-commit hooks (format, lint, tests) all pass

## Acceptance Criteria

- ✅ `gru prompt "<prompt>"` starts a persistent minion in CWD
- ✅ Quoted strings are treated as literal prompts (no template lookup)
- ✅ Minion gets auto-generated ID (M42, M43, etc.)
- ✅ Session persists across Lab restarts (via `--session-id`)
- ✅ Works from any directory (not just worktrees)

## Known Limitations

- Ad-hoc sessions don't yet appear in `gru status` (tracked separately)
- No automatic cleanup of old ad-hoc workspaces (use `gru clean` manually)
- Resume support works via `gru resume <minion-id>` but requires navigating to workspace

Fixes #74