### PR TITLE
Fixes #164: Fix session ID conflict when re-invoking Claude for review responses

### DIFF
--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -488,7 +488,7 @@ async fn invoke_with_session_retry(
     /// Helper to check if an error is a session lock error
     fn is_session_lock_error(error: &anyhow::Error) -> bool {
         let error_msg = error.to_string().to_lowercase();
-        error_msg.contains("session") && error_msg.contains("already in use")
+        error_msg.contains("session already in use")
     }
 
     // First attempt with original session


### PR DESCRIPTION
## Summary

Fixes session ID conflict when re-invoking for review responses. The implementation uses a retry-with-delay-and-fallback strategy to preserve conversation context while handling session lock edge cases gracefully.

- Added session retry logic with 5-second delay between attempts
- Falls back to new session if lock persists (preserves functionality)
- Improved error detection with case-insensitive matching
- Extracted retry logic into separate function for better maintainability
- Added debug logging to track session lock behavior

## Test plan

- Ran `just check` successfully (all tests pass, no clippy warnings, formatting correct)
- Pre-commit hooks pass
- Build successful

Testing the actual session retry behavior requires triggering the specific "session already in use" error from Claude CLI, which occurs when:
1. A fix command completes and creates a PR
2. Review comments are added to the PR
3. The monitoring loop attempts to re-invoke Claude with the same session ID

The fix handles three scenarios:
1. **Success on first attempt**: No retry needed (best case)
2. **Success on retry**: Waits 5 seconds and successfully reuses original session
3. **Fallback to new session**: After two failures, uses fresh session with warning

## Notes

**Code Review Improvements Applied:**

Based on feedback from the code-reviewer agent, this implementation includes:

1. **Extracted function**: The 50+ lines of nested match statements were refactored into a clean `invoke_with_session_retry()` function that's easier to test and maintain

2. **Better error detection**: Uses case-insensitive matching (`to_lowercase()`) to handle potential variations in error messages

3. **Debug logging**: Added `eprintln!` statements to log when session locks are detected and when fallback occurs, making it easier to diagnose issues

4. **Documented constant**: The `SESSION_RETRY_DELAY_SECS` constant now includes rationale for the 5-second value

5. **Clear control flow**: The new function uses early returns and clear error propagation instead of deeply nested matches

**Future Improvements:**

The code review suggested several enhancements for future work:
- Unit tests for the retry logic (would require mocking `invoke_claude_for_reviews`)
- Circuit breaker pattern if session locks become recurring
- Metrics/telemetry to track retry frequency
- Consideration of timeout interaction during retry delay

These are good ideas but beyond the scope of this fix. The current implementation solves the immediate problem pragmatically while maintaining code quality.

Fixes #164