### PR TITLE
Fixes #342: prompt.rs stores unbounded prompt text in registry

### DIFF
--- a/src/commands/prompt.rs
+++ b/src/commands/prompt.rs
@@ -667,7 +667,7 @@ pub async fn handle_prompt(prompt: &str, opts: PromptOptions) -> Result<i32> {
         repo: repo_display,
         issue: issue_number_val.unwrap_or(0),
         command: "prompt".to_string(),
-        prompt: rendered_prompt.clone(),
+        prompt: rendered_prompt.chars().take(200).collect(),
         started_at: now,
         branch: branch_name,
         worktree: workspace_path.clone(),


### PR DESCRIPTION
## Summary
- Truncate prompt text to 200 chars before storing in minion registry, matching the existing pattern in `review.rs:150`
- Prevents large template-expanded prompts from bloating `~/.gru/state/minions.json`

## Test plan
- `just check` passes (format, lint, 740 tests, build)
- Verified the fix matches the existing truncation pattern in `review.rs`

## Notes
- One-line change: `rendered_prompt.clone()` → `rendered_prompt.chars().take(200).collect()`
- Uses `.chars().take(200)` to safely handle Unicode (no mid-codepoint truncation)

Fixes #342