### PR TITLE
Fixes #192: gru prompt passes minion ID instead of UUID for --session-id

### DIFF
--- a/src/commands/prompt.rs
+++ b/src/commands/prompt.rs
@@ -11,6 +11,7 @@ use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command as TokioCommand;
 use tokio::time::{timeout, Duration};
+use uuid::Uuid;
 
 /// Timeout in seconds for each line read from Claude's output stream
 /// Set to 5 minutes to accommodate long-running LLM operations
@@ -160,6 +161,9 @@ pub async fn handle_prompt(prompt: &str, timeout_opt: Option<String>, quiet: boo
         .register(minion_id.clone(), registry_info)
         .context("Failed to register prompt Minion in registry")?;
 
+    // Generate a unique session ID (UUID) for Claude's --session-id flag
+    let session_id = Uuid::new_v4();
+
     println!("🤖 Launching Claude...\n");
 
     // Create progress display
@@ -178,7 +182,7 @@ pub async fn handle_prompt(prompt: &str, timeout_opt: Option<String>, quiet: boo
     cmd.arg("--print")
         .arg("--verbose")
         .arg("--session-id")
-        .arg(&minion_id) // Enable session persistence
+        .arg(session_id.to_string()) // Claude requires a valid UUID for --session-id
         .arg("--output-format")
         .arg("stream-json")
         .arg("--include-partial-messages")


### PR DESCRIPTION
## Summary
- Fix `gru prompt` failing with "Invalid session ID. Must be a valid UUID" by generating a `Uuid::new_v4()` for the `--session-id` flag instead of passing the minion ID (e.g., `M03j`)
- Matches the pattern used in `fix.rs` where `session_id` is a UUID and `minion_id` is kept for display/tracking

## Test plan
- All 245 existing tests pass (`just check`)
- Format, clippy, and build all pass
- Manual verification: the minion ID is still used for workspace paths, registry, progress display, and resume hints — only the `--session-id` flag now receives a UUID

## Notes
- The minion ID continues to be used for all non-Claude purposes (registry, workspace path, display, GRU_WORKSPACE env var)
- The session UUID is only used for Claude's `--session-id` requirement

Fixes #192