### PR TITLE
Fixes #185: Show session state in `gru status`

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -145,15 +145,23 @@ pub async fn handle_status(id: Option<String>, verbose: bool) -> Result<i32> {
             );
         }
 
-        // Detect dead processes and update registry
-        let registry_minions = registry.list();
-        for (minion_id, info) in &registry_minions {
-            if let Some(pid) = info.pid {
-                if !is_process_alive(pid) {
-                    registry.update(minion_id, |info| {
-                        info.mode = MinionMode::Stopped;
-                        info.pid = None;
-                    })?;
+        // Detect dead processes and update registry.
+        // Only on Unix where is_process_alive uses kill(pid, 0) for accurate checks.
+        // On non-Unix, is_process_alive always returns false which would incorrectly
+        // mark all minions as dead.
+        // Note: is_process_alive is a microsecond syscall, so running it under the
+        // registry lock is acceptable (unlike git operations in Phase 2).
+        #[cfg(unix)]
+        {
+            let registry_minions = registry.list();
+            for (minion_id, info) in &registry_minions {
+                if let Some(pid) = info.pid {
+                    if !is_process_alive(pid) {
+                        registry.update(minion_id, |info| {
+                            info.mode = MinionMode::Stopped;
+                            info.pid = None;
+                        })?;
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ enum Commands {
         #[arg(help = "Optional ID to filter by (minion ID, issue number, or PR number)")]
         id: Option<String>,
 
-        #[arg(short, long, help = "Show session ID and PID details")]
+        #[arg(short, long, help = "Show session ID, PID, and worktree path details")]
         verbose: bool,
     },
     #[command(about = "Stop a running Minion")]


### PR DESCRIPTION
## Summary
- Replace generic "Active"/"Stopped" status with mode-aware display: "running (autonomous)", "running (interactive)", or "stopped"
- Add `--verbose` flag (`-v`) to show session_id, PID, and worktree path in a focused table layout
- Detect dead processes during Phase 1 registry cleanup and persist the correction (set mode to Stopped, clear PID)
- Carry mode and session_id through BasicMinionData/EnhancedMinionInfo for display

## Test plan
- All 477 existing tests pass (`cargo test`)
- Added/updated unit tests for `format_mode_display` covering all mode/PID combinations:
  - No PID -> "stopped"
  - Alive PID + Autonomous -> "running (autonomous)"
  - Alive PID + Interactive -> "running (interactive)"
  - Dead PID -> "stopped"
  - Alive PID + Stopped mode (edge case) -> "running (unknown)" with warning
- Clippy passes with `-D warnings`
- Formatting verified with `cargo fmt --check`

## Notes
- Default view retains the existing rich table (MINION, REPO, ISSUE, TASK, PR, BRANCH, MODE, UPTIME, TOKENS) with MODE replacing the old STATUS column. The `--verbose` flag shows the simplified session-focused view (ID, ISSUE, MODE, SESSION ID, PID, PATH) matching the issue's example output.
- Dead PID detection calls `registry.update()` per dead process (each triggers a save). With typical registry sizes (1-5 minions) this is negligible; a batch update API could be added if needed.

Fixes #185