### PR TITLE
Fix bare repo branch references for worktree creation

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -256,13 +256,23 @@ impl GitRepo {
 
             // Configure fetch refspec so future fetches update local branches directly
             // (git clone --bare doesn't set this by default)
-            let _ = Command::new("git")
+            let output = Command::new("git")
                 .arg("-C")
                 .arg(&self.bare_path)
                 .arg("config")
                 .arg("remote.origin.fetch")
                 .arg("+refs/heads/*:refs/heads/*")
-                .output();
+                .output()
+                .context("Failed to execute git config for remote.origin.fetch")?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!(
+                    "git config remote.origin.fetch failed with exit code {:?}: {}",
+                    output.status.code(),
+                    stderr
+                );
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
- Fix "invalid reference" error when creating worktrees from bare repos
- Handle both old repos (with `origin/` prefix) and new repos (without prefix)
- Use explicit refspec in fetch to properly update local branches

## Problem
When running `gru fix` on a repository, worktree creation could fail with:
```
fatal: invalid reference: origin/main
```

**Root cause:** Bare repositories store branches differently depending on how they were cloned:
- `git clone --bare` (newer repos): branches stored directly as `main`
- Repos with mirror-style refspec (older repos): branches stored as `origin/main`

The code assumed `origin/main` always existed, which failed for newer repos.

## Solution
- Changed `get_base_branch()` to verify which reference actually exists before returning
- Updated `DEFAULT_BRANCHES` to try both patterns: `["main", "origin/main", "master", "origin/master"]`
- Changed fetch to use explicit refspec `+refs/heads/*:refs/heads/*`
- Added config step after clone to set fetch refspec for future fetches

## Test plan
- [x] Ran `just check` (fmt, lint, test, build all pass)
- [x] Tested `gru fix` on dmx repo (plain --bare clone) - works
- [x] Verified gru repo (mirror-style refspec) still has `origin/main` - compatible