### PR TITLE
Fixes #332: Lab uses blocking std::fs in async context

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -651,11 +651,13 @@ async fn spawn_minion(repo: &str, host: &str, issue_number: u64) -> Result<Child
         .append(true)
         .open(&log_path)
         .await
-        .with_context(|| format!("Failed to open log file: {}", log_path.display()))?;
-    let stdout_file = log_file.into_std().await;
-    let stderr_file = stdout_file
+        .with_context(|| format!("Failed to open log file: {}", log_path.display()))?
+        .try_into_std()
+        .expect("no in-flight I/O immediately after open");
+    let stdout_file = log_file
         .try_clone()
         .context("Failed to clone log file handle")?;
+    let stderr_file = log_file;
 
     // Spawn `gru do <issue>` as a background process with output captured to log file
     let mut child = tokio::process::Command::new(exe)


### PR DESCRIPTION
## Summary
- Replace blocking `std::fs::create_dir_all` with `tokio::fs::create_dir_all` in `spawn_minion`
- Replace blocking `std::fs::OpenOptions` with `tokio::fs::OpenOptions` in `spawn_minion`
- Convert `tokio::fs::File` to `std::fs::File` via `into_std().await` for `Stdio::from` compatibility

## Test plan
- `just check` passes (format, lint, 752 tests, build)
- Pre-commit hooks pass

## Notes
- The `into_std().await` call is needed because `Stdio::from` requires a `std::fs::File`, not a tokio file
- The `try_clone()` for stderr still uses `std::fs::File::try_clone` which is fine since it operates on the already-converted std file handle

Fixes #332