### PR TITLE
Fixes #382: CLI replacements for octocrab in github.rs

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -927,6 +927,10 @@ pub async fn edit_labels_via_cli(
     add: &[&str],
     remove: &[&str],
 ) -> Result<()> {
+    if add.is_empty() && remove.is_empty() {
+        return Ok(());
+    }
+
     let repo_full = format!("{}/{}", owner, repo);
     let mut args = vec![
         "issue".to_string(),
@@ -1044,6 +1048,10 @@ pub async fn check_auth_via_cli(host: &str) -> Result<()> {
 }
 
 /// Claim an issue by transitioning labels: remove gru:todo, add gru:in-progress.
+///
+/// Note: Unlike `GitHubClient::claim_issue`, this does not check whether the
+/// issue is already in-progress (race condition guard). Callers should add that
+/// check if needed.
 ///
 /// # Arguments
 /// * `host` - GitHub hostname


### PR DESCRIPTION
## Summary
- Simplify `gh_cli_command` to always use `"gh"` binary with `GH_HOST` env var for non-github.com hosts (instead of switching to `"ghe"` binary)
- Add `post_comment_via_cli` — wraps `gh issue comment`
- Add `edit_labels_via_cli` — wraps `gh issue edit` with `--add-label`/`--remove-label` in a single call
- Add `create_label_via_cli` — wraps `gh label create --force` for idempotent label creation
- Add `check_auth_via_cli` — wraps `gh auth status`
- Add state transition helpers: `claim_issue_via_cli`, `mark_issue_done_via_cli`, `mark_issue_failed_via_cli`, `mark_issue_blocked_via_cli` — all compose from `edit_labels_via_cli`
- `mark_issue_blocked_via_cli` removes in-progress, done, and failed labels to match octocrab behavior
- Unit tests for `gh_cli_command` verifying binary name and `GH_HOST` env var
- Integration tests (ignored) for CLI functions requiring auth

## Test plan
- `just check` passes (format, clippy, 745 tests, build)
- New unit tests verify `gh_cli_command` always uses `"gh"` and sets `GH_HOST` correctly
- Integration tests available via `cargo test cli_via -- --ignored` when `gh` auth is configured

## Notes
- All new functions are `#[allow(dead_code)]` — they will be activated in Phase 3 when octocrab `GitHubClient` is removed
- Existing `gh_command_for_host`/`gh_command_for_repo` (which return `"ghe"`) are left in place for callers outside `github.rs` (pr_monitor, ci, worktree_scanner, etc.) — those will be migrated separately
- Part of #373 (GHE host revamp), Phase 2 per `plans/GHE_HOST_REVAMP.md`

Fixes #382