### PR TITLE
Fixes #173: Fix gru status hanging when gru review is running

### DIFF
--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -135,10 +135,14 @@ pub async fn handle_review(pr_arg: Option<String>) -> Result<i32> {
         pr: Some(pr_num.clone()),
     };
 
-    let mut registry = MinionRegistry::load(None).context("Failed to load Minion registry")?;
-    registry
-        .register(minion_id.clone(), registry_info)
-        .context("Failed to register review Minion in registry")?;
+    // Load registry and register the Minion (spawn_blocking to avoid holding lock during review)
+    let minion_id_clone = minion_id.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut registry = MinionRegistry::load(None)?;
+        registry.register(minion_id_clone, registry_info)
+    })
+    .await
+    .context("Failed to spawn blocking task for registry registration")??;
 
     println!("🤖 Launching autonomous review agent...\n");
 


### PR DESCRIPTION
## Summary
- Fixed file lock contention by wrapping registry operations in `spawn_blocking`
- Ensured the lock is released immediately after registration instead of being held during the entire review process
- Mirrored the correct pattern already used in `fix.rs`

## Test plan
- Ran `just check` - all tests pass (210 passed, 5 ignored)
- Pre-commit hooks passed (format, lint, tests)
- Verified the fix follows the same pattern as `fix.rs:646-653`
- Code review by code-reviewer agent found no critical or high-priority issues

## Notes
- This fix prevents `gru status` from hanging indefinitely when `gru review` is running
- The registry variable now properly drops when the closure returns, releasing the file lock via RAII
- The double `??` operator correctly handles both spawn and registry operation errors

Fixes #173