### PR TITLE
Fixes #338: Consolidate duplicate CheckRun types in ci.rs and pr_monitor.rs

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -28,7 +28,7 @@ const CI_FIX_TIMEOUT_SECS: u64 = 1200;
 
 /// The status of a CI check run
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum CheckStatus {
     #[default]
     Queued,
@@ -48,6 +48,9 @@ pub enum CheckConclusion {
     Neutral,
     Skipped,
     Stale,
+    /// Catch-all for unknown or future conclusion values from the GitHub API.
+    #[serde(other)]
+    Unknown,
 }
 
 impl CheckConclusion {
@@ -74,6 +77,7 @@ impl fmt::Display for CheckConclusion {
             CheckConclusion::Neutral => write!(f, "neutral"),
             CheckConclusion::Skipped => write!(f, "skipped"),
             CheckConclusion::Stale => write!(f, "stale"),
+            CheckConclusion::Unknown => write!(f, "unknown"),
         }
     }
 }

--- a/src/pr_monitor.rs
+++ b/src/pr_monitor.rs
@@ -1085,6 +1085,24 @@ mod tests {
     }
 
     #[test]
+    fn test_check_run_deserialize_in_progress_status() {
+        use crate::ci::CheckStatus;
+        let json = r#"{"status": "in_progress", "conclusion": null}"#;
+        let check: CheckRun = serde_json::from_str(json).unwrap();
+        assert_eq!(check.status, CheckStatus::InProgress);
+        assert!(check.conclusion.is_none());
+    }
+
+    #[test]
+    fn test_check_run_deserialize_unknown_conclusion() {
+        use crate::ci::CheckConclusion;
+        let json = r#"{"conclusion": "some_future_value"}"#;
+        let check: CheckRun = serde_json::from_str(json).unwrap();
+        assert_eq!(check.conclusion, Some(CheckConclusion::Unknown));
+        assert!(!is_failed_check(&check));
+    }
+
+    #[test]
     fn test_check_runs_response_deserialize() {
         use crate::ci::CheckConclusion;
         let json = r#"{


### PR DESCRIPTION
## Summary
- Remove duplicate `CheckRun` struct from `pr_monitor.rs` and reuse the canonical `ci::CheckRun` type
- Add `#[serde(default)]` to `name` and `status` fields and `Default` impl for `CheckStatus` so the struct deserializes from both jq-transformed and raw GitHub API responses
- Add `CheckConclusion::is_failed()` method to replace string-matching in `is_failed_check`
- Fix `CheckStatus` serde rename from `"lowercase"` to `"snake_case"` so `"in_progress"` deserializes correctly from the GitHub API
- Add `Unknown` catch-all variant with `#[serde(other)]` to `CheckConclusion` for graceful handling of future/unexpected API values
- Update all `pr_monitor.rs` tests to use `CheckConclusion` enum variants instead of string comparisons

## Test plan
- All 749 tests pass (`cargo test`) — 2 new tests added
- New test: `test_check_run_deserialize_in_progress_status` verifies `"in_progress"` status deserializes correctly
- New test: `test_check_run_deserialize_unknown_conclusion` verifies unknown conclusion values are handled gracefully
- Clippy passes with warnings-as-errors (`cargo clippy --all-targets -- -D warnings`)
- Format check passes (`cargo fmt --all -- --check`)
- Pre-commit hooks pass (fmt + lint + test)

## Notes
- The `pr_monitor.rs` `CheckRunsResponse` wrapper struct remains local since it's only used there
- `CheckStatus` defaults to `Queued` which is a safe default for partial deserialization
- The `Unknown` variant ensures forward compatibility with any new conclusion values GitHub may add

Fixes #338