### PR TITLE
Update documentation to match actual codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ claude --print \
 
 **State Management:**
 - **GitHub as source of truth** - Labels, comments, PRs provide complete state
-- **Local state:** Persistent Minion registry at `~/.gru/state/minions.json` (atomic writes with file locking), file-based cursors for timeline polling
+- **Local state:** Persistent Minion registry at `~/.gru/state/minions.json` (atomic writes with file locking)
 - **No SQLite** - Rebuild state from GitHub on restart
 - **Minion IDs:** Stored in `~/.gru/state/next_id.txt` with file locking for atomicity
 
@@ -220,9 +220,8 @@ Located in `.claude/skills/`:
 - See `experiments/DMX_ANALYSIS.md` for approach comparison (CLI + Stream Parsing scored 0.735)
 
 ### GitHub Integration
-- Use `ghe` instead of `gh` for Netflix GitHub repos (auto-detected by owner name)
 - Never stage files with `git add -A` - always be explicit
-- Authentication priority: `gh`/`ghe` CLI token (`gh auth token`), then `GRU_GITHUB_TOKEN` env var as fallback
+- Authentication priority: `gh` CLI token (`gh auth token`), then `GRU_GITHUB_TOKEN` env var as fallback
 - Labels drive state machine: `ready-for-minion` → `in-progress` → `minion:done`/`minion:failed`
 - Comments use YAML frontmatter for structured events
 - Issue/PR parsing supports both numbers (when in repo) and full GitHub URLs

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ gru clean               # Remove worktrees for merged/closed PRs
 ### Workspace Setup
 
 ```bash
-gru init owner/repo     # Initialize workspace for a repo
-gru lab                 # Start daemon mode (polls for issues)
+gru init owner/repo                 # Initialize workspace for a repo
+gru lab --repos owner/repo          # Start daemon mode with explicit repos
+# or configure repos in ~/.gru/config.toml and run: gru lab
 ```
 
 ### Other Commands

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -215,21 +215,11 @@ The **Lab** is the main process that orchestrates Minions.
 **Configuration:**
 ```toml
 # ~/.gru/config.toml
-github:
-  token: ghp_xxxxxxxxxxxx
-  repos:
-    - owner/repo1
-    - owner/repo2
-    
-lab:
-  slots: 2                    # Max concurrent Minions
-  poll_interval: 30s          # How often to check for new issues
-  minion_timeout: 2h          # Max time before declaring stuck
-  
-llm:
-  provider: anthropic
-  model: claude-sonnet-4-5
-  max_tokens_per_issue: 100000
+[daemon]
+repos = ["owner/repo1", "owner/repo2"]
+poll_interval_secs = 30       # How often to check for new issues
+max_slots = 2                 # Max concurrent Minions
+label = "ready-for-minion"    # Label to watch for
 ```
 
 ### Minion
@@ -239,8 +229,8 @@ A **Minion** is a Claude Code session working on a single issue.
 **Key Insight:** Each Minion **IS** a Claude Code session. One-to-one mapping.
 
 ```
-Minion M42  =  Claude Code session in worktree ~/.gru/work/owner/repo/M42
-Minion M43  =  Claude Code session in worktree ~/.gru/work/owner/repo/M43
+Minion M042  =  Claude Code session in worktree ~/.gru/work/owner/repo/minion/issue-42-M042/checkout/
+Minion M043  =  Claude Code session in worktree ~/.gru/work/owner/repo/minion/issue-43-M043/checkout/
 ```
 
 **How Lab manages Minions:**
@@ -1454,9 +1444,8 @@ async fn recover(&self) -> Result<(), LabError> {
 
 **1. GitHub Token Security**
 ```rust
-// ~/.gru/config.toml (mode 0600)
-// github:
-//   token: ghp_xxxxxxxxxxxx
+// GitHub auth: gh/ghe CLI token (primary) or GRU_GITHUB_TOKEN env var (fallback)
+// Tokens are never stored in config files
 
 // Never log tokens
 impl std::fmt::Display for Config {
@@ -1628,14 +1617,6 @@ POST /api/minions/:id/abandon # Abandon Minion
 │                   └── checkout/    # Git worktree (repo files)
 │                       ├── .git
 │                       └── <repo files>
-├── archive/                         # Completed Minion artifacts
-│   ├── M42/
-│   │   ├── events.jsonl             # Structured event log
-│   │   ├── plan.md                  # Execution plan
-│   │   ├── commits.log              # Git commit history
-│   │   ├── ci-results.json          # CI check run results
-│   │   └── metrics.json             # Cost and performance metrics
-│   └── M43/
 ├── state/
 │   ├── next_id.txt                  # Monotonic counter for Minion IDs (base36)
 │   ├── minions.json                 # Persistent Minion registry
@@ -1667,41 +1648,18 @@ export GRU_GITHUB_TOKEN="ghp_xxxxxxxxxxxx"
 ```toml
 # ~/.gru/config.toml
 
+[daemon]
 # Repositories to monitor (multi-repo support)
-repos:
-  - owner/repo1
-  - owner/repo2
-  - anotherowner/repo3
+repos = ["owner/repo1", "owner/repo2", "anotherowner/repo3"]
 
-lab:
-  # Concurrency - slots shared across all repos
-  slots: 2
-  
-  # Polling interval (seconds)
-  poll_interval: 30
-  
-  # Retry limits
-  max_ci_retries: 10  # High limit before pausing for human review
-  
-  # Archive retention (0 = keep forever)
-  archive_retention_days: 0
+# Max concurrent Minions
+max_slots = 2
 
-git:
-  # User identity for commits
-  user_name: "Gru Minion"
-  user_email: "minion@gru.local"
-  
-  # Branch naming
-  branch_prefix: "minion/issue-"
+# Polling interval (seconds)
+poll_interval_secs = 30
 
-observability:
-  # Logging
-  log_level: info
-  log_file: ~/.gru/logs/gru.log
-  
-  # Metrics (Prometheus format)
-  metrics_enabled: true
-  metrics_port: 9090
+# Label to watch for issues (default: "ready-for-minion")
+label = "ready-for-minion"
 ```
 
 ---


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Added 20 missing modules, removed ghost `logger.rs`, expanded CLI commands from 5 to 13, fixed state management description (persistent `minions.json`, not "in-memory only"), corrected worktree paths (branch names, not minion IDs), fixed auth priority, corrected retry counts, attributed timeout constants to `claude_runner.rs`
- **README.md**: Fixed Rust version (1.73 not 1.70), updated stale "Phase 1" description, expanded usage to show all commands, updated roadmap to reflect V1 as complete
- **docs/DESIGN.md**: Fixed config format (`config.yaml` → `config.toml`), updated filesystem layout, corrected env var docs

## Test plan
- [ ] Verify `CLAUDE.md` module list matches `src/**/*.rs` files
- [ ] Verify CLI commands match `src/main.rs` Clap definitions
- [ ] Verify constants (timeouts, retries) match source code values
- [ ] Verify filesystem layout matches `workspace.rs` and `minion_registry.rs`