### PR TITLE
Fixes #265: gru clean marks worktrees with open PRs as cleanable

### DIFF
--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -266,6 +266,7 @@ pub async fn handle_clean(dry_run: bool, force: bool, base_branch: &str) -> Resu
     // Check status of each worktree
     let mut cleanable = Vec::new();
     let mut skipped_active_minions = Vec::new();
+    let mut skipped_open_prs = Vec::new();
     for wt in worktrees {
         // Skip if this worktree has an active minion
         // Canonicalize the worktree path for reliable comparison
@@ -305,10 +306,7 @@ pub async fn handle_clean(dry_run: bool, force: bool, base_branch: &str) -> Resu
             });
 
             if has_open_pr {
-                println!(
-                    "  Skipping {} (minion stopped but has open PR)",
-                    wt.path.display()
-                );
+                skipped_open_prs.push(wt);
             } else {
                 cleanable.push((wt, worktree_scanner::WorktreeStatus::MinionStopped));
             }
@@ -336,12 +334,27 @@ pub async fn handle_clean(dry_run: bool, force: bool, base_branch: &str) -> Resu
         }
     }
 
+    // Display skipped worktrees with open PRs
+    if !skipped_open_prs.is_empty() {
+        println!(
+            "Skipped {} worktree(s) with open PRs:\n",
+            skipped_open_prs.len()
+        );
+        for wt in &skipped_open_prs {
+            println!("  {} (open PR)", wt.path.display());
+            println!("    Branch: {}", wt.branch);
+            println!("    Repo: {}", wt.repo);
+            println!();
+        }
+    }
+
     if cleanable.is_empty() && orphaned_minions.is_empty() {
-        if skipped_active_minions.is_empty() {
+        let has_skips = !skipped_active_minions.is_empty() || !skipped_open_prs.is_empty();
+        if !has_skips {
             println!("No worktrees to clean.");
         } else {
             println!(
-                "No cleanable worktrees found (all worktrees were skipped due to active minions)."
+                "No cleanable worktrees found (skipped worktrees have active minions or open PRs)."
             );
         }
         return Ok(0);

--- a/src/worktree_scanner.rs
+++ b/src/worktree_scanner.rs
@@ -201,6 +201,8 @@ impl Worktree {
     ///
     /// Squash merges create new commit hashes, so `git branch --merged` won't detect them.
     /// This method uses `gh pr list --state merged --head <branch>` to check GitHub directly.
+    /// Callers should treat errors conservatively (i.e., assume the PR may not have been
+    /// confirmed as merged).
     pub async fn check_pr_merged_on_github(&self) -> Result<bool> {
         Ok(self.count_prs_in_state("merged").await? > 0)
     }


### PR DESCRIPTION
## Summary
- Add `check_has_open_pr()` to `Worktree` in `worktree_scanner.rs` to detect open PRs for a branch
- Extract shared `gh pr list` logic into a private `count_prs_in_state()` helper, deduplicating `check_pr_merged_on_github()` and `check_has_open_pr()`
- Gate the `MinionStopped` fallback in `clean.rs` on no open PR — worktrees with open PRs under review are now preserved
- Use conservative default (`unwrap_or(true)`) so that if the `gh` command fails, worktrees are kept rather than cleaned

## Test plan
- `just check` passes (format, lint, 480 tests, build)
- Manual verification: worktrees with open PRs are no longer listed as cleanable by `gru clean`

## Notes
- Fixes #265
- The `count_prs_in_state()` helper replaces ~45 lines of duplicated code between the merged and open PR checks
- When `gh`/`ghe` fails to spawn, the error defaults to "has open PR" (conservative) to avoid accidental cleanup