### PR TITLE
Fixes #485: Add Concepts doc explaining Gru's mental model

### DIFF
--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -82,24 +82,28 @@ Minion claims issue (gru:in-progress)
 Worktree created, agent implements fix
         │
         ▼
-PR opened (gru:done) ──► CI monitored ◄───────────────────┐
-                                │                          │
-                                ├─ CI fails ──► auto-fix   │
-                                │              attempted   │
-                                │              (2x max)    │
-                                ▼                          │
-                        Review comments handled            │
-                                │                          │
-                                ├─ Blocked ──► gru:blocked │
-                                │              + escalation │
-                                │                          │
-                                └─ Changes requested ──────┘
-                                   push fix, re-run CI
-
-        (all checks pass, approved)
-                │
-                ▼
-            PR merged
+PR opened (gru:done) ──► CI monitored ◄──────────────────────┐
+                                │                             │
+                                ├─ CI fails ──► auto-fix      │
+                                │              attempted      │
+                                │              (2x max)       │
+                                │              │              │
+                                │              └─ still fails │
+                                │                 ──► gru:blocked
+                                │
+                                ▼
+                        Review comments handled
+                                │
+                                ├─ Blocked ──► gru:blocked + escalation
+                                │
+                                ├─ Changes requested ──► push fix ──────┘
+                                │                        (re-run CI)
+                                │
+                                ▼
+                        All checks pass + approved
+                                │
+                                ▼
+                            PR merged
 ```
 
 If anything goes unresolvably wrong, the Minion labels the issue `gru:blocked` or `gru:failed` and typically leaves a comment explaining what it needs.


### PR DESCRIPTION
## Summary
- Adds `docs/CONCEPTS.md`: a ~500-word user-facing mental model explainer for Gru
- Covers all seven concepts from the issue: Minions, Worktrees, Labels as State, GitHub as Database, Lab Mode, Agent Backends, and The Lifecycle
- Includes ASCII lifecycle diagram with happy path, CI failure auto-fix loop, review iteration loop, and blocked escalation
- Labels section covers both issue labels and PR labels (`gru:ready-to-merge`, `gru:auto-merge`, `gru:needs-human-review`)
- Lab Mode section points users to `gru init` for repo registration

## Test plan
- Manually verified the document reads cleanly in under 3 minutes
- Each concept stays within the 2-4 sentence limit from acceptance criteria
- No implementation internals leaked (no Tokio, stream-json, bare repos, or internal constants)
- All pre-commit checks pass: `just fmt-check`, `just lint`, `just test`

## Notes
- The gru-guide skill (#481) is blocked by this issue; the symlink into `skills/gru-guide/docs/` is deferred until that skill exists
- The lifecycle diagram shows the review iteration loop (changes requested → push fix → re-run CI → re-review) which was the most important non-obvious path for new users

Fixes #485

<sub>🤖 M0w4</sub>