### PR TITLE
Fix session ID conflict by using --resume for review responses

### DIFF
--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -88,6 +88,33 @@ fn build_claude_command(worktree_path: &Path, session_id: &Uuid, prompt: &str) -
     cmd
 }
 
+/// Builds a Claude command to resume an existing session
+///
+/// This is used when continuing a conversation from a previous session,
+/// such as when addressing review comments after the initial fix.
+/// Uses --resume instead of --session-id to avoid "session already in use" errors.
+fn build_claude_resume_command(
+    worktree_path: &Path,
+    session_id: &Uuid,
+    prompt: &str,
+) -> TokioCommand {
+    let mut cmd = TokioCommand::new("claude");
+    cmd.arg("--print")
+        .arg("--verbose")
+        .arg("--resume")
+        .arg(session_id.to_string())
+        .arg("--output-format")
+        .arg("stream-json")
+        .arg("--include-partial-messages")
+        .arg("--dangerously-skip-permissions")
+        .arg(prompt)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .current_dir(worktree_path);
+    cmd
+}
+
 /// Runs Claude with stream monitoring and timeout detection
 ///
 /// Returns the exit status for the caller to inspect. Caller is responsible for
@@ -436,7 +463,7 @@ async fn invoke_claude_for_reviews(
     prompt: &str,
     timeout_opt: Option<&str>,
 ) -> Result<()> {
-    let cmd = build_claude_command(worktree_path, session_id, prompt);
+    let cmd = build_claude_resume_command(worktree_path, session_id, prompt);
     let status = run_claude_with_stream_monitoring(
         cmd,
         worktree_path,


### PR DESCRIPTION
## Summary

- Fixes session ID conflict when re-invoking the agent for review responses
- Adds `build_claude_resume_command()` function that uses `--resume` flag
- Updates `invoke_claude_for_reviews()` to use the new resume command
- Uses correct API: `--session-id` for creating sessions, `--resume` for continuing them

## Root Cause

The original implementation incorrectly used `--session-id` for both creating and resuming sessions. The API has two distinct flags:
- `--session-id`: Creates a new session with a specific ID
- `--resume`: Resumes an existing session

Using `--session-id` with an already-existing session ID caused "session already in use" errors.

## Solution

This fix addresses the root cause directly by using the correct API flag:
- Initial `/fix` invocation uses `--session-id` to create a new session (src/commands/fix.rs:708)
- Review responses use `--resume` to continue the existing session (src/commands/fix.rs:466)

This preserves conversational context across the initial fix and subsequent review responses, which was the intended behavior.

## Test Plan

- Ran `just check` (all tests passed, clippy clean, formatted correctly)
- Verified the implementation with code-reviewer agent
- Key code references:
  - `build_claude_resume_command()`: src/commands/fix.rs:96-116
  - Usage in `invoke_claude_for_reviews()`: src/commands/fix.rs:466

## Notes

- This is a much simpler solution than retry-with-delay workarounds (see PR #167)
- No retry logic needed - the correct API just works
- PR #167 should be closed in favor of this approach
- Code review identified this as a clean, root-cause fix with no critical issues

Fixes #164