### PR TITLE
Fix review prompt to perform code review instead of responding to reviews

### DIFF
--- a/src/prompt_loader.rs
+++ b/src/prompt_loader.rs
@@ -134,7 +134,7 @@ URL: https://github.com/{{ repo_owner }}/{{ repo_name }}/pull/{{ pr_number }}
 Review this pull request: fetch details, analyze changes, and provide code review feedback.
 
 ## 1. Fetch PR Details
-- The PR title, description, and URL are provided above. Use `gh pr view {{ pr_number }} --repo {{ repo_owner }}/{{ repo_name }} --json files,author,closingIssuesReferences` to get changed files, author, and issues this PR closes in a single call.
+- The PR title, description, and URL are provided above. Use `gh pr view {{ pr_number }} --repo {{ repo_owner }}/{{ repo_name }} --json files,author,closingIssuesReferences --jq '{author: .author.login, files: [.files[].path], closingIssues: [.closingIssuesReferences[].number]}'` to get changed files, author, and issues this PR closes in a single call.
 - Fetch existing review comments: `gh api --paginate repos/{{ repo_owner }}/{{ repo_name }}/pulls/{{ pr_number }}/comments`
 - Understand the scope and intent of the PR, and any prior discussion
 - The code should already be checked out in the current directory


### PR DESCRIPTION
## Summary
- Rewrites the built-in `review` prompt from a "respond to PR comments" workflow into an actual code review workflow (fetch details, analyze changes, provide feedback, submit review)
- Adds self-review detection to prevent GitHub API errors when reviewing your own PR
- Consolidates 3 separate `gh pr view` API calls into a single `--json files,author,closingIssuesReferences` call
- Notes that PR title/body are already embedded in the prompt header to avoid redundant fetching

## Test plan
- [x] All 469 tests pass (`just test`)
- [ ] Manual test: run `gru review` on a PR and verify it performs a code review
- [ ] Verify the self-review check works when reviewing your own PR