### PR TITLE
Handle worktree conflicts gracefully in ensure_bare_clone

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -208,11 +208,24 @@ impl GitRepo {
 
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                anyhow::bail!(
-                    "git fetch failed with exit code {:?}: {}",
-                    output.status.code(),
-                    stderr
-                );
+                // If fetch fails because a branch is checked out in a worktree,
+                // that's OK - the specific branch fetch will handle what we need.
+                // This happens when doing a blanket fetch and some unrelated branch
+                // is checked out in a worktree.
+                if stderr.contains("refusing to fetch into branch")
+                    && stderr.contains("checked out at")
+                {
+                    log::warn!(
+                        "Skipping full fetch due to worktree conflict (will fetch specific branch later): {}",
+                        stderr.trim()
+                    );
+                } else {
+                    anyhow::bail!(
+                        "git fetch failed with exit code {:?}: {}",
+                        output.status.code(),
+                        stderr
+                    );
+                }
             }
         } else {
             // Clone as bare repository


### PR DESCRIPTION
## Summary
- Fix `gru review` failing when unrelated stale worktrees exist
- Detect "refusing to fetch into branch...checked out at" error and log warning instead of failing
- The specific branch fetch that happens later still gets the branch we need

## Problem
When running `gru review 190`, the command failed with:
```
git fetch failed with exit code Some(128): fatal: refusing to fetch into branch 'refs/heads/fix-test-cleanup-132' checked out at '/Users/sspalding/.gru/work/fotoetienne/gru/fix-test-cleanup-132'
```

The branch causing the failure (`fix-test-cleanup-132`) was unrelated to the PR being reviewed (`fix/bare-repo-branch-refs`). The blanket fetch of all branches fails if *any* branch is checked out in a worktree.

## Test plan
- [x] `just check` passes
- [ ] Test `gru review` with stale worktrees present