### PR TITLE
Fixes #489: Post GitHub notification when monitoring stops with unaddressed reviews

### DIFF
--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -87,9 +87,9 @@ async fn auto_rebase_pr(worktree_path: &Path) -> Result<bool> {
 /// section with the minion ID and resume command.
 fn format_exit_notification_comment(minion_id: &str, unaddressed_count: usize) -> String {
     let review_word = if unaddressed_count == 1 {
-        "review comment"
+        "review"
     } else {
-        "review comments"
+        "reviews"
     };
     format!(
         "---\ntype: monitoring-paused\n---\n\n\
@@ -1017,10 +1017,7 @@ mod tests {
             body.contains("gru resume M042"),
             "comment must contain resume command"
         );
-        assert!(
-            body.contains("2 review comments"),
-            "comment must mention the count"
-        );
+        assert!(body.contains("2 reviews"), "comment must mention the count");
         assert!(
             body.contains("type: monitoring-paused"),
             "comment must include YAML frontmatter type"

--- a/src/pr_monitor.rs
+++ b/src/pr_monitor.rs
@@ -138,7 +138,7 @@ struct Head {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Review {
-    pub(crate) id: u64,
+    id: u64,
     pub(crate) submitted_at: DateTime<Utc>,
     pub(crate) user: User,
 }


### PR DESCRIPTION
## Summary
- When `monitor_pr_lifecycle` exits (timeout, max review rounds, errors, interrupt), check if the PR is still open with unaddressed external reviews and post a GitHub comment if so
- GitHub comment includes YAML frontmatter (`type: monitoring-paused`) for machine discoverability and a human-readable resume instruction with the minion ID
- Terminal message `⏸️  Monitoring paused. N review(s) pending. Resume: gru resume M0xx` printed on successful comment post
- Self-reviews and reviews on merged/closed PRs never trigger the notification

## New API in `pr_monitor.rs`
- `has_unaddressed_reviews(reviews, pr_author, since) -> usize` — pure, testable
- `should_post_exit_notification(pr_open, unaddressed_count) -> bool` — pure, testable
- `get_pr_info_for_exit_notification(...)` — thin wrapper returning `(is_open, pr_author)` without leaking internal types
- `get_all_reviews`, `Review`, `User` made `pub(crate)`

## Test plan
- 881 tests pass (`cargo test`)
- 6 new tests added per issue spec:
  - `has_unaddressed_reviews` filters PR author reviews
  - `has_unaddressed_reviews` returns 0 for reviews at or before baseline
  - `has_unaddressed_reviews` returns 0 for empty list
  - `should_post_exit_notification` false when PR is closed/merged
  - `should_post_exit_notification` false when count is 0
  - Exit notification format contains minion ID and resume command
- `just lint` clean
- `just check` passes

## Notes
- `is_open` checks both `state != "closed"` and `!merged` to guard the narrow race where state hasn't propagated after merge
- Terminal message only fires when the GitHub comment was actually posted (not on API failure)
- All errors in `post_exit_notification_if_needed` are best-effort — logged as warnings, never propagate to the main monitoring flow
- `review_baseline` must be `Some` for the notification to fire; it is `None` only if the monitor loop never made a single successful poll (extremely unlikely in practice)

Fixes #489

<sub>🤖 M0wr</sub>