### PR TITLE
Fixes #420: Resume silently swallows PR creation failure instead of setting Failed phase

### DIFF
--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -270,8 +270,8 @@ pub async fn handle_resume(
     let pr_number = match handle_pr_creation(&issue_ctx, &wt_ctx).await {
         Ok(pr) => pr,
         Err(e) => {
-            log::warn!("⚠️  PR creation failed: {}", e);
-            None
+            update_orchestration_phase(&minion.minion_id, OrchestrationPhase::Failed).await;
+            return Err(e);
         }
     };
 


### PR DESCRIPTION
## Summary
- PR creation failure in `resume.rs` now sets `OrchestrationPhase::Failed` and returns the error, matching `fix/mod.rs` behavior
- Previously, the error was logged as a warning and execution continued with `pr_number = None`, eventually reaching `Completed` phase despite the failure

## Test plan
- `just check` passes (fmt, clippy, 784 tests, build)
- Change is a 2-line diff: replaces `log::warn` + `None` fallback with `update_orchestration_phase(Failed)` + `return Err(e)`

## Notes
- The fix aligns `resume.rs:270-276` with the equivalent error handling in `fix/mod.rs:266-272`
- Found during review of #407, pre-existing behavior

Fixes #420