### PR TITLE
Fixes #210: Fix Lab mode: slots leak, no process monitoring, no graceful shutdown

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -117,21 +117,42 @@ async fn shutdown_children(children: &mut [Child]) {
         return;
     }
 
+    // Reap already-exited children first for an accurate running count
+    let mut running_pids = Vec::new();
+    for child in children.iter_mut() {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                log::info!("Minion process already exited with status: {}", status);
+            }
+            Ok(None) => {
+                if let Some(pid) = child.id() {
+                    running_pids.push(pid);
+                }
+            }
+            Err(e) => {
+                log::warn!("Failed to check child process status: {}", e);
+            }
+        }
+    }
+
+    if running_pids.is_empty() {
+        println!("No running Minion processes to shut down.");
+        return;
+    }
+
     println!(
         "🔪 Signaling {} running Minion(s) to shut down...",
-        children.len()
+        running_pids.len()
     );
 
-    // Send SIGTERM to all children
-    for child in children.iter() {
-        if let Some(pid) = child.id() {
-            #[cfg(unix)]
-            {
-                // SAFETY: kill with SIGTERM is safe - it requests graceful termination.
-                // The PID is valid because we just obtained it from the child handle.
-                unsafe {
-                    libc::kill(pid as i32, libc::SIGTERM);
-                }
+    // Send SIGTERM to all still-running children
+    for pid in &running_pids {
+        #[cfg(unix)]
+        {
+            // SAFETY: kill with SIGTERM is safe - it requests graceful termination.
+            // The PID is valid because we just obtained it from the child handle.
+            unsafe {
+                libc::kill(*pid as i32, libc::SIGTERM);
             }
         }
     }
@@ -140,13 +161,15 @@ async fn shutdown_children(children: &mut [Child]) {
     println!("⏳ Waiting for Minions to exit...");
     sleep(Duration::from_secs(5)).await;
 
-    // Force-kill any remaining processes and wait for them to exit
+    // Force-kill any remaining processes and reap to avoid zombies
     for child in children.iter_mut() {
         match child.try_wait() {
             Ok(Some(_)) => {} // Already exited
             _ => {
                 log::warn!("Force-killing Minion process that didn't exit gracefully");
                 let _ = child.kill().await;
+                // Reap the child process to avoid leaving a zombie
+                let _ = child.wait().await;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Use PID liveness checks (`is_process_alive`) instead of registry status string for slot counting and issue claim detection, fixing crashed minions permanently consuming lab slots
- Track child process handles in a `Vec<Child>` instead of dropping them, enabling process lifecycle monitoring and graceful shutdown
- Capture stdout/stderr to per-minion log files (`~/.gru/state/logs/<repo>-issue-<number>.log`) instead of `/dev/null` for debugging visibility
- Signal all running minion processes (SIGTERM + force-kill after 5s) on Ctrl-C to prevent orphaned processes
- Prune stale registry entries (missing worktrees) at the start of each polling cycle to prevent dead minion accumulation

## Test plan
- All existing tests pass: `just check` (fmt + clippy + 332 tests + build)
- New unit tests added for `reap_children` and log path construction
- Manual verification: the changes are confined to `src/commands/lab.rs` and don't affect other commands

## Notes
- The `available_slots` and `is_issue_claimed` functions each acquire the registry lock independently per poll cycle. This is a pre-existing TOCTOU limitation; merging them into a single registry read is a future optimization.
- Log files use append mode so re-runs of the same issue accumulate rather than overwrite
- The `prune_stale_entries` function mirrors the cleanup logic already used by `gru status`

Fixes #210