### PR TITLE
Fixes #19: Add review comment handling

### DIFF
--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -40,6 +40,10 @@ const EXIT_CODE_SIGNAL_TERMINATED: i32 = 128;
 /// Reviews can take longer than fixes due to analysis depth
 const DEFAULT_REVIEW_TIMEOUT_SECS: u64 = 1800;
 
+/// Maximum number of review rounds to handle automatically
+/// After this limit, the user must handle additional reviews manually
+const MAX_REVIEW_ROUNDS: usize = 5;
+
 /// Logs an event to events.jsonl in the worktree directory
 async fn log_event(worktree_path: &Path, event: &stream::StreamOutput) -> Result<()> {
     let events_file = worktree_path.join("events.jsonl");
@@ -276,6 +280,11 @@ fn parse_timeout(timeout_str: &str) -> Result<Duration> {
 ///
 /// This function spawns Claude with a custom prompt containing review comments.
 /// It reuses the same session ID to maintain context from the original implementation.
+///
+/// This function handles timeout detection and inactivity monitoring. If a timeout is specified
+/// via the `timeout_opt` parameter, the function will terminate if the operation exceeds the
+/// given duration. The function also monitors for inactivity (no output) and will fail if there
+/// is no activity for an extended period (15 minutes by default).
 async fn invoke_claude_for_reviews(
     worktree_path: &Path,
     session_id: &Uuid,
@@ -893,6 +902,7 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
                     println!("   Press Ctrl+C to stop monitoring\n");
 
                     // Keep monitoring in a loop to handle multiple rounds of reviews
+                    let mut review_round = 0;
                     loop {
                         match pr_monitor::monitor_pr(&owner, &repo, &pr_number, &worktree_path)
                             .await
@@ -910,14 +920,40 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
                                 break;
                             }
                             Ok(MonitorResult::NewReviews(comments)) => {
+                                review_round += 1;
                                 let count = comments.len();
                                 println!(
-                                    "💬 Detected {} new review comment(s) on PR #{}",
-                                    count, pr_number
+                                    "💬 Detected {} new review comment(s) on PR #{} (review round {}/{})",
+                                    count, pr_number, review_round, MAX_REVIEW_ROUNDS
                                 );
 
+                                // Check if we've hit the maximum review rounds limit
+                                if review_round > MAX_REVIEW_ROUNDS {
+                                    println!(
+                                        "⚠️  Reached maximum review rounds limit ({})",
+                                        MAX_REVIEW_ROUNDS
+                                    );
+                                    println!("   Additional reviews will need manual handling");
+                                    println!(
+                                        "   View PR: https://github.com/{}/{}/pull/{}",
+                                        owner, repo, pr_number
+                                    );
+                                    break;
+                                }
+
                                 // Format the review prompt with detailed comments
-                                let issue_number = issue_num.parse::<u64>().unwrap_or(0);
+                                let issue_number = match issue_num.parse::<u64>() {
+                                    Ok(num) => num,
+                                    Err(e) => {
+                                        eprintln!(
+                                            "⚠️  Failed to parse issue number '{}': {}",
+                                            issue_num, e
+                                        );
+                                        eprintln!("   Cannot format review prompt without a valid issue number");
+                                        break;
+                                    }
+                                };
+
                                 let review_prompt = pr_monitor::format_review_prompt(
                                     issue_number,
                                     &pr_number,
@@ -939,6 +975,12 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
                                         println!("\n✅ Finished addressing review comments");
                                         println!("🔄 Continuing to monitor PR...\n");
                                         // Continue monitoring for more reviews
+                                        //
+                                        // Note: monitor_pr re-initializes last_check_time from existing reviews
+                                        // on each call, so it will pick up from the most recent review timestamp.
+                                        // This mitigates (but doesn't completely eliminate) the race condition
+                                        // where the same reviews could be re-detected. A more robust solution
+                                        // would track processed review IDs or return last_check_time from monitor_pr.
                                     }
                                     Err(e) => {
                                         eprintln!("⚠️  Failed to address review comments: {}", e);

--- a/src/pr_monitor.rs
+++ b/src/pr_monitor.rs
@@ -22,7 +22,8 @@ struct Head {
 struct Review {
     id: u64,
     submitted_at: DateTime<Utc>,
-    #[allow(dead_code)] // Used for future features like tracking reviewer identity
+    #[allow(dead_code)]
+    // Available for future use; currently only id and submitted_at are accessed
     user: User,
 }
 
@@ -211,6 +212,7 @@ async fn get_review_comments(
     reviews: &[Review],
 ) -> Result<Vec<ReviewComment>> {
     let mut all_comments = Vec::new();
+    let mut failed_reviews = 0;
 
     for review in reviews {
         // Fetch comments for this specific review
@@ -233,6 +235,7 @@ async fn get_review_comments(
                 "Warning: Failed to fetch comments for review {}: {}",
                 review.id, stderr
             );
+            failed_reviews += 1;
             continue;
         }
 
@@ -250,13 +253,22 @@ async fn get_review_comments(
         }
     }
 
+    // Log summary if any reviews failed to fetch
+    if failed_reviews > 0 {
+        eprintln!(
+            "⚠️  Failed to fetch comments from {} out of {} review(s)",
+            failed_reviews,
+            reviews.len()
+        );
+    }
+
     Ok(all_comments)
 }
 
 /// Format review comments into a prompt for Claude
 pub fn format_review_prompt(issue_num: u64, pr_number: &str, comments: &[ReviewComment]) -> String {
     let mut prompt = format!(
-        "You previously implemented a fix for issue #{}. A reviewer has left feedback \
+        "You previously implemented a fix for issue #{}. Review feedback has been provided \
         on PR #{}. Please address the following comments:\n\n",
         issue_num, pr_number
     );


### PR DESCRIPTION
## Summary

Implements automatic detection and handling of PR review comments for Gru:
- Extends PR monitoring to detect new review comments with detailed metadata (file, line, body, reviewer)
- Re-invokes Claude with the same session ID to maintain full context when reviews arrive
- Implements iterative review handling loop to address multiple rounds of feedback
- Formats review comments into structured prompts for Claude to address

When the PR monitor detects new review comments, Gru automatically:
1. Fetches detailed comment information from GitHub API
2. Formats comments into a structured prompt with file locations and reviewer names
3. Re-invokes Claude with the original session ID to maintain implementation context
4. Continues monitoring for additional review rounds until PR is merged or closed

## Technical Details

**PR Monitoring (`src/pr_monitor.rs`)**:
- Extended `MonitorResult` enum to include `NewReviews(Vec<ReviewComment>)` with full comment details
- Added `ReviewComment` struct with file path, line number, comment body, and reviewer
- Implemented `get_review_comments()` to fetch comments via GitHub API for each review
- Created `format_review_prompt()` to generate structured prompts from review comments

**Review Handling (`src/commands/fix.rs`)**:
- Added `invoke_claude_for_reviews()` helper function that spawns Claude with review context
- Reuses the same session ID to maintain conversation continuity from original implementation
- Implements iterative monitoring loop that continues handling reviews until PR reaches terminal state
- Handles all timeout and inactivity detection for review response process

## Test Plan

Tests added:
- `test_format_review_prompt_single_comment` - Verifies single comment formatting
- `test_format_review_prompt_multiple_comments` - Verifies multiple comments with different reviewers
- `test_format_review_prompt_no_line_number` - Handles general file comments without line numbers
- `test_review_comment_clone` - Ensures ReviewComment is cloneable

All existing tests pass (154 tests):
```bash
just check
```

Manual testing:
1. Run `gru fix <issue>` on an issue
2. Wait for PR creation and monitoring to start
3. Leave review comments on the PR
4. Verify Gru detects comments and re-invokes Claude
5. Check that Claude addresses the feedback and commits changes
6. Verify monitoring continues for additional review rounds

## Notes

**Known Limitations** (addressed in code review):
1. **Session ID reuse**: The same session ID is reused across all review rounds. This maintains context but could hit token limits after many rounds. Consider adding a max rounds limit (e.g., 5) in a follow-up.

2. **Race condition potential**: After processing reviews, `last_check_time` isn't updated based on the handled reviews. This could theoretically cause duplicate processing, though the iterative loop mitigates this in practice.

3. **No review round limit**: The monitoring loop continues indefinitely. A max rounds counter (e.g., 5 rounds) would prevent runaway resource usage in contentious PRs.

**Follow-up Work** (not blocking):
- Add maximum review rounds limit with user feedback
- Update `last_check_time` tracking to prevent race conditions
- Add default timeout for review response handling
- Consider parallel fetching of comments for PRs with many reviews
- Add timestamp and review state to `ReviewComment` struct for better tracking

**Dependencies**:
- Blocked by: #18 (PR monitoring loop) ✅ Already implemented
- Depends on: GitHub API access via `gh` CLI
- Works with: Existing Claude session management and stream parsing

Fixes #19

Fixes #19