### PR TITLE
Fixes #52: Pass issue details to Claude prompt

### DIFF
--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -415,6 +415,25 @@ async fn create_pr_for_issue(
     Ok(pr_number)
 }
 
+/// Handles the result of fetching issue details via CLI
+/// Returns Some with (title, body, empty labels) on success, None on failure
+async fn handle_cli_fetch_result(
+    result: Result<crate::github::IssueInfo>,
+) -> Option<(String, String, String)> {
+    match result {
+        Ok(issue_info) => {
+            // CLI version doesn't include labels, but we can still provide title and body
+            let body = issue_info.body.unwrap_or_default();
+            Some((issue_info.title, body, String::new()))
+        }
+        Err(e) => {
+            eprintln!("⚠️  Failed to fetch issue details via CLI: {}", e);
+            eprintln!("   Continuing with basic prompt format");
+            None
+        }
+    }
+}
+
 /// Parses a timeout string into a Duration
 /// Supports formats like "10s", "5m", "1h", "30"
 fn parse_timeout(timeout_str: &str) -> Result<Duration> {
@@ -728,36 +747,27 @@ pub async fn handle_fix(issue: &str, timeout_opt: Option<String>, quiet: bool) -
                     eprintln!("⚠️  Failed to fetch issue details via API: {}", e);
                     eprintln!("   Falling back to gh CLI...");
                     // Try CLI fallback
-                    match crate::github::get_issue_via_cli(&owner, &repo, issue_number).await {
-                        Ok(issue_info) => {
-                            // CLI version doesn't include labels, but we can still provide title and body
-                            let body = issue_info.body.unwrap_or_default();
-                            Some((issue_info.title, body, String::new()))
-                        }
-                        Err(cli_err) => {
-                            eprintln!("⚠️  Failed to fetch issue details via CLI: {}", cli_err);
-                            eprintln!("   Continuing with basic prompt format");
-                            eprintln!("   Fix authentication with: gh auth login");
-                            None
-                        }
+                    let cli_result =
+                        crate::github::get_issue_via_cli(&owner, &repo, issue_number).await;
+                    let result = handle_cli_fetch_result(cli_result).await;
+
+                    // Only show auth guidance if both API and CLI failed
+                    if result.is_none() {
+                        eprintln!("   Fix authentication with: gh auth login");
                     }
+                    result
                 }
             }
         } else {
             // No API client - try CLI directly
-            match crate::github::get_issue_via_cli(&owner, &repo, issue_number).await {
-                Ok(issue_info) => {
-                    // CLI version doesn't include labels, but we can still provide title and body
-                    let body = issue_info.body.unwrap_or_default();
-                    Some((issue_info.title, body, String::new()))
-                }
-                Err(e) => {
-                    eprintln!("⚠️  Failed to fetch issue details via CLI: {}", e);
-                    eprintln!("   Continuing with basic prompt format");
-                    eprintln!("   Fix authentication with: gh auth login");
-                    None
-                }
+            let cli_result = crate::github::get_issue_via_cli(&owner, &repo, issue_number).await;
+            let result = handle_cli_fetch_result(cli_result).await;
+
+            // Show auth guidance when CLI fails and we have no API client
+            if result.is_none() {
+                eprintln!("   Fix authentication with: gh auth login");
             }
+            result
         }
     } else {
         None


### PR DESCRIPTION
## Summary
- Passes issue title, body, and labels to Claude prompt when running `gru fix`
- Eliminates duplicate issue fetching (was fetched twice)
- Adds cascading fallback: API → CLI → basic prompt
- Improves error messages with actionable guidance

## Test plan
- Built successfully with `just build`
- All tests pass with `just test`
- Linter passes with `just lint`
- Code reviewed by code-reviewer agent

## Changes

### Issue Context in Prompt (src/commands/fix.rs:703-764)
When `gru fix` launches Claude, it now fetches issue details and formats them into a structured prompt:

```
Fix this GitHub issue:

Issue #52: Pass issue details to Claude prompt
URL: https://github.com/owner/repo/issues/52
Labels: feature, phase-4

Description:
[issue body here]

Please implement a fix for this issue.
```

### Cascading Fallback Strategy
1. **API first**: Try GitHub API if token available
2. **CLI fallback**: If API fails, try gh CLI
3. **Basic prompt**: If both fail, use `/fix N` format
4. **Clear errors**: Each step provides actionable error messages

### Optimization
- **Eliminated duplicate fetching**: Previously fetched issue twice (once for prompt, once for PR title)
- **Single parse**: Issue number parsed once and reused
- **Cached title**: Issue title from first fetch is passed to PR creation

### Error Messages
Improved error handling with guidance:
```
⚠️  Failed to fetch issue details via API: [error]
   Falling back to gh CLI...
⚠️  Failed to fetch issue details via CLI: [error]
   Continuing with basic prompt format
   Fix authentication with: gh auth login
```

## Notes
- Maintains backward compatibility - falls back gracefully if fetching fails
- Reduces GitHub API rate limit usage by eliminating duplicate fetches
- Works with both URL format (`owner/repo#123`) and plain issue numbers (`123`)

Fixes #52