### PR TITLE
Fixes #435: Bug: Lab daemon resumes minions for already-merged PRs

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -415,6 +415,44 @@ async fn resume_interrupted_minions(
             None => continue, // repo no longer in config
         };
 
+        // Skip minions whose issue is already closed (PR merged or issue resolved)
+        let (owner, repo_name) = match candidate.info.repo.split_once('/') {
+            Some(parts) => parts,
+            None => continue,
+        };
+        match github::is_issue_closed_via_cli(owner, repo_name, &host, candidate.info.issue).await {
+            Ok(true) => {
+                println!(
+                    "⏭️  Skipping {} (issue #{}, {}): issue is closed",
+                    candidate.minion_id, candidate.info.issue, candidate.info.repo,
+                );
+                // Mark as Completed in the registry
+                let mid = candidate.minion_id.clone();
+                if let Err(e) = with_registry(move |reg| {
+                    reg.update(&mid, |info| {
+                        info.orchestration_phase = OrchestrationPhase::Completed;
+                    })
+                })
+                .await
+                {
+                    log::warn!("Failed to mark {} as completed: {}", candidate.minion_id, e);
+                }
+                continue;
+            }
+            Ok(false) => {} // Issue is still open, proceed with resume
+            Err(e) => {
+                // Transient failure (network, auth, etc.) — skip this cycle;
+                // the candidate stays active so it will be retried next poll.
+                log::warn!(
+                    "⚠️  Failed to check issue state for {} (issue #{}): {} — will retry next poll",
+                    candidate.minion_id,
+                    candidate.info.issue,
+                    e,
+                );
+                continue;
+            }
+        }
+
         // Skip minions whose timeout_deadline has passed
         if let Some(deadline) = candidate.info.timeout_deadline {
             if Utc::now() >= deadline {

--- a/src/github.rs
+++ b/src/github.rs
@@ -217,6 +217,48 @@ pub async fn get_issue_via_cli(
     Ok(issue)
 }
 
+/// Check if a GitHub issue is closed (or has a merged/closed PR).
+///
+/// Returns `true` if the issue state is `CLOSED` (the GraphQL enum value
+/// returned by `gh issue view --json state`).
+pub async fn is_issue_closed_via_cli(
+    owner: &str,
+    repo: &str,
+    host: &str,
+    number: u64,
+) -> Result<bool> {
+    let repo_full = format!("{}/{}", owner, repo);
+    let output = gh_cli_command(host)
+        .args([
+            "issue",
+            "view",
+            &number.to_string(),
+            "--repo",
+            &repo_full,
+            "--json",
+            "state",
+            "--jq",
+            ".state",
+        ])
+        .output()
+        .await
+        .context("Failed to execute gh issue view command")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "Failed to fetch issue #{} state from {}/{}: {}",
+            number,
+            owner,
+            repo,
+            stderr
+        ));
+    }
+
+    let state = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(state == "CLOSED")
+}
+
 /// Simple struct to hold issue information from gh CLI
 #[derive(Debug, serde::Deserialize)]
 pub struct IssueInfo {


### PR DESCRIPTION
## Summary
- Add `is_issue_closed_via_cli()` to `github.rs` that checks if a GitHub issue is closed using `gh issue view --json state --jq .state`
- In `resume_interrupted_minions()`, check each candidate's issue state before resuming — if closed, mark the minion as `Completed` and skip it
- On transient API failures, skip the candidate for this poll cycle and retry next time (no permanent state change)

## Test plan
- `just check` passes (format, lint, 804 tests, build)
- Manual verification: the new code path is exercised when `find_resumable_minions()` returns candidates whose issues are already closed on GitHub

## Notes
- Uses `--jq .state` approach consistent with `worktree_scanner.rs::check_issue_closed()`
- The `gh` CLI returns uppercase GraphQL enum values (`CLOSED`, `OPEN`)
- Future follow-up: consolidate `worktree_scanner::check_issue_closed()` to delegate to the new `github::is_issue_closed_via_cli()`

Fixes #435