### PR TITLE
Fixes #311: Auto-configure git hooks in minion worktrees

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use log::info;
+
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
@@ -246,6 +246,36 @@ async fn configure_hooks(worktree_path: &Path) -> Result<()> {
         return Ok(());
     }
 
+    // Check if core.hooksPath is already set — don't overwrite existing config
+    let existing = Command::new("git")
+        .arg("-C")
+        .arg(worktree_path)
+        .arg("config")
+        .arg("core.hooksPath")
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .await
+        .ok();
+
+    if let Some(ref out) = existing {
+        if out.status.success() {
+            let current = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !current.is_empty() && current != ".githooks" {
+                log::debug!(
+                    "core.hooksPath already set to '{}' in {}, skipping",
+                    current,
+                    worktree_path.display()
+                );
+                return Ok(());
+            }
+            if current == ".githooks" {
+                return Ok(());
+            }
+        }
+    }
+
     let output = Command::new("git")
         .arg("-C")
         .arg(worktree_path)
@@ -267,7 +297,7 @@ async fn configure_hooks(worktree_path: &Path) -> Result<()> {
         anyhow::bail!("Failed to configure git hooks: {}", stderr);
     }
 
-    info!(
+    log::info!(
         "Configured core.hooksPath=.githooks in {}",
         worktree_path.display()
     );
@@ -1172,13 +1202,18 @@ mod tests {
         let dir = temp_dir.path();
 
         // Initialize a git repo
-        clean_git_cmd()
+        let init_output = clean_git_cmd()
             .arg("-C")
             .arg(dir)
             .arg("init")
             .output()
             .await
             .unwrap();
+        assert!(
+            init_output.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&init_output.stderr)
+        );
 
         // Create .githooks directory
         std::fs::create_dir_all(dir.join(".githooks")).unwrap();
@@ -1197,7 +1232,17 @@ mod tests {
             .output()
             .await
             .unwrap();
-        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), ".githooks");
+        assert!(
+            output.status.success(),
+            "git config --local core.hooksPath failed: status={:?}, stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            ".githooks",
+            "unexpected core.hooksPath value"
+        );
     }
 
     #[tokio::test]
@@ -1206,13 +1251,18 @@ mod tests {
         let dir = temp_dir.path();
 
         // Initialize a git repo (no .githooks directory)
-        clean_git_cmd()
+        let init_output = clean_git_cmd()
             .arg("-C")
             .arg(dir)
             .arg("init")
             .output()
             .await
             .unwrap();
+        assert!(
+            init_output.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&init_output.stderr)
+        );
 
         // Run configure_hooks — should be a no-op
         let result = configure_hooks(dir).await;


### PR DESCRIPTION
## Summary
- Add `configure_hooks()` function in `src/git.rs` that detects `.githooks/` directories and sets `core.hooksPath` after worktree creation
- Called from both `create_worktree()` and `checkout_worktree()` paths so all minion worktrees get hooks configured
- Clears `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` env vars in the git config command to avoid interference from parent git processes
- Hook configuration is non-fatal — if `git config` fails, a warning is logged but worktree creation succeeds

## Test plan
- Added `test_configure_hooks_sets_hooks_path_when_githooks_exists` — verifies hooks are configured when `.githooks/` is present
- Added `test_configure_hooks_skips_when_no_githooks_dir` — verifies no-op when `.githooks/` is absent
- Tests use `tempfile::tempdir()` for isolation and `clean_git_cmd()` helper to clear git env vars (required for tests to pass inside pre-commit hooks)
- Commands run: `just check` (fmt + lint + test + build) — all 649 tests pass

## Notes
- The `core.hooksPath` config is written to the bare repo's shared config (default `--local` scope in linked worktrees), which means all worktrees for the same repo inherit it — this is the desired behavior since `.githooks` is a relative path resolved per-worktree
- Hook failures will surface naturally in Claude's output and minion logs since they cause git commands to fail with non-zero exit codes

Fixes #311