### PR TITLE
Fixes #456: Lab-spawned minions rename wrong tmux windows

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -909,10 +909,13 @@ async fn spawn_minion(repo: &str, host: &str, issue_number: u64) -> Result<Child
     let stderr_file = log_file;
 
     // Spawn `gru do <issue>` as a background process with output captured to log file.
-    // Use setsid to give the child its own process group so it survives lab shutdown.
+    // Remove TMUX/TMUX_PANE so the child doesn't inherit the lab's tmux session —
+    // otherwise TmuxGuard renames arbitrary windows in the parent's tmux.
     let mut cmd = tokio::process::Command::new(exe);
     cmd.arg("do")
         .arg(&issue_ref)
+        .env_remove("TMUX")
+        .env_remove("TMUX_PANE")
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout_file))
         .stderr(Stdio::from(stderr_file));


### PR DESCRIPTION
## Summary
- Strip `TMUX` and `TMUX_PANE` environment variables from child processes spawned by `spawn_minion()` in `lab.rs`
- Prevents background minions from inheriting the lab's tmux session and renaming arbitrary windows via `TmuxGuard`

## Test plan
- `just check` passes (format, lint, 799 tests, build)
- Manual: run `gru lab` in a tmux pane with other windows open; spawned minions should no longer rename unrelated windows

## Notes
- The fix is in `spawn_minion()` which is used by both new issue spawns and `resume_interrupted_minions()`, so both paths are covered
- `TmuxGuard::new()` becomes a no-op when `$TMUX` is unset, so no other code paths are affected

Fixes #456