### PR TITLE
Fixes #559: Standardize registry cleanup across commands

### DIFF
--- a/src/commands/prompt.rs
+++ b/src/commands/prompt.rs
@@ -1,4 +1,4 @@
-use crate::agent::{AgentEvent, TokenUsage};
+use crate::agent::AgentEvent;
 use crate::agent_registry;
 use crate::agent_runner::{run_agent_with_stream_monitoring, EXIT_CODE_SIGNAL_TERMINATED};
 use crate::git;
@@ -700,23 +700,6 @@ fn build_progress_display(
     std::sync::Arc::new(ProgressDisplay::new(config))
 }
 
-/// Best-effort cleanup after agent run: clears PID, sets mode to Stopped,
-/// and persists token usage regardless of exit status.
-async fn cleanup_agent_run(minion_id: &str, token_usage: Option<TokenUsage>) {
-    // Best-effort: errors here must not shadow the primary run result.
-    let cleanup_id = minion_id.to_string();
-    let _ = with_registry(move |registry| {
-        registry.update(&cleanup_id, |info| {
-            info.clear_pid();
-            info.mode = MinionMode::Stopped;
-            if let Some(usage) = token_usage {
-                info.token_usage = Some(usage);
-            }
-        })
-    })
-    .await;
-}
-
 /// Interprets the agent exit status and prints appropriate result messages.
 fn handle_agent_result(
     status: std::process::ExitStatus,
@@ -799,8 +782,28 @@ async fn register_and_run_agent(
     )
     .await;
 
+    // Best-effort cleanup: clear PID, set mode to Stopped, save token usage, and
+    // mark orchestration phase as terminal. Prompt is ephemeral (does not support
+    // the full fix/resume lifecycle), so we always move to Completed/Failed to
+    // prevent the lab daemon from attempting to resume a finished prompt session.
+    let exit_ok = run_result.as_ref().is_ok_and(|r| r.status.success());
     let token_usage = run_result.as_ref().ok().map(|r| r.token_usage.clone());
-    cleanup_agent_run(&minion_id, token_usage).await;
+    let cleanup_id = minion_id.clone();
+    let _ = with_registry(move |registry| {
+        registry.update(&cleanup_id, |info| {
+            info.clear_pid();
+            info.mode = MinionMode::Stopped;
+            info.orchestration_phase = if exit_ok {
+                OrchestrationPhase::Completed
+            } else {
+                OrchestrationPhase::Failed
+            };
+            if let Some(usage) = token_usage {
+                info.token_usage = Some(usage);
+            }
+        })
+    })
+    .await;
 
     let agent_run = run_result?;
 

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -219,16 +219,22 @@ pub async fn handle_review(pr_arg: Option<String>, agent_name: &str) -> Result<i
     )
     .await;
 
-    // Best-effort cleanup: clear PID, set mode to Stopped, and save token usage.
-    // Token usage is persisted regardless of exit status (Ok with non-zero exit) because
-    // cost data is valuable even for failed tasks. Only stream-level errors (timeout, stuck)
-    // result in Err, in which case partial usage is not saved.
+    // Best-effort cleanup: clear PID, set mode to Stopped, save token usage, and
+    // mark orchestration phase as terminal. Review is ephemeral (does not support
+    // resume), so we always move to Completed/Failed to prevent the lab daemon from
+    // attempting to resume a finished review.
+    let exit_ok = run_result.as_ref().is_ok_and(|r| r.status.success());
     let token_usage = run_result.as_ref().ok().map(|r| r.token_usage.clone());
     let cleanup_id = minion_id.clone();
     let _ = with_registry(move |registry| {
         registry.update(&cleanup_id, |info| {
             info.clear_pid();
             info.mode = MinionMode::Stopped;
+            info.orchestration_phase = if exit_ok {
+                OrchestrationPhase::Completed
+            } else {
+                OrchestrationPhase::Failed
+            };
             if let Some(usage) = token_usage {
                 info.token_usage = Some(usage);
             }


### PR DESCRIPTION
## Summary
- `review.rs` and `prompt.rs` now set `orchestration_phase` to `Completed` (on success) or `Failed` (on error) during registry cleanup
- Previously both commands left `orchestration_phase` as `RunningAgent` after completion, which caused the lab daemon's `find_resumable_minions()` to incorrectly treat finished review/prompt sessions as resumable
- This matches the pattern already used by `fix.rs` and `resume.rs`, which properly transition to terminal phases

## Test plan
- Ran `just check` (format + lint + test + build) — all 912 tests pass
- Verified the cleanup logic uses `is_ok_and(|r| r.status.success())` to correctly distinguish success from failure
- Confirmed `fix.rs` and `resume.rs` already follow the Completed/Failed pattern via `update_orchestration_phase()`

## Notes
- The root issue was that `find_resumable_minions()` in `lab.rs` checks `orchestration_phase.is_active()` — `RunningAgent` is active, so completed review/prompt minions appeared resumable
- Review and prompt are ephemeral commands that don't support the full fix/resume lifecycle, so they should always reach a terminal phase on exit

Fixes #559

<sub>🤖 M10p</sub>