### PR TITLE
Fixes #194: ensure_bare_clone: fetch falls back to no-op when worktrees conflict

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -326,7 +326,8 @@ impl GitRepo {
     /// branch name (e.g. "main", "master"). This is a local operation with no network
     /// access, making it suitable for fallback paths where speed matters.
     ///
-    /// Falls back to "main" if the symref can't be read or parsed.
+    /// Falls back to "main" if the symref can't be parsed or the command returns non-zero.
+    /// Returns an error if git cannot be executed.
     fn local_default_branch_name(&self) -> Result<String> {
         let output = Command::new("git")
             .arg("-C")
@@ -352,7 +353,8 @@ impl GitRepo {
     ///
     /// Returns just the branch name as it appears on the remote (without any
     /// "origin/" prefix or "refs/heads/" prefix). Falls back to "main" if the
-    /// remote query fails or can't be parsed.
+    /// remote query returns non-zero or can't be parsed. Returns an error if git
+    /// cannot be executed.
     fn query_default_branch_name(&self) -> Result<String> {
         let output = Command::new("git")
             .arg("-C")


### PR DESCRIPTION
## Summary
- When the blanket fetch (`+refs/heads/*:refs/heads/*`) fails due to worktree conflicts, fall back to fetching just the default branch so `main` stays up to date
- Read the local `HEAD` symref from the bare repo (fast, no network) to determine the default branch for the fallback fetch
- Surface a user-facing warning suggesting `gru clean` to remove stale worktrees
- Extract `query_default_branch_name()` from `get_base_branch()` to share the remote default branch detection logic

## Test plan
- `just check` passes (format, lint, test, build)
- All 245 unit tests pass, 0 failures
- The fallback fetch uses `git symbolic-ref HEAD` (local, no network) for speed and offline resilience
- If even the default branch fetch fails (e.g. it's checked out in a worktree), the code warns but doesn't fail — the bare repo still exists with a potentially recent-enough copy

## Notes
- The blanket fetch still runs first — the fallback only activates when git reports "refusing to fetch into branch" + "checked out at"
- `query_default_branch_name()` (with `ls-remote`) is kept for `get_base_branch()` where a fresh network lookup is appropriate
- `local_default_branch_name()` (with `symbolic-ref HEAD`) is used in the fallback path for speed

Fixes #194

Fixes #194