### PR TITLE
Fixes #503: Lab resume_interrupted_minions has no per-issue deduplication — multiple minions resume for the same issue

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -725,6 +725,29 @@ async fn resume_interrupted_minions(
             None => continue, // repo no longer in config
         };
 
+        // Cross-cycle guard: skip if another minion for this issue is already running
+        // (e.g. the most-recent was resumed in the previous cycle and is still alive).
+        match is_issue_claimed(&candidate.info.repo, candidate.info.issue).await {
+            Ok(true) => {
+                log::info!(
+                    "Skipping {} (issue #{}, {}): another minion for this issue is already running",
+                    candidate.minion_id,
+                    candidate.info.issue,
+                    candidate.info.repo,
+                );
+                continue;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                log::warn!(
+                    "⚠️  Failed to check if issue #{} is claimed: {} — skipping to be safe",
+                    candidate.info.issue,
+                    e,
+                );
+                continue;
+            }
+        }
+
         // Skip minions whose issue is already closed (PR merged or issue resolved)
         let (owner, repo_name) = match candidate.info.repo.split_once('/') {
             Some(parts) => parts,


### PR DESCRIPTION
# Fixes #503: Lab resume_interrupted_minions has no per-issue deduplication

## Summary

- Extract `sort_and_dedup_resumable`: sorts resumable candidates by minion ID descending (most recent first) and deduplicates by `(repo, issue_number)` upfront, so the main loop never sees more than one candidate per issue
- Add cross-cycle guard: call `is_issue_claimed` before spawning each candidate so that if a previously-resumed minion is still running in a later poll cycle, remaining stopped minions for the same issue are skipped
- Use `sort_by_cached_key` with `std::cmp::Reverse` to avoid per-comparison allocations; normalize to lowercase via `to_ascii_lowercase` to handle legacy uppercase IDs correctly

## Root cause

When lab restarts repeatedly while minions are mid-flight, the registry accumulates multiple stopped/dead minions for the same issue. `resume_interrupted_minions` filtered by `resumed_this_session` (keyed by minion ID), but all N minions for a single issue pass that filter — so all N get resumed concurrently. This causes duplicate PR reviews and conflicting agent actions.

Two related failure modes are fixed:

1. **Within-cycle**: all N stopped minions are present in a single poll → `sort_and_dedup_resumable` keeps only the most recent
2. **Cross-cycle**: the most-recent minion was resumed in cycle N and is still running; other stopped minions for the same issue would be resumed in cycle N+1 → `is_issue_claimed` blocks them

## Test plan

- `just test` — all 897 tests pass (11 new unit tests for `sort_and_dedup_resumable`)
- `just lint` — no clippy warnings
- `just fmt-check` — formatting clean

Fixes the root cause of the duplicate PR review symptom described in #501.

Fixes #503

<sub>🤖 M0y8</sub>