### PR TITLE
Fixes #151: Remove timestamps from streaming text output to fix janky multi-line display

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -360,7 +360,7 @@ impl ProgressDisplay {
                                 if let Some(flushed_text) = self.text_buffer.add(text) {
                                     let truncated =
                                         Self::truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
-                                    self.print_event(&format!("[{}] {}", timestamp, truncated));
+                                    self.print_event(&truncated);
                                 }
                             }
                         }
@@ -406,7 +406,7 @@ impl ProgressDisplay {
                     // No tool, check for buffered text
                     if let Some(flushed_text) = self.text_buffer.flush() {
                         let truncated = Self::truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
-                        self.print_event(&format!("[{}] {}", timestamp, truncated));
+                        self.print_event(&truncated);
                     }
                 }
             }
@@ -429,7 +429,7 @@ impl ProgressDisplay {
                 // Flush any remaining buffered text before completing
                 if let Some(flushed_text) = self.text_buffer.flush() {
                     let truncated = Self::truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
-                    self.print_event(&format!("[{}] {}", timestamp, truncated));
+                    self.print_event(&truncated);
                 }
                 self.update_status("✅ Message complete");
             }
@@ -437,7 +437,7 @@ impl ProgressDisplay {
                 // Flush any buffered text before showing error
                 if let Some(flushed_text) = self.text_buffer.flush() {
                     let truncated = Self::truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
-                    self.print_event(&format!("[{}] {}", timestamp, truncated));
+                    self.print_event(&truncated);
                 }
 
                 self.update_status("❌ Error");


### PR DESCRIPTION
## Summary

- Removed timestamps from streaming text output to fix janky multi-line display
- Timestamps now only appear on significant events (tool calls, message boundaries, errors)
- Multi-line content (code blocks, JSON, prose) now displays cleanly without timestamp interruptions

## Implementation Details

Modified `src/progress.rs` to remove timestamps from four locations where text buffers are flushed:
1. Line 363: Text delta output (streaming text chunks)
2. Line 409: Content block stop flush (end of text block)
3. Line 432: Message stop flush (final text flush)
4. Line 440: Error text flush (before displaying error)

Timestamps are preserved for:
- Message boundary events (Message started, Complete)
- Tool calls (Run: command, Read: file, etc.)
- Tool results (✓/✗ with completion status)
- Error messages

## Test Plan

- All 184 existing tests pass (`just test`)
- Pre-commit hooks pass (formatting, linting, tests)
- Code review completed with no blocking issues
- Manual verification: Streaming text now displays without per-line timestamps

## Impact

**Before:**
```
[23:11:21] json
{
[23:11:21]
  "M
[23:11:22] 42": {
    "prompt
[23:11:22] ": "fix --issue 123",
```

**After:**
```
[23:11:21] Message started
json
{
  "M42": {
    "prompt": "fix --issue 123",
[23:11:25] Run: git status
[23:11:26] Complete
```

## Notes

- The code reviewer identified some low-priority suggestions for future improvements (mutex poisoning monitoring, debug mode, integration tests)
- No breaking changes or API modifications
- All acceptance criteria from issue #151 are met

Fixes #151