### PR TITLE
Fixes #198: gru attach fails to find minions shown by gru status

### DIFF
--- a/src/minion_resolver.rs
+++ b/src/minion_resolver.rs
@@ -133,9 +133,10 @@ fn load_from_registry() -> Vec<MinionInfo> {
             let uptime = {
                 let now = chrono::Utc::now();
                 let duration = now.signed_duration_since(info.started_at);
-                let minutes = duration.num_minutes();
-                let hours = duration.num_hours();
-                let days = duration.num_days();
+                // Guard against clock skew (started_at in the future)
+                let minutes = duration.num_minutes().max(0);
+                let hours = duration.num_hours().max(0);
+                let days = duration.num_days().max(0);
                 if days > 0 {
                     format!("{}d", days)
                 } else if hours > 0 {


### PR DESCRIPTION
## Summary
- `resolve_minion()` now checks the `MinionRegistry` first (same source as `gru status`), with filesystem scanning as fallback
- Extracted shared resolution logic into `try_resolve_from_list()` (plain `fn`, no network calls) to avoid duplication between registry and filesystem paths
- Added `load_from_registry()` to convert registry entries to the resolver's `MinionInfo` format
- PR-to-issue resolution (`gh pr view`) fires at most once, after both local sources are exhausted
- Registry entries are never silently filtered — callers handle missing worktrees gracefully

## Test plan
- Added 5 new unit tests for `try_resolve_from_list()` covering: exact ID match, M-prefix resolution, issue number lookup, not-found case, and empty list
- All 328 existing tests pass (`just test`)
- `just check` passes (format + lint + test + build)
- Pre-commit hooks all pass

## Notes
- Fixes #198: `gru attach`, `gru path`, `gru resume`, and `gru stop` now find any minion visible in `gru status`
- The registry is loaded with best-effort semantics — if it fails, resolution falls back to filesystem scanning (preserving backwards compatibility for worktrees not in the registry)
- Registry lock is held only during `load_from_registry()` (read-only), then released before any filesystem scanning or git operations

Fixes #198