### PR TITLE
Fixes #563: Centralize WORKSPACE singleton with test override support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -181,14 +181,12 @@ pub fn try_load_config() -> Option<LabConfig> {
 /// Returns a registry with just `github.com` if the config can't be loaded.
 /// This is a convenience for callers that need host info but don't require
 /// full daemon config validation.
+///
+/// Respects the test config path override set via [`set_test_config_path`].
 pub fn load_host_registry() -> HostRegistry {
-    let path = match LabConfig::default_path() {
-        Ok(p) => p,
-        Err(_) => return HostRegistry::from_config(&LabConfig::default()),
-    };
-    match LabConfig::load_partial(&path) {
-        Ok(cfg) => HostRegistry::from_config(&cfg),
-        Err(_) => HostRegistry::from_config(&LabConfig::default()),
+    match try_load_config() {
+        Some(cfg) => HostRegistry::from_config(&cfg),
+        None => HostRegistry::from_config(&LabConfig::default()),
     }
 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,6 +1,7 @@
 use once_cell::sync::OnceCell;
 use std::fs;
 use std::io;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 /// Cached workspace instance initialized once on first successful call.
@@ -8,7 +9,7 @@ use std::path::{Path, PathBuf};
 static GLOBAL_WORKSPACE: OnceCell<Workspace> = OnceCell::new();
 
 // Thread-local override for tests. When set, `Workspace::global()` returns
-// a reference to this workspace instead of the process-wide singleton.
+// an owned clone instead of the process-wide singleton.
 // This allows parallel tests to each have their own isolated workspace root.
 #[cfg(test)]
 thread_local! {
@@ -24,6 +25,7 @@ thread_local! {
 /// - `work`: Active working directories for minions
 /// - `archive`: Completed or archived minion workspaces
 /// - `state`: State files (e.g., minion ID counter)
+#[derive(Clone)]
 pub struct Workspace {
     #[allow(dead_code)] // Accessed via root() in tests
     root: PathBuf,
@@ -34,6 +36,31 @@ pub struct Workspace {
     state: PathBuf,
 }
 
+/// A reference to a `Workspace` — either a `&'static` from the process-wide
+/// singleton or an owned clone from a thread-local test override.
+///
+/// Dereferences to `&Workspace`, so callers can use it identically regardless
+/// of which variant is active. In production builds only `Static` is used.
+pub enum WorkspaceRef {
+    /// Reference to the process-wide singleton (production path).
+    Static(&'static Workspace),
+    /// Owned clone from a thread-local test override.
+    #[cfg(test)]
+    Owned(Workspace),
+}
+
+impl Deref for WorkspaceRef {
+    type Target = Workspace;
+
+    fn deref(&self) -> &Workspace {
+        match self {
+            WorkspaceRef::Static(ws) => ws,
+            #[cfg(test)]
+            WorkspaceRef::Owned(ws) => ws,
+        }
+    }
+}
+
 impl Workspace {
     /// Returns a reference to the global cached Workspace instance.
     ///
@@ -42,25 +69,18 @@ impl Workspace {
     ///
     /// In test builds, checks for a thread-local override set via
     /// [`set_test_workspace`] before falling back to the process-wide singleton.
-    pub fn global() -> io::Result<&'static Workspace> {
+    /// Returns a [`WorkspaceRef`] that dereferences to `&Workspace`.
+    pub fn global() -> io::Result<WorkspaceRef> {
         #[cfg(test)]
         {
-            // SAFETY: We transmute the lifetime from the thread-local borrow to 'static.
-            // This is safe because:
-            // 1. The thread-local is only set/cleared within a single test function
-            // 2. The returned reference is used within the same test scope
-            // 3. Tests run on their own thread, so the thread-local outlives all uses
-            let maybe = TEST_WORKSPACE_OVERRIDE.with(|cell| {
-                let borrow = cell.borrow();
-                borrow
-                    .as_ref()
-                    .map(|ws| unsafe { &*(ws as *const Workspace) as &'static Workspace })
-            });
+            let maybe = TEST_WORKSPACE_OVERRIDE.with(|cell| cell.borrow().clone());
             if let Some(ws) = maybe {
-                return Ok(ws);
+                return Ok(WorkspaceRef::Owned(ws));
             }
         }
-        GLOBAL_WORKSPACE.get_or_try_init(Workspace::new)
+        Ok(WorkspaceRef::Static(
+            GLOBAL_WORKSPACE.get_or_try_init(Workspace::new)?,
+        ))
     }
 
     /// Creates directories with appropriate permissions (0755 on Unix).


### PR DESCRIPTION
## Summary
- Add `thread_local!` test overrides for `Workspace::global()` and `try_load_config()` so tests in the same process can use isolated workspace roots and config files
- Introduce `WorkspaceRef` enum (safe, no `unsafe`) that wraps `&'static Workspace` in production and an owned `Workspace` clone in test overrides
- Add RAII guards (`TestWorkspaceGuard`, `TestConfigGuard`) that auto-clear overrides on drop
- Add `LabConfig::from_path(path)` constructor for loading config from an explicit path
- Refactor `load_host_registry()` to use `try_load_config()` so it respects the test config override
- All override machinery is `#[cfg(test)]`-gated — zero production overhead

## Test plan
- Added `test_set_test_workspace_overrides_global` — verifies `Workspace::global()` returns overridden workspace
- Added `test_set_test_workspace_guard_clears_on_drop` — verifies cleanup on guard drop
- Added `test_minion_id_with_workspace_override` — verifies `generate_minion_id()` respects workspace override end-to-end
- Added `test_from_path_loads_config` and `test_from_path_nonexistent_file_returns_error`
- Added `test_set_test_config_path_overrides_try_load` and `test_set_test_config_path_guard_clears_on_drop`
- All 919 tests pass: `just check` (fmt + lint + test + build)

## Notes
- `WorkspaceRef` uses `Deref<Target=Workspace>` so all existing callers work without changes
- `Workspace` now derives `Clone` (all fields are `PathBuf`)
- `MinionRegistry::load(None)` already accepts `Option<&Path>` for test isolation; the workspace override now makes the `None` path testable too

Fixes #563

<sub>🤖 M10g</sub>