### PR TITLE
Fixes #89: Validate required parameters from prompt frontmatter

### DIFF
--- a/src/commands/prompt.rs
+++ b/src/commands/prompt.rs
@@ -277,12 +277,16 @@ pub async fn handle_prompt(
     // Try to resolve the prompt as a file-based prompt name.
     // If it matches a loaded prompt file, use its content and validate requirements.
     // Otherwise, treat it as ad-hoc prompt text.
-    let repo_root = std::env::current_dir().ok();
+    // Use git toplevel (not cwd) so prompts are found from subdirectories.
+    let repo_root = git::detect_git_repo().await.ok();
     let loaded_prompts = prompt_loader::load_prompts(repo_root.as_deref()).unwrap_or_else(|e| {
         log::warn!("Failed to load prompt files: {}", e);
         HashMap::new()
     });
     let resolved_prompt = if let Some(file_prompt) = loaded_prompts.get(trimmed_prompt) {
+        // Validate prompt syntax (non-empty content, valid param names)
+        prompt_loader::validate_prompt(file_prompt)?;
+
         // Validate requirements before proceeding
         prompt_loader::validate_prompt_requirements(
             &file_prompt.name,

--- a/src/prompt_loader.rs
+++ b/src/prompt_loader.rs
@@ -431,7 +431,7 @@ pub fn validate_requires(
 ) -> Vec<(String, String)> {
     let mut missing = Vec::new();
     for req in requires {
-        match req.to_lowercase().as_str() {
+        match req.trim().to_lowercase().as_str() {
             "issue" => {
                 if !issue_provided {
                     missing.push(("issue".to_string(), "--issue <number>".to_string()));
@@ -1088,6 +1088,17 @@ Repo content"#,
         assert_eq!(missing.len(), 2);
 
         // Providing them should satisfy the check
+        let missing = validate_requires(&requires, true, true);
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn test_validate_requires_trims_whitespace() {
+        // Values with leading/trailing whitespace should still match
+        let requires = vec!["issue ".to_string(), " pr".to_string()];
+        let missing = validate_requires(&requires, false, false);
+        assert_eq!(missing.len(), 2);
+
         let missing = validate_requires(&requires, true, true);
         assert!(missing.is_empty());
     }


### PR DESCRIPTION
## Summary
- Add `validate_requires()` to check `requires` field in frontmatter (e.g., `requires: [issue]` ensures `--issue` is provided)
- Add `validate_prompt_requirements()` that validates both context requirements and custom params, reporting all missing requirements in a single error
- Integrate prompt file resolution into `handle_prompt()` — when the prompt text matches a file-based prompt name, loads the file and validates before execution
- Case-insensitive matching for `requires` values (`Issue`, `PR`, etc. all work)
- Warn (don't crash) when prompt loading fails or unknown requirements are encountered

## Test plan
- Added 16 unit tests covering: requires validation (issue/pr provided/missing, both, empty, unknown, case-insensitive), combined validation (all satisfied, missing requires, missing param, combined errors, no requirements, optional params ok)
- All 435 tests pass: `cargo test`
- Clean clippy: `cargo clippy --all-targets -- -D warnings`
- Clean formatting: `cargo fmt --check`
- Pre-commit hooks pass on all commits

## Notes
- This is Phase 3 of the Custom Prompts feature, blocked by #80 (load prompt files) and #87 (--param flag) which are both merged
- Validation runs before any expensive side effects (worktree creation, GitHub API calls)
- Unknown `requires` values produce a warning rather than an error for forward compatibility
- Prompt file load errors are logged as warnings rather than silently swallowed

Fixes #89