### PR TITLE
Fixes #467: gru:blocked label never removed after CI recovery

### DIFF
--- a/src/commands/fix/helpers.rs
+++ b/src/commands/fix/helpers.rs
@@ -34,12 +34,19 @@ pub(crate) async fn try_mark_issue_blocked(host: &str, owner: &str, repo: &str, 
     }
 }
 
-/// Attempts to unblock an issue via CLI (fire-and-forget).
-/// Removes gru:blocked and restores gru:in-progress.
-pub(crate) async fn try_unblock_issue(host: &str, owner: &str, repo: &str, issue_num: u64) {
-    match crate::github::unblock_issue_via_cli(host, owner, repo, issue_num).await {
+/// Removes `gru:blocked` from the PR and restores `gru:in-progress` on the issue.
+/// Fire-and-forget: logs on failure but does not propagate errors.
+/// Idempotent: safe to call even if the label is not present.
+pub(crate) async fn try_remove_blocked_label(
+    host: &str,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    issue_num: u64,
+) {
+    match crate::github::remove_blocked_label(host, owner, repo, pr_number, issue_num).await {
         Ok(()) => {
-            println!("🏷️  Removed '{}' label from issue", crate::labels::BLOCKED);
+            println!("🏷️  Removed '{}' label", crate::labels::BLOCKED);
         }
         Err(e) => {
             log::warn!("⚠️  Failed to remove blocked label: {}", e);

--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -315,14 +315,18 @@ pub(crate) async fn monitor_pr_lifecycle(
             Ok((MonitorResult::ReadyToMerge, _)) => {
                 // All merge gates pass — remove gru:blocked if it was stale
                 if issue_was_blocked {
-                    super::helpers::try_unblock_issue(
-                        &issue_ctx.host,
-                        &issue_ctx.owner,
-                        &issue_ctx.repo,
-                        issue_ctx.issue_num,
-                    )
-                    .await;
+                    if let Ok(pr_num) = pr_number.parse::<u64>() {
+                        super::helpers::try_remove_blocked_label(
+                            &issue_ctx.host,
+                            &issue_ctx.owner,
+                            &issue_ctx.repo,
+                            pr_num,
+                            issue_ctx.issue_num,
+                        )
+                        .await;
+                    }
                     issue_was_blocked = false;
+                    ci_escalated = false;
                 }
 
                 // Lazily ensure the gru:needs-human-review label exists on
@@ -563,10 +567,11 @@ pub(crate) async fn monitor_pr_lifecycle(
                         println!("✅ CI checks now pass after auto-fix");
                         // Remove gru:blocked label if it was added during escalation
                         if issue_was_blocked {
-                            super::helpers::try_unblock_issue(
+                            super::helpers::try_remove_blocked_label(
                                 &issue_ctx.host,
                                 &issue_ctx.owner,
                                 &issue_ctx.repo,
+                                pr_num_u64,
                                 issue_ctx.issue_num,
                             )
                             .await;

--- a/src/github.rs
+++ b/src/github.rs
@@ -719,26 +719,57 @@ pub async fn mark_issue_failed_via_cli(
     .await
 }
 
-/// Unblock an issue: remove gru:blocked, restore gru:in-progress.
+/// Remove `gru:blocked` label from a PR and restore `gru:in-progress` on the issue.
 ///
-/// Called after a previously-blocked issue recovers (e.g., CI passes after
-/// auto-fix or external action).
+/// The CI escalation path adds `gru:blocked` to the **PR** via `gh pr edit`,
+/// so removal must also target the PR. The issue gets `gru:in-progress`
+/// restored since `mark_issue_blocked_via_cli` removed it.
 ///
-/// # Arguments
-/// * `host` - GitHub hostname
-/// * `owner` - Repository owner
-/// * `repo` - Repository name
-/// * `number` - Issue number
-pub async fn unblock_issue_via_cli(host: &str, owner: &str, repo: &str, number: u64) -> Result<()> {
-    edit_labels_via_cli(
+/// Idempotent: silently succeeds if the label is not present.
+pub async fn remove_blocked_label(
+    host: &str,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    issue_number: u64,
+) -> Result<()> {
+    let repo_full = format!("{}/{}", owner, repo);
+
+    // Remove gru:blocked from the PR (where ci.rs adds it)
+    let output = gh_cli_command(host)
+        .args([
+            "pr",
+            "edit",
+            &pr_number.to_string(),
+            "--repo",
+            &repo_full,
+            "--remove-label",
+            labels::BLOCKED,
+        ])
+        .output()
+        .await
+        .context("Failed to remove blocked label from PR")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Ignore "not found" errors — label may not be present
+        if !stderr.contains("404") && !stderr.contains("not found") {
+            anyhow::bail!("Failed to remove blocked label from PR: {}", stderr);
+        }
+    }
+
+    // Restore gru:in-progress on the issue (blocking removed it)
+    let _ = edit_labels_via_cli(
         host,
         owner,
         repo,
-        number,
+        issue_number,
         &[labels::IN_PROGRESS],
         &[labels::BLOCKED],
     )
-    .await
+    .await;
+
+    Ok(())
 }
 
 /// Mark an issue as blocked: add gru:blocked, remove in-progress/done/failed.


### PR DESCRIPTION
## Summary
- Add `unblock_issue_via_cli` to `github.rs` that removes `gru:blocked` and restores `gru:in-progress`
- Add `try_unblock_issue` fire-and-forget helper in `helpers.rs`
- Remove `gru:blocked` label after CI auto-fix succeeds (`monitor_and_fix_ci` returns `Ok(true)`)
- Remove `gru:blocked` label when merge-readiness check returns `ReadyToMerge` (all gates pass)
- Track `issue_was_blocked` flag to avoid unnecessary API calls on every poll cycle
- Reset `ci_escalated` on CI recovery so subsequent failures get another auto-fix attempt

## Test plan
- All 828 existing tests pass
- `just check` passes (format + lint + test + build)
- Manual verification: the `gru:blocked` label is only removed when the tracking flag indicates a prior block occurred, avoiding spurious API calls

## Notes
- The `gru:blocked` label is added by `ci::post_escalation_comment_body` inside `monitor_and_fix_ci` when CI fix attempts are exhausted
- The rebase escalation path in `monitor.rs` does not add `gru:blocked` (only posts a comment), so `issue_was_blocked` is only set on the CI escalation path
- `edit_labels_via_cli` errors when removing a label that isn't present, so the tracking flag prevents noisy warnings in the logs

Fixes #467