### PR TITLE
Fixes #465: gru status silently deletes registry entries (destructive read)

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -200,28 +200,9 @@ pub async fn handle_status(id: Option<String>, verbose: bool) -> Result<i32> {
         basic_minions
             .into_iter()
             .map(|basic| {
-                if basic.is_stale {
-                    // Stale entry: worktree doesn't exist, skip git operations
-                    let uptime = calculate_uptime(basic.started_at);
-                    EnhancedMinionInfo {
-                        minion_id: basic.minion_id,
-                        repo: basic.repo,
-                        issue: basic.issue,
-                        task: basic.task,
-                        pr: basic.pr,
-                        branch: basic.branch,
-                        is_running: false,
-                        mode_display: "stale".to_string(),
-                        uptime,
-                        token_usage: basic.token_usage,
-                        session_id: basic.session_id,
-                        pid: None,
-                        worktree_path: basic.worktree.display().to_string(),
-                        agent_name: basic.agent_name,
-                        is_stale: true,
-                    }
-                } else if !basic.worktree.exists() {
-                    // Worktree removed between Phase 1 and Phase 2 (race condition)
+                if basic.is_stale || !basic.worktree.exists() {
+                    // Stale entry: worktree doesn't exist (detected in Phase 1,
+                    // or removed between Phase 1 and Phase 2). Skip git operations.
                     let uptime = calculate_uptime(basic.started_at);
                     EnhancedMinionInfo {
                         minion_id: basic.minion_id,


### PR DESCRIPTION
## Summary
- Remove destructive registry entry deletion from `gru status` — it was silently removing entries for minions whose worktree directories no longer existed on disk
- Stale entries are now displayed with a `"stale"` mode indicator and sorted to the bottom of the table
- Footer shows stale count with a hint to run `gru clean` for cleanup
- `gru clean` already handles stale worktree cleanup (orphan detection + registry removal)

## Test plan
- `just check` passes (fmt, clippy, 805 tests, build)
- Pre-commit hooks pass on both commits
- Manual verification: stale entries would appear with "stale" mode instead of being silently deleted

## Notes
- The code reviewer noted a pre-existing gap in `gru clean` where orphan detection compares `checkout_path()` against `discovered_paths` from `git worktree list`, which may not catch all cases where `minion_dir` was deleted with `rm -rf`. This is a separate issue from the fix here (which correctly stops `status` from being destructive).

Fixes #465