### PR TITLE
Fixes #432: Bug: Lab daemon logs resume-skip warnings every poll cycle for already-resumed minions

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -382,7 +382,23 @@ async fn resume_interrupted_minions(
         return Ok(0);
     }
 
-    let resumable = find_resumable_minions(config).await?;
+    let resumable: Vec<_> = find_resumable_minions(config)
+        .await?
+        .into_iter()
+        .filter(|c| {
+            if resumed_this_session.contains(&c.minion_id) {
+                log::debug!(
+                    "Skipping {} (issue #{}, {}): already resumed this session",
+                    c.minion_id,
+                    c.info.issue,
+                    c.info.repo,
+                );
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
     if resumable.is_empty() {
         return Ok(0);
     }
@@ -397,17 +413,6 @@ async fn resume_interrupted_minions(
     for candidate in resumable {
         if *available == 0 {
             break;
-        }
-
-        // Skip minions already attempted this session (defense-in-depth against resume loops)
-        if resumed_this_session.contains(&candidate.minion_id) {
-            log::warn!(
-                "⏭️  Skipping {} (issue #{}, {}): already resumed this session",
-                candidate.minion_id,
-                candidate.info.issue,
-                candidate.info.repo,
-            );
-            continue;
         }
 
         let host = match host_for_repo(config, &candidate.info.repo) {


### PR DESCRIPTION
## Summary
- Filter already-resumed minions **before** printing the "Found N resumable" count, so the message only appears when there are genuinely new candidates
- Demote the skip log from `warn` to `debug` level to eliminate noisy repeated output every poll cycle
- When all resumable candidates have already been attempted, no output is printed at all

## Test plan
- `just check` passes (format, lint, 798 tests, build)
- Manual verification: the filter now runs before the count print and the `is_empty()` early return

## Notes
- The `resumed_this_session.insert()` remains inside the for-loop (only marks minions after actual attempt), which is correct by design — the filter prevents re-attempting on subsequent polls

Fixes #432