### PR TITLE
Fixes #329: CI escalation missing for timeout and no-commits exhaustion

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -579,8 +579,6 @@ pub async fn post_escalation_comment(
     failed_checks: &[CheckRun],
     attempts: u32,
 ) -> Result<()> {
-    let repo_full = format!("{}/{}", owner, repo);
-
     let mut body = format!(
         "## 🚨 CI Fix Escalation\n\n\
          Automated CI fix failed after **{}/{}** attempts. Human intervention required.\n\n\
@@ -609,45 +607,7 @@ pub async fn post_escalation_comment(
 
     body.push_str(&format!("\n**Labels:** `{}`\n", labels::BLOCKED));
 
-    let gh_cmd = github::gh_command_for_repo(&repo_full);
-    let output = Command::new(gh_cmd)
-        .args([
-            "pr",
-            "comment",
-            &pr_number.to_string(),
-            "--repo",
-            &repo_full,
-            "--body",
-            &body,
-        ])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .await
-        .context("Failed to post escalation comment")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Failed to post escalation comment: {}", stderr);
-    }
-
-    // Add the blocked label
-    let _ = Command::new(gh_cmd)
-        .args([
-            "pr",
-            "edit",
-            &pr_number.to_string(),
-            "--repo",
-            &repo_full,
-            "--add-label",
-            labels::BLOCKED,
-        ])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .await;
-
-    Ok(())
+    post_escalation_comment_body(owner, repo, pr_number, &body).await
 }
 
 /// Post an escalation comment when CI exhaustion occurs due to timeout or no-commits.
@@ -658,8 +618,6 @@ pub async fn post_exhaustion_escalation_comment(
     reason: &str,
     attempts: u32,
 ) -> Result<()> {
-    let repo_full = format!("{}/{}", owner, repo);
-
     let body = format!(
         "## 🚨 CI Fix Escalation\n\n\
          Automated CI fix failed after **{}/{}** attempts. Human intervention required.\n\n\
@@ -672,7 +630,19 @@ pub async fn post_exhaustion_escalation_comment(
         labels::BLOCKED
     );
 
+    post_escalation_comment_body(owner, repo, pr_number, &body).await
+}
+
+/// Posts an escalation comment body to a PR and adds the blocked label.
+async fn post_escalation_comment_body(
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    body: &str,
+) -> Result<()> {
+    let repo_full = format!("{}/{}", owner, repo);
     let gh_cmd = github::gh_command_for_repo(&repo_full);
+
     let output = Command::new(gh_cmd)
         .args([
             "pr",
@@ -681,7 +651,7 @@ pub async fn post_exhaustion_escalation_comment(
             "--repo",
             &repo_full,
             "--body",
-            &body,
+            body,
         ])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
## Summary
- Fix two silent exhaustion paths in `monitor_and_fix_ci` that returned `Ok(false)` without posting escalation comments
- **Timeout path**: now posts an escalation comment with the timeout reason and adds `gru:blocked` label on the final attempt
- **No-commits path**: now calls `post_escalation_comment` with the failed check details on the final attempt
- Extract shared `gh pr comment` + `gh pr edit --add-label` logic into `post_escalation_comment_body` helper to deduplicate the two escalation functions

## Test plan
- `just check` passes (fmt, clippy, tests, build)
- Both exhaustion paths now explicitly `return Ok(false)` after posting escalation instead of falling through via `break`

## Notes
- The existing `post_escalation_comment` (for failed checks with details) and new `post_exhaustion_escalation_comment` (for timeout/generic reasons) both delegate to a shared private helper
- No new tests added for the escalation functions since they require subprocess execution (consistent with existing test strategy)

Fixes #329