### PR TITLE
Fixes #493: Duplicate self-reviews posted on every monitor_pr_lifecycle entry

### DIFF
--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -5,6 +5,7 @@ use crate::ci;
 use crate::config::LabConfig;
 use crate::merge_judge::{self, JudgeAction, JudgeState};
 use crate::pr_monitor::{self, MonitorResult};
+use crate::pr_state::PrState;
 use anyhow::{Context, Result};
 use std::path::Path;
 use tokio::process::Command as TokioCommand;
@@ -212,22 +213,59 @@ pub(crate) async fn monitor_pr_lifecycle(
     // during the review are not missed when the monitoring loop starts.
     let pre_review_time = chrono::Utc::now();
 
-    // Auto-trigger review for Minion-created PRs
-    println!("\n🔍 Starting automated PR review...");
-    match trigger_pr_review(pr_number, &wt_ctx.checkout_path, review_timeout).await {
-        Ok(review_exit_code) => {
-            if review_exit_code == 0 {
-                println!("✅ PR review completed successfully");
-            } else {
-                log::warn!(
-                    "⚠️  PR review completed with exit code: {}",
-                    review_exit_code
-                );
+    // Guard: skip self-review if we already posted one for the current HEAD SHA.
+    // This prevents duplicate reviews when monitor_pr_lifecycle is re-entered
+    // (e.g., on lab daemon resume or run_worker restart).
+    let head_sha = ci::get_head_sha(&wt_ctx.checkout_path).await.ok();
+    let already_reviewed = head_sha.as_deref().is_some_and(|sha| {
+        PrState::load(&wt_ctx.minion_dir)
+            .ok()
+            .flatten()
+            .and_then(|s| s.self_review_sha)
+            .as_deref()
+            == Some(sha)
+    });
+
+    if already_reviewed {
+        println!(
+            "\n⏭️  Skipping self-review: already posted for current HEAD ({})",
+            head_sha.as_deref().unwrap_or("unknown")
+        );
+    } else {
+        // Auto-trigger review for Minion-created PRs
+        println!("\n🔍 Starting automated PR review...");
+        match trigger_pr_review(pr_number, &wt_ctx.checkout_path, review_timeout).await {
+            Ok(review_exit_code) => {
+                if review_exit_code == 0 {
+                    println!("✅ PR review completed successfully");
+                    // Record the HEAD SHA so we don't re-post on next entry.
+                    if let Some(ref sha) = head_sha {
+                        match PrState::load(&wt_ctx.minion_dir) {
+                            Ok(Some(mut state)) => {
+                                state.self_review_sha = Some(sha.clone());
+                                if let Err(e) = state.save(&wt_ctx.minion_dir) {
+                                    log::warn!("⚠️  Failed to save self_review_sha: {}", e);
+                                }
+                            }
+                            Ok(None) => {
+                                log::warn!("⚠️  No PR state found to record self_review_sha");
+                            }
+                            Err(e) => {
+                                log::warn!("⚠️  Failed to load PR state: {}", e);
+                            }
+                        }
+                    }
+                } else {
+                    log::warn!(
+                        "⚠️  PR review completed with exit code: {}",
+                        review_exit_code
+                    );
+                }
             }
-        }
-        Err(e) => {
-            log::warn!("⚠️  Failed to run PR review: {}", e);
-            log::warn!("   You can review manually with: gru review {}", pr_number);
+            Err(e) => {
+                log::warn!("⚠️  Failed to run PR review: {}", e);
+                log::warn!("   You can review manually with: gru review {}", pr_number);
+            }
         }
     }
 

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -100,6 +100,7 @@ pub async fn handle_resume(
     let timeout_deadline: Option<DateTime<Utc>> = info.timeout_deadline;
     let attempt_count = info.attempt_count;
     let no_watch = info.no_watch;
+    let start_phase = info.orchestration_phase.clone();
 
     // Check if timeout_deadline has passed — fail instead of resuming
     if let Some(deadline) = timeout_deadline {
@@ -221,77 +222,94 @@ pub async fn handle_resume(
         details: None,
     };
 
-    update_orchestration_phase(&minion.minion_id, OrchestrationPhase::RunningAgent).await;
+    // Phase: Run agent (skip if already past this phase)
+    if start_phase <= OrchestrationPhase::RunningAgent {
+        update_orchestration_phase(&minion.minion_id, OrchestrationPhase::RunningAgent).await;
 
-    // Run agent in autonomous mode with stream monitoring
-    let claude_result = run_autonomous_agent(
-        &*backend,
-        &wt_ctx,
-        &prompt,
-        quiet,
-        effective_timeout.as_deref(),
-        issue_num,
-        &issue_ctx.host,
-    )
-    .await;
+        let claude_result = run_autonomous_agent(
+            &*backend,
+            &wt_ctx,
+            &prompt,
+            quiet,
+            effective_timeout.as_deref(),
+            issue_num,
+            &issue_ctx.host,
+        )
+        .await;
 
-    match claude_result {
-        Ok(status) => {
-            if !status.success() {
+        match claude_result {
+            Ok(status) => {
+                if !status.success() {
+                    update_orchestration_phase(&minion.minion_id, OrchestrationPhase::Failed).await;
+                    try_mark_issue_failed(
+                        &issue_ctx.host,
+                        &issue_ctx.owner,
+                        &issue_ctx.repo,
+                        issue_ctx.issue_num,
+                    )
+                    .await;
+                    println!("❌ Claude session exited with non-zero status");
+                    return Ok(status.code().unwrap_or(EXIT_CODE_SIGNAL_TERMINATED));
+                }
+            }
+            Err(e) if is_stuck_or_timeout_error(&e) => {
                 update_orchestration_phase(&minion.minion_id, OrchestrationPhase::Failed).await;
-                try_mark_issue_failed(
+                try_mark_issue_blocked(
                     &issue_ctx.host,
                     &issue_ctx.owner,
                     &issue_ctx.repo,
                     issue_ctx.issue_num,
                 )
                 .await;
-                println!("❌ Claude session exited with non-zero status");
-                return Ok(status.code().unwrap_or(EXIT_CODE_SIGNAL_TERMINATED));
+                log::error!("🚨 {:#}", e);
+                return Ok(1);
+            }
+            Err(e) => {
+                update_orchestration_phase(&minion.minion_id, OrchestrationPhase::Failed).await;
+                return Err(e);
             }
         }
-        Err(e) if is_stuck_or_timeout_error(&e) => {
-            update_orchestration_phase(&minion.minion_id, OrchestrationPhase::Failed).await;
-            try_mark_issue_blocked(
-                &issue_ctx.host,
-                &issue_ctx.owner,
-                &issue_ctx.repo,
-                issue_ctx.issue_num,
-            )
-            .await;
-            log::error!("🚨 {:#}", e);
-            return Ok(1);
-        }
-        Err(e) => {
-            update_orchestration_phase(&minion.minion_id, OrchestrationPhase::Failed).await;
-            return Err(e);
-        }
+    } else {
+        println!("⏭️  Skipping agent session (already completed)");
     }
 
-    // Phase: Create PR (handle_pr_creation checks if branch was pushed internally)
-    update_orchestration_phase(&minion.minion_id, OrchestrationPhase::CreatingPr).await;
+    // Phase: Create PR (skip if already past this phase)
+    let pr_number = if start_phase <= OrchestrationPhase::CreatingPr {
+        update_orchestration_phase(&minion.minion_id, OrchestrationPhase::CreatingPr).await;
 
-    let pr_number = match handle_pr_creation(&issue_ctx, &wt_ctx).await {
-        Ok(pr) => pr,
-        Err(e) => {
-            update_orchestration_phase(&minion.minion_id, OrchestrationPhase::Failed).await;
-            return Err(e);
-        }
-    };
+        let pr_number = match handle_pr_creation(&issue_ctx, &wt_ctx).await {
+            Ok(pr) => pr,
+            Err(e) => {
+                update_orchestration_phase(&minion.minion_id, OrchestrationPhase::Failed).await;
+                return Err(e);
+            }
+        };
 
-    // If handle_pr_creation didn't return a PR number, check the registry
-    // (the PR may have been created in a previous session)
-    let pr_number = match pr_number {
-        Some(pr) => Some(pr),
-        None => {
-            let mid = minion.minion_id.clone();
-            with_registry(move |registry| Ok(registry.get(&mid).and_then(|info| info.pr.clone())))
+        // If handle_pr_creation didn't return a PR number, check the registry
+        // (the PR may have been created in a previous session)
+        match pr_number {
+            Some(pr) => Some(pr),
+            None => {
+                let mid = minion.minion_id.clone();
+                with_registry(move |registry| {
+                    Ok(registry.get(&mid).and_then(|info| info.pr.clone()))
+                })
                 .await
                 .unwrap_or_else(|e| {
                     log::warn!("Failed to look up PR number from registry: {}", e);
                     None
                 })
+            }
         }
+    } else {
+        println!("⏭️  Skipping PR creation (already completed)");
+        let mid = minion.minion_id.clone();
+        with_registry(move |registry| Ok(registry.get(&mid).and_then(|info| info.pr.clone())))
+            .await
+            .unwrap_or_else(|e| {
+                log::warn!("Failed to look up PR number from registry: {}", e);
+                None
+            })
     };
 
     // Last resort: discover PR by head branch (handles manual PR creation or missing registry state)

--- a/src/pr_state.rs
+++ b/src/pr_state.rs
@@ -12,6 +12,11 @@ pub struct PrState {
     pub issue_number: String,
     /// Current status of the PR
     pub status: PrStatus,
+    /// HEAD SHA at which the last successful self-review was posted.
+    /// Used to prevent duplicate reviews when monitor_pr_lifecycle is re-entered.
+    /// None means no self-review has been posted yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_review_sha: Option<String>,
 }
 
 /// Status of a pull request
@@ -31,6 +36,7 @@ impl PrState {
             pr_number,
             issue_number,
             status: PrStatus::Draft,
+            self_review_sha: None,
         }
     }
 
@@ -170,5 +176,28 @@ mod tests {
         assert_eq!(deserialized.pr_number, "42");
         assert_eq!(deserialized.issue_number, "15");
         assert_eq!(deserialized.status, PrStatus::Draft);
+    }
+
+    #[test]
+    fn test_pr_state_self_review_sha_round_trip() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let mut state = PrState::new("42".to_string(), "15".to_string());
+        assert!(state.self_review_sha.is_none());
+
+        // Set a SHA and round-trip through save/load
+        state.self_review_sha = Some("abc123def456".to_string());
+        state.save(temp_dir.path()).unwrap();
+
+        let loaded = PrState::load(temp_dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.self_review_sha, Some("abc123def456".to_string()));
+    }
+
+    #[test]
+    fn test_pr_state_self_review_sha_absent_in_old_json() {
+        // Existing PR state files without self_review_sha should deserialize fine
+        let json = r#"{"pr_number":"42","issue_number":"15","status":"draft"}"#;
+        let state: PrState = serde_json::from_str(json).unwrap();
+        assert!(state.self_review_sha.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- **Primary fix**: Add `self_review_sha: Option<String>` to `PrState`. Before calling `trigger_pr_review()`, `monitor_pr_lifecycle` checks whether the stored SHA matches the current HEAD. If they match, the review is skipped with a message. On a successful review (exit code 0 only), the SHA is stored so subsequent re-entries skip the duplicate. Force-pushes naturally reset the guard because the HEAD SHA changes.
- **Secondary fix**: `handle_resume()` in `resume.rs` now reads `orchestration_phase` from the registry and skips the agent session and PR creation phases when resuming a minion that is already in `MonitoringPr` or beyond, matching the existing phase-aware logic in `run_worker()`.

## Test plan

- Added `test_pr_state_self_review_sha_round_trip`: verifies the new field survives save/load
- Added `test_pr_state_self_review_sha_absent_in_old_json`: verifies backwards compatibility — existing state files without `self_review_sha` deserialize with `None`
- `just check` passes: 873 tests, 0 failures, clippy clean, formatted

## Notes

- `self_review_sha` uses `#[serde(default, skip_serializing_if = "Option::is_none")]` so existing `.gru_pr_state.json` files without the field are read correctly and the field is omitted from JSON when `None`.
- The `resume.rs` phase-skipping does not change the duplicate-review guard — the SHA guard in `monitor_pr_lifecycle` is sufficient on its own. The phase-skipping is a separate efficiency improvement that avoids re-running the agent when it has already completed.

Fixes #493