### PR TITLE
Fixes #504: Lab liveness condition too broad: treats mid-startup minions as dead

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -344,11 +344,17 @@ fn host_for_repo(config: &LabConfig, owner_repo: &str) -> Option<String> {
 /// Scan the registry for minions that can be resumed.
 ///
 /// A minion is resumable if:
-/// - Its process is not running (PID is absent or the process is dead — e.g. after
-///   SIGKILL before cleanup could run). We do not check `mode == Stopped` explicitly
-///   because that state implies `pid = None`, which already makes `is_running()` false.
-///   Checking `mode == Stopped` as an OR would also match the transient startup window
-///   where mode is Autonomous but the PID hasn't been written yet.
+/// - Its process is not running. Two cases are distinguished:
+///
+///   1. `mode == Stopped` — the minion was cleanly stopped; no PID is present.
+///   2. Running-mode (`Autonomous`/`Interactive`) with a recorded PID that is now
+///      dead — e.g. after SIGKILL before cleanup could run.
+///
+///   We require a PID to be present for case 2 to avoid a false positive during the
+///   transient startup window: `check_and_claim_session` sets `mode = Autonomous` but
+///   the outer lab hasn't written the PID yet. In that window `is_running()` returns
+///   false (no PID ⟹ false), which would incorrectly flag the minion as dead.
+///   Gating on `pid.is_some()` excludes that window.
 /// - Its orchestration phase is active (RunningAgent, CreatingPr, or MonitoringPr)
 /// - Its worktree still exists on disk
 /// - Its repo is in the Lab config
@@ -359,7 +365,8 @@ async fn find_resumable_minions(config: &LabConfig) -> Result<Vec<ResumableMinio
             .list()
             .into_iter()
             .filter(|(_id, info)| {
-                let process_dead = !info.is_running();
+                let process_dead =
+                    info.mode == MinionMode::Stopped || (info.pid.is_some() && !info.is_running());
                 process_dead
                     && info.orchestration_phase.is_active()
                     && info.worktree.exists()


### PR DESCRIPTION
## Summary

- Distinguish two resumable-minion cases in `find_resumable_minions`: cleanly stopped (`mode == Stopped`) vs. crashed (running-mode with a recorded PID that is now dead)
- Require `pid.is_some()` before the liveness check to close the transient startup false-positive window
- Update the doc comment to describe both cases accurately and explain the guard

## Problem

`find_resumable_minions` had a liveness condition that was too broad. The original:

```rust
let process_dead = info.mode == MinionMode::Stopped || !info.is_running();
```

The `||` was incorrect: `mode == Stopped` implies `pid = None`, making `is_running()` return false already — redundant. More critically, the OR created a ~100ms false-positive window: `check_and_claim_session` sets `mode = Autonomous` before the outer lab writes the PID. During that window `is_running()` is false (no PID), so `process_dead = true` and the live minion gets incorrectly re-queued.

Removing the mode check to `!info.is_running()` narrowed the condition but did not close the window — `is_running()` still returns false when `pid = None`.

## Fix

```rust
let process_dead =
    info.mode == MinionMode::Stopped || (info.pid.is_some() && !info.is_running());
```

This separates the two cases explicitly:

| State | `mode == Stopped` | `pid.is_some() && !is_running()` | Resumable? |
|---|---|---|---|
| Cleanly stopped | ✓ | — | Yes |
| Crashed (pid gone) | — | ✓ | Yes |
| Startup window (`mode=Autonomous, pid=None`) | ✗ | ✗ | **No** ← fixed |
| Running normally | ✗ | ✗ | No |

The doc comment now describes both cases and explains why `pid.is_some()` is the key guard.

## Test plan

- `just check` — 881 tests pass, clippy clean, formatting clean

## Notes

- A follow-up regression test for `find_resumable_minions` covering `(mode=Autonomous, pid=None, phase=RunningAgent)` would harden against regressions
- Related: #502 (per-issue deduplication), #501 (duplicate self-reviews as downstream symptom)

Fixes #504

<sub>🤖 M0wz</sub>