### PR TITLE
Fixes #348: Populate new MinionInfo fields at spawn time

### DIFF
--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -844,7 +844,11 @@ async fn setup_worktree(
         .map(parse_timeout)
         .transpose()
         .context("Invalid --timeout value")?
-        .and_then(|dur| chrono::TimeDelta::from_std(dur).ok())
+        .map(|dur| {
+            chrono::TimeDelta::from_std(dur)
+                .map_err(|_| anyhow::anyhow!("--timeout value is too large to represent"))
+        })
+        .transpose()?
         .map(|delta| now + delta);
     let registry_info = RegistryMinionInfo {
         repo: repo_name.clone(),
@@ -2156,7 +2160,7 @@ pub async fn handle_fix(issue: &str, opts: FixOptions) -> Result<i32> {
                 let mid = minion_id.clone();
                 with_registry(move |reg| {
                     reg.update(&mid, |info| {
-                        info.attempt_count += 1;
+                        info.attempt_count = info.attempt_count.saturating_add(1);
                     })
                 })
                 .await

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -100,7 +100,7 @@ pub async fn handle_resume(
     let mid = minion.minion_id.clone();
     with_registry(move |reg| {
         reg.update(&mid, |info| {
-            info.attempt_count += 1;
+            info.attempt_count = info.attempt_count.saturating_add(1);
         })
     })
     .await


### PR DESCRIPTION
## Summary
- Compute `timeout_deadline` from `--timeout` flag at spawn time (`Utc::now() + duration`) and store in registry
- Set `attempt_count` to 1 on initial spawn (previously hardcoded to 0)
- Store `no_watch` from `--no-watch` flag in registry entry (previously hardcoded to false)
- Increment `attempt_count` on each `gru resume` invocation
- Increment `attempt_count` on auto-resume path in `gru do` (when interrupted minion is detected)
- Pass `FixOptions` to `setup_worktree()` so spawn-time flags flow into the registry

## Test plan
- `just check` passes (fmt + lint + 718 tests + build)
- Existing tests cover MinionInfo serialization with new fields
- Lab-spawned minions use default opts (no timeout, no_watch=false, attempt_count=1) which is correct

## Notes
- `review.rs` and `prompt.rs` registry entries keep default values for these fields since those commands don't accept `--timeout`/`--no-watch` flags
- `attempt_count` increment in resume/auto-resume is best-effort (`.ok()`) to avoid failing the operation if the counter update fails
- `timeout_deadline` uses `chrono::TimeDelta::from_std()` to convert from `std::time::Duration`

Fixes #348