### PR TITLE
Fixes #299: Skip blocked issues in lab polling

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -218,13 +218,25 @@ async fn poll_and_spawn(config: &LabConfig, children: &mut Vec<Child>) -> Result
             }
         };
 
-        // Fetch ready issues, excluding blocked ones (both GitHub-blocked and minion:blocked)
+        // Fetch ready issues, excluding blocked ones (both GitHub-blocked and minion:blocked).
+        // Try CLI first (supports -is:blocked qualifier), fall back to octocrab with
+        // client-side filtering if CLI is unavailable.
         let issue_numbers = match list_ready_issues_via_cli(owner, repo, &config.daemon.label).await
         {
             Ok(numbers) => numbers,
-            Err(e) => {
-                log::warn!("⚠️  Failed to fetch issues for {}: {}", repo_spec, e);
-                continue;
+            Err(cli_err) => {
+                log::warn!(
+                    "⚠️  CLI issue fetch failed for {}: {}, trying API fallback",
+                    repo_spec,
+                    cli_err
+                );
+                match fallback_list_issues(owner, repo, &config.daemon.label).await {
+                    Ok(numbers) => numbers,
+                    Err(e) => {
+                        log::warn!("⚠️  API fallback also failed for {}: {}", repo_spec, e);
+                        continue;
+                    }
+                }
             }
         };
 
@@ -409,6 +421,29 @@ async fn spawn_minion(repo: &str, issue_number: u64) -> Result<Child> {
     println!("📝 Log: {}", log_path.display());
 
     Ok(child)
+}
+
+/// Fallback issue listing using octocrab API with client-side filtering.
+/// Used when the gh CLI is unavailable. Cannot filter GitHub-native blocked state
+/// (no API equivalent of `-is:blocked`), but does filter out `minion:blocked` and
+/// `in-progress` labels.
+async fn fallback_list_issues(owner: &str, repo: &str, label: &str) -> Result<Vec<u64>> {
+    let client = GitHubClient::from_env(owner, repo).await?;
+    let issues = client.list_issues_with_label(owner, repo, label).await?;
+
+    let blocked_labels = ["minion:blocked", "in-progress"];
+    let filtered: Vec<u64> = issues
+        .into_iter()
+        .filter(|issue| {
+            !issue
+                .labels
+                .iter()
+                .any(|l| blocked_labels.contains(&l.name.as_str()))
+        })
+        .map(|issue| issue.number)
+        .collect();
+
+    Ok(filtered)
 }
 
 #[cfg(test)]

--- a/src/github.rs
+++ b/src/github.rs
@@ -570,13 +570,20 @@ pub async fn mark_pr_ready_via_cli(owner: &str, repo: &str, pr_number: &str) -> 
 ///
 /// # Returns
 /// List of issue numbers matching the search criteria (capped at 100)
+/// Build a GitHub search query that finds issues with the given label while excluding
+/// blocked and in-progress issues. Escapes special characters in the label.
+fn build_ready_issues_search_query(label: &str) -> String {
+    let escaped_label = label.replace('\\', "\\\\").replace('"', "\\\"");
+    format!(
+        "label:\"{}\" -is:blocked -label:\"minion:blocked\" -label:in-progress",
+        escaped_label
+    )
+}
+
 pub async fn list_ready_issues_via_cli(owner: &str, repo: &str, label: &str) -> Result<Vec<u64>> {
     let repo_full = format!("{}/{}", owner, repo);
     let gh_cmd = gh_command_for_repo(&repo_full);
-    let search_query = format!(
-        "label:\"{}\" -is:blocked -label:\"minion:blocked\" -label:in-progress",
-        label
-    );
+    let search_query = build_ready_issues_search_query(label);
     let output = Command::new(gh_cmd)
         .args([
             "issue",
@@ -1004,5 +1011,70 @@ mod tests {
             .remove_label(owner, repo, issue, label)
             .await
             .expect("Failed to remove label");
+    }
+
+    // --- IssueNumber deserialization tests ---
+
+    #[test]
+    fn test_issue_number_deserialize() {
+        let json = r#"[{"number": 1}, {"number": 42}, {"number": 100}]"#;
+        let items: Vec<IssueNumber> = serde_json::from_str(json).unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].number, 1);
+        assert_eq!(items[1].number, 42);
+        assert_eq!(items[2].number, 100);
+    }
+
+    #[test]
+    fn test_issue_number_deserialize_empty() {
+        let json = "[]";
+        let items: Vec<IssueNumber> = serde_json::from_str(json).unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn test_issue_number_deserialize_extra_fields() {
+        let json = r#"[{"number": 5, "title": "ignored", "url": "https://example.com"}]"#;
+        let items: Vec<IssueNumber> = serde_json::from_str(json).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].number, 5);
+    }
+
+    #[test]
+    fn test_issue_number_deserialize_missing_number() {
+        let json = r#"[{"title": "no number"}]"#;
+        let result: Result<Vec<IssueNumber>, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    // --- Search query construction tests ---
+
+    #[test]
+    fn test_build_ready_issues_search_query_simple() {
+        let query = build_ready_issues_search_query("ready-for-minion");
+        assert_eq!(
+            query,
+            "label:\"ready-for-minion\" -is:blocked -label:\"minion:blocked\" -label:in-progress"
+        );
+    }
+
+    #[test]
+    fn test_build_ready_issues_search_query_with_spaces() {
+        let query = build_ready_issues_search_query("ready for minion");
+        assert!(query.starts_with("label:\"ready for minion\""));
+    }
+
+    #[test]
+    fn test_build_ready_issues_search_query_escapes_quotes() {
+        let query = build_ready_issues_search_query(r#"label"with"quotes"#);
+        // Input quotes are escaped: label"with"quotes → label\"with\"quotes
+        assert!(query.starts_with(r#"label:"label\"with\"quotes""#));
+    }
+
+    #[test]
+    fn test_build_ready_issues_search_query_escapes_backslashes() {
+        let query = build_ready_issues_search_query(r"back\slash");
+        // Input backslash is escaped: back\slash → back\\slash
+        assert!(query.starts_with(r#"label:"back\\slash""#));
     }
 }


### PR DESCRIPTION
## Summary
- Add `list_ready_issues_via_cli()` in `github.rs` that uses `gh issue list --search` with `-is:blocked` and `-label:minion:blocked` qualifiers to exclude blocked issues at the API level
- Update `poll_and_spawn` in `lab.rs` to use the new CLI-based search instead of `list_issues_with_label`, preventing wasted Minion slots on blocked issues

## Test plan
- `just check` passes (format, lint, 542 tests, build)
- The `gh` CLI search query `label:{label} -is:blocked -label:minion:blocked` excludes both GitHub's native blocked state and Gru's own `minion:blocked` label server-side

## Notes
- Uses `gh issue list --search` instead of octocrab's issues list API because only GitHub's search API supports the `-is:blocked` qualifier
- The `GitHubClient` is now created only after fetching the issue list (moved after the CLI search), since it's only needed for claiming issues
- The old `list_issues_with_label` octocrab method is preserved for other callers that don't need blocked-issue filtering

Fixes #299