### PR TITLE
Fixes #157: Fix janky line breaks in streaming output from partial messages

### DIFF
--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -394,13 +394,13 @@ mod tests {
 
         // Simulate LLM token stream that might break mid-word
         buffer.add("Comple");
-        buffer.add("xity Asse");
+        buffer.add("xity Ass");
 
         // Wait for timeout
         thread::sleep(Duration::from_millis(60));
 
         // Add more text - should flush at word boundary
-        let result = buffer.add("ssment");
+        let result = buffer.add("essment");
 
         // Should flush "Complexity " (up to last space), keeping "Assessment" in buffer
         assert_eq!(result, Some("Complexity ".to_string()));


### PR DESCRIPTION
## Summary

Fixes janky mid-word line breaks in streaming output by implementing word-boundary flushing in TextBuffer. Previously, timeout and buffer-full conditions would flush mid-word (e.g., "Shoul" then "d" on separate lines), creating a poor user experience. Now the buffer intelligently flushes at word boundaries (spaces, newlines) while keeping partial words buffered.

Key changes:
- Added `flush_at_word_boundary()` helper that finds the last whitespace and flushes up to that point
- Updated timeout and buffer-full flush logic to respect word boundaries
- Ensured UTF-8 safety with proper handling of multi-byte Unicode characters (emoji, CJK, etc.)
- Natural boundaries (newlines, sentence endings) still flush immediately as before
- Falls back to full flush if no word boundary exists (very long words)

## Test Plan

All tests pass (`just check`):
- 199 tests passed, 0 failed
- Clippy and formatting checks passed
- 8 new test cases added:
  - `test_timeout_flushes_at_word_boundary` - verifies timeout respects word boundaries
  - `test_timeout_with_no_word_boundary` - handles long words without spaces
  - `test_buffer_full_flushes_at_word_boundary` - verifies buffer-full respects boundaries
  - `test_no_mid_word_breaks_on_partial_fragments` - simulates realistic LLM token stream ("Comple" + "xity Asse" + "ssment")
  - `test_multibyte_unicode_after_boundary` - ensures Chinese characters stay intact
  - `test_emoji_after_word_boundary` - verifies emoji (multi-byte UTF-8) handling
  - `test_unicode_whitespace_boundary` - tests non-ASCII whitespace (non-breaking space)
  - `test_flush_when_ending_with_whitespace` - edge case coverage

Manual verification:
- Tested with actual Claude streaming output during development
- No visual mid-word breaks observed
- Output still feels real-time (max 2 second delay as before)

## Notes

The implementation uses `char_indices()` to ensure UTF-8 safety when splitting at word boundaries, preventing panics with multi-byte Unicode characters. This follows code review recommendations and includes proper documentation of UTF-8 safety guarantees.

The fix maintains backward compatibility - natural boundaries (newlines, sentence endings) continue to flush immediately, and the 2-second timeout still applies. The only behavior change is that timeout/buffer-full flushes now respect word boundaries instead of breaking mid-word.

Fixes #157

Fixes #157