### PR TITLE
Fix EventLogger test artifacts polluting archive directory

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -109,6 +109,30 @@ impl EventLogger {
         })
     }
 
+    /// Creates a new EventLogger with a custom workspace (for testing only).
+    ///
+    /// This constructor allows tests to use temporary directories instead of
+    /// polluting the production `~/.gru/` directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `minion_id` - Unique minion identifier
+    /// * `workspace` - Custom workspace instance (typically with temp directory root)
+    #[cfg(test)]
+    pub fn new_with_workspace(minion_id: impl Into<String>, workspace: &Workspace) -> Result<Self> {
+        let minion_id = minion_id.into();
+
+        let archive_dir = workspace
+            .archive_dir(&minion_id)
+            .context("Invalid minion_id")?;
+        let log_path = archive_dir.join("events.jsonl");
+
+        Ok(Self {
+            minion_id,
+            log_path,
+        })
+    }
+
     /// Gets the log path for a given minion_id
     /// Returns ~/.gru/archive/<minion-id>/events.jsonl
     ///
@@ -182,34 +206,23 @@ mod tests {
     use super::*;
     use std::fs;
     use std::io::{BufRead, BufReader};
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-    fn unique_minion_id(prefix: &str) -> String {
-        let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
-        format!(
-            "{}_{}_{}",
-            prefix,
-            Utc::now().timestamp_nanos_opt().unwrap(),
-            counter
-        )
-    }
 
     #[test]
     fn test_event_logger_new() {
-        let minion_id = unique_minion_id("M_TEST_NEW");
-        let logger = EventLogger::new(&minion_id).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = Workspace::new_with_root(temp_dir.path().to_path_buf()).unwrap();
+        let logger = EventLogger::new_with_workspace("M_TEST_NEW", &workspace).unwrap();
 
-        assert_eq!(logger.minion_id(), minion_id);
+        assert_eq!(logger.minion_id(), "M_TEST_NEW");
         assert!(logger.log_path().to_string_lossy().contains("archive"));
         assert!(logger.log_path().to_string_lossy().contains("events.jsonl"));
     }
 
     #[test]
     fn test_log_event_creates_file() {
-        let minion_id = unique_minion_id("M_TEST_CREATE");
-        let logger = EventLogger::new(&minion_id).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = Workspace::new_with_root(temp_dir.path().to_path_buf()).unwrap();
+        let logger = EventLogger::new_with_workspace("M_TEST_CREATE", &workspace).unwrap();
 
         // Log a test event
         let event = ClaudeEvent::Thinking {
@@ -219,18 +232,13 @@ mod tests {
 
         // Verify file exists
         assert!(logger.log_path().exists());
-
-        // Clean up - only remove file, leave directory structure
-        fs::remove_file(logger.log_path()).ok();
     }
 
     #[test]
     fn test_log_event_appends_to_file() {
-        let minion_id = unique_minion_id("M_TEST_APPEND");
-        let logger = EventLogger::new(&minion_id).unwrap();
-
-        // Clean up any existing file from previous test runs
-        fs::remove_file(logger.log_path()).ok();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = Workspace::new_with_root(temp_dir.path().to_path_buf()).unwrap();
+        let logger = EventLogger::new_with_workspace("M_TEST_APPEND", &workspace).unwrap();
 
         // Log multiple events
         logger
@@ -255,21 +263,16 @@ mod tests {
         // Verify each line is valid JSON
         for line in &lines {
             let logged_event: LoggedEvent = serde_json::from_str(line).unwrap();
-            assert_eq!(logged_event.minion_id, minion_id);
+            assert_eq!(logged_event.minion_id, "M_TEST_APPEND");
             assert!(logged_event.timestamp <= Utc::now());
         }
-
-        // Clean up - only remove file, leave directory structure
-        fs::remove_file(logger.log_path()).ok();
     }
 
     #[test]
     fn test_log_event_includes_timestamp_and_minion_id() {
-        let minion_id = unique_minion_id("M_TEST_TIMESTAMP");
-        let logger = EventLogger::new(&minion_id).unwrap();
-
-        // Clean up any existing file from previous test runs
-        fs::remove_file(logger.log_path()).ok();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = Workspace::new_with_root(temp_dir.path().to_path_buf()).unwrap();
+        let logger = EventLogger::new_with_workspace("M_TEST_TIMESTAMP", &workspace).unwrap();
 
         let event = ClaudeEvent::ToolUse {
             name: "bash".to_string(),
@@ -283,7 +286,7 @@ mod tests {
         let line = reader.lines().next().unwrap().unwrap();
         let logged_event: LoggedEvent = serde_json::from_str(&line).unwrap();
 
-        assert_eq!(logged_event.minion_id, minion_id);
+        assert_eq!(logged_event.minion_id, "M_TEST_TIMESTAMP");
         assert!(logged_event.timestamp <= Utc::now());
 
         match logged_event.event {
@@ -292,9 +295,6 @@ mod tests {
             }
             _ => panic!("Expected ToolUse event"),
         }
-
-        // Clean up - only remove file, leave directory structure
-        fs::remove_file(logger.log_path()).ok();
     }
 
     #[test]
@@ -332,8 +332,9 @@ mod tests {
 
     #[test]
     fn test_rejects_oversized_content() {
-        let minion_id = unique_minion_id("M_TEST_SIZE");
-        let logger = EventLogger::new(&minion_id).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = Workspace::new_with_root(temp_dir.path().to_path_buf()).unwrap();
+        let logger = EventLogger::new_with_workspace("M_TEST_SIZE", &workspace).unwrap();
 
         // Create content that exceeds MAX_CONTENT_LENGTH
         let large_content = "A".repeat(MAX_CONTENT_LENGTH + 1);
@@ -343,15 +344,13 @@ mod tests {
 
         // Should fail validation
         assert!(logger.log_event(event).is_err());
-
-        // Cleanup
-        fs::remove_file(logger.log_path()).ok();
     }
 
     #[test]
     fn test_rejects_oversized_tool_input() {
-        let minion_id = unique_minion_id("M_TEST_TOOL_SIZE");
-        let logger = EventLogger::new(&minion_id).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = Workspace::new_with_root(temp_dir.path().to_path_buf()).unwrap();
+        let logger = EventLogger::new_with_workspace("M_TEST_TOOL_SIZE", &workspace).unwrap();
 
         // Create a tool input that's too large when serialized
         // Each string "x" takes about 3 bytes in JSON: "x",
@@ -364,15 +363,13 @@ mod tests {
 
         // Should fail validation
         assert!(logger.log_event(event).is_err());
-
-        // Cleanup
-        fs::remove_file(logger.log_path()).ok();
     }
 
     #[test]
     fn test_rejects_oversized_tool_name() {
-        let minion_id = unique_minion_id("M_TEST_TOOL_NAME");
-        let logger = EventLogger::new(&minion_id).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = Workspace::new_with_root(temp_dir.path().to_path_buf()).unwrap();
+        let logger = EventLogger::new_with_workspace("M_TEST_TOOL_NAME", &workspace).unwrap();
 
         // Create a tool name that's too long
         let long_name = "A".repeat(MAX_TOOL_NAME_LENGTH + 1);
@@ -383,8 +380,5 @@ mod tests {
 
         // Should fail validation
         assert!(logger.log_event(event).is_err());
-
-        // Cleanup
-        fs::remove_file(logger.log_path()).ok();
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -69,6 +69,51 @@ impl Workspace {
         })
     }
 
+    /// Creates a workspace with a custom root directory (for testing only).
+    ///
+    /// This constructor allows tests to use temporary directories instead of
+    /// polluting the production `~/.gru/` directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `root` - Custom root directory path (typically from `tempfile::tempdir()`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Directory creation fails due to permissions or I/O errors
+    /// - Setting directory permissions fails (Unix only)
+    #[cfg(test)]
+    pub fn new_with_root(root: PathBuf) -> io::Result<Self> {
+        let repos = root.join("repos");
+        let work = root.join("work");
+        let archive = root.join("archive");
+        let state = root.join("state");
+
+        for dir in [&root, &repos, &work, &archive, &state] {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::DirBuilderExt;
+                let mut builder = fs::DirBuilder::new();
+                builder.mode(0o755);
+                builder.recursive(true);
+                builder.create(dir)?;
+            }
+            #[cfg(not(unix))]
+            {
+                fs::create_dir_all(dir)?;
+            }
+        }
+
+        Ok(Workspace {
+            root,
+            repos,
+            work,
+            archive,
+            state,
+        })
+    }
+
     /// Returns a reference to the workspace root directory path (`~/.gru`).
     pub fn root(&self) -> &Path {
         &self.root


### PR DESCRIPTION
Fixes #132

## Problem

EventLogger tests were creating 1,082+ directories in `~/.gru/archive/` with names like `M_TEST_APPEND_1765426672319903000_1` that were never cleaned up, polluting the production archive directory.

## Solution

Added test-only constructors to allow tests to use temporary directories, following the existing pattern from `minion.rs`:

- **`Workspace::new_with_root(PathBuf)`** - Test constructor for custom workspace root
- **`EventLogger::new_with_workspace(&Workspace)`** - Test constructor using custom workspace
- Updated 8 EventLogger tests to use `tempfile::tempdir()` for automatic cleanup
- Removed `unique_minion_id()` helper (no longer needed with temp directories)
- Cleaned up existing 1,080+ test artifact directories

## Benefits

- ✅ Automatic cleanup via `tempfile::TempDir` Drop implementation
- ✅ Complete test isolation (each test gets own temp directory)
- ✅ Tests can run in parallel without conflicts
- ✅ No changes to production APIs (all `#[cfg(test)]` only)
- ✅ Follows existing pattern in codebase

## Verification

- All 149 tests pass
- No new directories created in `~/.gru/archive/` after test runs
- Parallel execution works: `cargo test logger -- --test-threads=4`
- Linting and formatting checks pass

## Code References

- `src/workspace.rs:87-115` - Added `new_with_root()` test constructor
- `src/logger.rs:122-134` - Added `new_with_workspace()` test constructor
- `src/logger.rs:210-396` - Updated all 8 EventLogger tests