### PR TITLE
Fixes #466: Self-reviews structurally cannot satisfy merge-readiness gate

### DIFF
--- a/src/merge_readiness.rs
+++ b/src/merge_readiness.rs
@@ -29,7 +29,7 @@ pub struct MergeReadiness {
     pub not_draft: bool,
     /// All CI check runs passed (success, skipped, or neutral), none pending/in-progress.
     pub ci_passing: bool,
-    /// Review gate satisfied: at least one external APPROVED review with no outstanding
+    /// Review gate satisfied: at least one APPROVED review with no outstanding
     /// CHANGES_REQUESTED, or the PR author left a self-review comment (GitHub prevents
     /// self-approval) and no reviewer has blocked.
     pub review_approved: bool,


### PR DESCRIPTION
## Summary
- Fix structurally unsatisfiable merge-readiness gate for self-reviewed PRs
- `evaluate_reviews` now accepts the PR author login and treats author COMMENTED reviews as satisfying the review gate (GitHub prevents self-approval, so COMMENTED is the best a self-reviewer can produce)
- External CHANGES_REQUESTED still blocks merge-readiness as before
- Added 4 new tests covering self-review scenarios (satisfies gate, blocked by changes requested, non-author comment doesn't satisfy, combined with external approval)

## Test plan
- `just check` passes (fmt, lint, 809 tests, build)
- New tests: `test_reviews_self_review_comment_satisfies_gate`, `test_reviews_self_review_comment_blocked_by_changes_requested`, `test_reviews_non_author_comment_does_not_satisfy_gate`, `test_reviews_self_review_with_external_approval`
- All 42 existing merge_readiness tests continue to pass

## Notes
- Only `src/merge_readiness.rs` was modified — the PR API response already includes the `user` field, we just weren't deserializing it
- The self-review exception only applies when the PR author's login matches the COMMENTED reviewer; non-author COMMENTED reviews still don't satisfy the gate

Fixes #466