### PR TITLE
Fixes #407: Ensure every worker/resume exit path sets Completed or Failed phase

### DIFF
--- a/src/commands/fix/mod.rs
+++ b/src/commands/fix/mod.rs
@@ -233,7 +233,10 @@ async fn run_worker(minion_id: &str, issue: &str, opts: FixOptions) -> Result<i3
                 .await;
                 return Ok(1);
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::Failed).await;
+                return Err(e);
+            }
         }
     } else {
         println!("⏭️  Skipping agent session (already completed)");
@@ -260,22 +263,41 @@ async fn run_worker(minion_id: &str, issue: &str, opts: FixOptions) -> Result<i3
     // Phase 4: Create PR
     let pr_number = if start_phase <= OrchestrationPhase::CreatingPr {
         update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::CreatingPr).await;
-        handle_pr_creation(&issue_ctx, &wt_ctx).await?
+        match handle_pr_creation(&issue_ctx, &wt_ctx).await {
+            Ok(pr) => pr,
+            Err(e) => {
+                update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::Failed).await;
+                return Err(e);
+            }
+        }
     } else {
         println!("⏭️  Skipping PR creation (already completed)");
         let minion_id_owned = wt_ctx.minion_id.clone();
-        let existing_pr = with_registry(move |registry| {
+        let existing_pr = match with_registry(move |registry| {
             Ok(registry
                 .get(&minion_id_owned)
                 .and_then(|info| info.pr.clone()))
         })
-        .await?;
+        .await
+        {
+            Ok(pr) => pr,
+            Err(e) => {
+                update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::Failed).await;
+                return Err(e);
+            }
+        };
 
         if existing_pr.is_some() {
             existing_pr
         } else {
             log::info!("ℹ️  PR not found in registry, retrying PR creation");
-            handle_pr_creation(&issue_ctx, &wt_ctx).await?
+            match handle_pr_creation(&issue_ctx, &wt_ctx).await {
+                Ok(pr) => pr,
+                Err(e) => {
+                    update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::Failed).await;
+                    return Err(e);
+                }
+            }
         }
     };
 
@@ -351,6 +373,7 @@ async fn run_worker(minion_id: &str, issue: &str, opts: FixOptions) -> Result<i3
         Ok(true) => log::info!("✅ CI checks passed"),
         Ok(false) => {
             log::warn!("⚠️  CI checks failed or were escalated");
+            update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::Failed).await;
             try_mark_issue_blocked(
                 &issue_ctx.host,
                 &issue_ctx.owner,

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -258,7 +258,10 @@ pub async fn handle_resume(
             log::error!("🚨 {:#}", e);
             return Ok(1);
         }
-        Err(e) => return Err(e),
+        Err(e) => {
+            update_orchestration_phase(&minion.minion_id, OrchestrationPhase::Failed).await;
+            return Err(e);
+        }
     }
 
     // Phase: Create PR (handle_pr_creation checks if branch was pushed internally)
@@ -355,6 +358,7 @@ pub async fn handle_resume(
             Ok(true) => log::info!("✅ CI checks passed"),
             Ok(false) => {
                 log::warn!("⚠️  CI checks failed or were escalated");
+                update_orchestration_phase(&minion.minion_id, OrchestrationPhase::Failed).await;
                 try_mark_issue_blocked(
                     &issue_ctx.host,
                     &issue_ctx.owner,


### PR DESCRIPTION
## Summary
- Set orchestration phase to `Failed` before every early return in `run_worker` (fix/mod.rs) and `handle_resume` (resume.rs) that previously left the phase stuck in an active state (`RunningAgent`, `CreatingPr`, `MonitoringPr`)
- Fixed CI failure `Ok(false)` paths in both files — these were the primary cause of the resume loop bug
- Fixed agent error `Err(e)` propagation paths in both files to set `Failed` before returning
- Fixed PR creation error paths in fix/mod.rs (both the primary path and the fallback retry path)

## Test plan
- `just check` passes (fmt, clippy, 785 tests, build)
- Audited all exit paths in `run_worker` and `handle_resume` to confirm no active phase can leak

## Notes
- The CI monitoring `Err(e)` case remains non-fatal — it falls through to `Completed` since a monitoring error doesn't mean the work itself failed
- `monitor_pr_lifecycle()` still returns `()` — a future improvement could have it return a status, but that's a larger refactor outside the scope of this fix
- Blocks #406 (resume loop bug)

Fixes #407