### PR TITLE
Fixes #569: Skip CI monitoring after PR is already merged

### DIFF
--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -316,6 +316,10 @@ async fn trigger_pr_review(
 
 /// Monitors a PR for reviews, CI failures, and merge/close events.
 /// Handles automatic review rounds up to MAX_REVIEW_ROUNDS.
+///
+/// Returns `Some(Merged)` or `Some(Closed)` when the PR reaches a terminal
+/// state. Returns `None` for all other exit paths (timeout, user interrupt,
+/// review-round cap, rebase failure, consecutive errors).
 pub(crate) async fn monitor_pr_lifecycle(
     backend: &dyn AgentBackend,
     issue_ctx: &IssueContext,
@@ -324,7 +328,7 @@ pub(crate) async fn monitor_pr_lifecycle(
     timeout_opt: Option<&str>,
     review_timeout: Option<Duration>,
     monitor_timeout: Duration,
-) {
+) -> Option<MonitorResult> {
     // Ensure the gru:ready-to-merge label exists in the repo
     if let Err(e) =
         pr_monitor::ensure_ready_to_merge_label(&issue_ctx.host, &issue_ctx.owner, &issue_ctx.repo)
@@ -408,6 +412,7 @@ pub(crate) async fn monitor_pr_lifecycle(
     let mut rebase_attempts = 0;
     let mut judge_state = JudgeState::new();
     let mut judge_label_ensured = false;
+    let mut terminal_result: Option<MonitorResult> = None;
     let mut consecutive_errors: u32 = 0;
     // 10 consecutive monitor_pr invocation failures before giving up.
     // Wall-clock time per failure varies since monitor_pr does its own internal
@@ -492,11 +497,13 @@ pub(crate) async fn monitor_pr_lifecycle(
             Ok((MonitorResult::Merged, _)) => {
                 println!("✅ PR #{} was merged successfully!", pr_number);
                 println!("🎉 Issue {} is complete!", issue_ctx.issue_num);
+                terminal_result = Some(MonitorResult::Merged);
                 break;
             }
             Ok((MonitorResult::Closed, _)) => {
                 println!("⚠️  PR #{} was closed without merging", pr_number);
                 println!("   The issue may need to be reopened or addressed differently");
+                terminal_result = Some(MonitorResult::Closed);
                 break;
             }
             Ok((MonitorResult::ReadyToMerge, _)) => {
@@ -962,6 +969,8 @@ pub(crate) async fn monitor_pr_lifecycle(
         )
         .await;
     }
+
+    terminal_result
 }
 
 /// Monitors CI after the initial fix and attempts auto-fixes if checks fail.

--- a/src/commands/fix/worker.rs
+++ b/src/commands/fix/worker.rs
@@ -167,7 +167,7 @@ pub(super) async fn monitor_pr_phase(
 ) -> Result<()> {
     if let Some(ref pr_num) = pr_number {
         update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::MonitoringPr).await;
-        monitor_pr_lifecycle(
+        let _ = monitor_pr_lifecycle(
             backend,
             issue_ctx,
             wt_ctx,

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -13,6 +13,7 @@ use crate::minion_registry::{
     OrchestrationPhase,
 };
 use crate::minion_resolver;
+use crate::pr_monitor::MonitorResult;
 use crate::progress::{ProgressConfig, ProgressDisplay};
 use crate::session_claim;
 use crate::tmux::TmuxGuard;
@@ -382,10 +383,11 @@ pub async fn handle_resume(
     }
 
     // Phase: Monitor PR lifecycle (reviews, CI, merge)
+    let mut pr_terminal_result = None;
     if let Some(ref pr_num) = pr_number {
         update_orchestration_phase(&minion.minion_id, OrchestrationPhase::MonitoringPr).await;
         let monitor_timeout = Duration::from_secs(24 * 3600);
-        monitor_pr_lifecycle(
+        pr_terminal_result = monitor_pr_lifecycle(
             &*backend,
             &issue_ctx,
             &wt_ctx,
@@ -397,8 +399,12 @@ pub async fn handle_resume(
         .await;
     }
 
-    // CI monitoring (only if a PR exists)
-    if pr_number.is_some() {
+    // CI monitoring (only if a PR exists and wasn't already merged/closed)
+    let skip_ci = matches!(
+        pr_terminal_result,
+        Some(MonitorResult::Merged) | Some(MonitorResult::Closed)
+    );
+    if pr_number.is_some() && !skip_ci {
         let ci_passed = monitor_ci_after_fix(
             &issue_ctx.host,
             &issue_ctx.owner,


### PR DESCRIPTION
## Summary
- Make `monitor_pr_lifecycle` return `Option<MonitorResult>` instead of `()` so callers can inspect the terminal PR state
- In `resume.rs`, skip `monitor_ci_after_fix` when the PR was already merged or closed, avoiding unnecessary GitHub API calls
- Add doc comment explaining the return value semantics

## Test plan
- All 929 existing tests pass (`just check` — format, lint, test, build)
- No new tests needed: the change is a control-flow guard around an existing function call. The underlying `monitor_ci_after_fix` and `monitor_pr_lifecycle` are already tested.

## Notes
- The bug was in `resume.rs` where `monitor_ci_after_fix` ran unconditionally after `monitor_pr_lifecycle`, even when the PR was already merged/closed
- `worker.rs` was not affected (its CI monitoring is in a separate branch for the no-PR case), but the return value is now consumed with `let _ =` for explicitness

Fixes #569

<sub>🤖 M10v</sub>