### PR TITLE
Fixes #414: Document multi-agent support in README and user docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ gru do 42 --timeout 30m
 gru do 42 --agent codex
 ```
 
-**`gru review <pr>`** - Review a GitHub pull request using Claude CLI
+**`gru review <pr>`** - Review a GitHub pull request using the configured agent backend
 
 ```bash
 gru review 42
@@ -92,8 +92,8 @@ binary = "/usr/local/bin/claude"   # Optional: override binary path
 `gru status` shows which agent each Minion is using:
 
 ```
-ID       AGENT    REPO                 ISSUE  TASK       PR       BRANCH                         MODE                   UPTIME   TOKENS
-M001     claude-code owner/repo           #42    do         #43      minion/issue-42-M001           monitoring (PR ready)  5m       1.2M
+MINION   AGENT    REPO                 ISSUE  TASK       PR       BRANCH                         MODE                   UPTIME   TOKENS
+M001     claude   owner/repo           #42    do         #43      minion/issue-42-M001           monitoring (PR ready)  5m       1.2M
 M002     codex    owner/repo           #44    do         -        minion/issue-44-M002           working                2m       -
 ```
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -40,11 +40,11 @@ binary = "/usr/local/bin/claude"
 Gru spawns Claude Code in non-interactive mode with stream JSON output:
 
 ```bash
-claude --print --verbose --output-format stream-json --dangerously-skip-permissions --include-partial-messages "<prompt>"
+claude --print --verbose --session-id <uuid> --output-format stream-json --dangerously-skip-permissions --include-partial-messages "<prompt>"
 ```
 
 Key flags:
-- `--print` — non-interactive (no TTY)
+- `--print` — non-interactive (prints to stdout and exits)
 - `--verbose` — include tool calls in output
 - `--output-format stream-json` — real-time event stream
 - `--dangerously-skip-permissions` — autonomous operation
@@ -89,7 +89,7 @@ Resume support uses:
 codex exec resume --last --json --full-auto "<prompt>"
 ```
 
-Note: Codex does not support interactive resume (`gru attach` will not work with Codex minions).
+Note: Codex does not support interactive resume (`gru attach` will not work with Codex minions). Codex also ignores the `session_id` parameter — it relies on its own session persistence for both new and resumed sessions.
 
 ## Selecting a Backend
 


### PR DESCRIPTION
## Summary
- Updated README.md to mention multi-agent support, the `--agent` flag, and available backends (Claude Code, Codex)
- Added `--agent codex` example to the `gru do` usage section
- Added "Agent Backends" section to README with config.toml examples and `gru status` output showing the agent column
- Created `docs/AGENTS.md` with install/auth/verify instructions for each backend, feature comparison table, and guide for adding new backends

## Test plan
- `just check` passes (format, lint, 798 tests, build)
- Verified documented CLI flags match `src/main.rs` (`--agent` on do, review, prompt)
- Verified config.toml `[agent]` section matches `src/config.rs` (`AgentConfig`, `ClaudeAgentConfig`)
- Verified available agents match `src/agent_registry.rs` (claude, codex)

## Notes
- This is documentation-only; no code changes
- Codex CLI commands documented from `src/codex_backend.rs` (`codex exec --json --full-auto`)
- Feature comparison table notes that Codex doesn't support interactive attach (verified in `codex_backend.rs` where `build_interactive_resume_command` returns `None`)

Fixes #414