### PR TITLE
Fixes #399: gru clean shows "branch merged" for worktrees with no commits

### DIFF
--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -387,7 +387,7 @@ pub async fn handle_clean(dry_run: bool, force: bool, base_branch: &str) -> Resu
         println!("Cleanable worktrees:\n");
         for (wt, status) in &cleanable {
             let reason = match status {
-                worktree_scanner::WorktreeStatus::Merged => "branch merged",
+                worktree_scanner::WorktreeStatus::Merged => "no unmerged commits",
                 worktree_scanner::WorktreeStatus::PrMerged => "PR merged",
                 worktree_scanner::WorktreeStatus::IssueClosed => "issue closed",
                 worktree_scanner::WorktreeStatus::RemoteDeleted => "remote deleted",

--- a/src/worktree_scanner.rs
+++ b/src/worktree_scanner.rs
@@ -22,7 +22,8 @@ pub struct Worktree {
 /// Status of a worktree indicating whether it can be cleaned
 #[derive(Debug, PartialEq)]
 pub enum WorktreeStatus {
-    /// Branch has been merged into the base branch
+    /// Branch has no unmerged commits relative to the base branch (either fully
+    /// merged or freshly created with no new commits yet)
     Merged,
     /// PR was merged on GitHub (e.g., squash merge where commit hashes differ)
     PrMerged,


### PR DESCRIPTION
## Summary
- Changed `gru clean` display label from `"branch merged"` to `"no unmerged commits"` for the `WorktreeStatus::Merged` case, which fires for both fully merged branches and freshly created branches with no new commits
- Updated the `WorktreeStatus::Merged` doc comment to clarify it covers both scenarios

## Test plan
- `just check` passes (fmt, clippy, tests, build)
- Manual verification: the label change is a string literal swap with no logic changes

## Notes
- No behavioral change — only the display label and doc comment are updated
- The worktree is still cleanable in both cases (correctly requires `--force` when dirty)

Fixes #399