### PR TITLE
Fixes #288: Make `gru init` default to current directory when no argument given

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,9 +45,9 @@ enum Commands {
     #[command(about = "Initialize a repository for use with Gru")]
     Init {
         #[arg(
-            help = "Repository to initialize: 'owner/repo' for GitHub, '.' for current directory, or a path"
+            help = "Repository to initialize: 'owner/repo' for GitHub, '.' for current directory, or a path. Defaults to current directory."
         )]
-        repo: String,
+        repo: Option<String>,
     },
     #[command(about = "Work on a GitHub issue", alias = "fix")]
     Do {
@@ -249,7 +249,7 @@ async fn main() {
         .init();
 
     let result = match cli.command {
-        Commands::Init { repo } => init::handle_init(repo).await,
+        Commands::Init { repo } => init::handle_init(repo.unwrap_or_else(|| ".".to_string())).await,
         Commands::Do {
             issue,
             timeout,


### PR DESCRIPTION
## Summary
- Make the `repo` argument optional in `gru init`, defaulting to current directory detection (equivalent to `gru init .`)
- Changes `repo: String` to `repo: Option<String>` in the `Init` command variant
- Defaults to `"."` via `unwrap_or_else` at the call site

## Test plan
- `just check` passes (format, lint, 491 tests, build)
- Pre-commit hooks pass

## Notes
- ~3-line change in `src/main.rs` only; `init.rs` unchanged since `handle_init` already accepts a `String`

Fixes #288