### PR TITLE
Fixes #474: Issue dependency checking: GHES hardening and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,8 +253,9 @@ Located in `.claude/skills/`:
   - Use `#` prefix for issue numbers (bare numbers are ignored)
   - Cross-repo references (`owner/repo#123`) are skipped with a warning
   - Example: `**Blocked by:** #10, #20, #30`
-- **Two-layer checking:** Body parsing (free) runs first, then the native GitHub dependencies API verifies
+- **Two-layer checking:** The native GitHub dependencies API is called first; body parsing is the fallback when the API is unavailable
 - **Native API resolution:** API result is authoritative when available (200). Body text is sole source on 404 (GHES)
+- **Mutually exclusive:** When the API returns a result (even an empty list), it is the sole source of truth — body-text blockers are not merged in. Body parsing is only used when the API is unavailable
 - **GHES compatibility:** When the native dependencies API returns 404, Gru falls back to body-text parsing only. No functionality is lost — body-text deps work identically
 - **Error handling:** 403/500/502/503 errors are logged as warnings and cause fallback to body parsing (same as 404). If body has blockers, they are respected. If body has no blockers, the issue is treated as unblocked
 - **`gru do` behavior:** Warns about open blockers but proceeds (user explicitly chose the issue). Use `--ignore-deps` to suppress

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -419,11 +419,31 @@ mod tests {
 
     #[test]
     fn test_server_error_falls_back_to_body_parsing() {
-        // On 403/500/502/503, API returns Unavailable (None), so body parsing
-        // is used as fallback — same behavior as GHES 404.
-        // If body has blockers, they ARE respected (not silently ignored).
+        // Exercise parse_api_output for each error code, then verify resolve_blockers
+        // uses body parsing as fallback when the API is unavailable.
         let body = "**Blocked by:** #10";
-        let blockers = resolve_blockers(body, None);
-        assert_eq!(blockers, vec![10]);
+        for (stderr, code) in [
+            ("HTTP 403: Forbidden", 42),
+            ("HTTP 500: Internal Server Error", 42),
+            ("HTTP 502: Bad Gateway", 42),
+            ("HTTP 503: Service Unavailable", 42),
+        ] {
+            let api_result = parse_api_output(false, "", stderr, code);
+            assert_eq!(
+                api_result,
+                ApiResult::Unavailable,
+                "Expected Unavailable for {stderr}"
+            );
+            let api_blockers = match api_result {
+                ApiResult::Supported(v) => Some(v),
+                ApiResult::Unavailable => None,
+            };
+            let blockers = resolve_blockers(body, api_blockers);
+            assert_eq!(
+                blockers,
+                vec![10],
+                "Body blockers should be respected on {stderr}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Extract `resolve_blockers()` pure function from `get_blockers()` for testable resolution logic
- Add 14 new tests covering GHES fallback scenarios, resolution policy enforcement, and error code differentiation (404 vs 403/500)
- Document `**Blocked by:** #X, #Y` convention and GHES compatibility in CLAUDE.md
- Document `gru:waiting` label deferral decision (not rejected, deferred pending user feedback)

## Test plan
- `just check` passes (867 tests, lint clean, build succeeds)
- New tests verify:
  - GHES 404 fallback: API unavailable → body parsing used as sole source
  - Resolution policy: API result is authoritative when available, body text is fallback
  - Sources never combined (API and body results are mutually exclusive)
  - Error differentiation: 404 (GHES/expected) vs 403/500/502/503 (transient errors)
  - End-to-end scenarios: blocked issue detected via body on GHES, unblocked issue passes through

## Notes
- The `resolve_blockers()` extraction makes the resolution policy testable without async/process mocking
- All acceptance criteria from #474 are addressed:
  - 404 → returns Unavailable (falls back to body parsing) with debug log
  - Body parsing works standalone for GHES environments
  - 403/500 logged as warnings, issue treated as unblocked
  - Documentation added for body-text convention
  - `gru:waiting` deferral decision documented

Fixes #474