### PR TITLE
Fixes #555: Extract and test CI escalation decision logic

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -847,6 +847,7 @@ pub async fn monitor_and_fix_ci(
                 return Ok(true);
             }
             CiFixAction::RetryNextAttempt => {
+                // Only reachable via CiResult::Timeout (non-final attempt)
                 eprintln!("⏱️  CI checks timed out");
                 continue;
             }
@@ -869,10 +870,23 @@ pub async fn monitor_and_fix_ci(
                 return Ok(false);
             }
             CiFixAction::Escalate(EscalationReason::ChecksFailed) => {
-                let failed_checks = match ci_result {
+                let mut failed_checks = match ci_result {
                     CiResult::Failed(checks) => checks,
                     _ => unreachable!(),
                 };
+
+                // Enrich with detailed logs before escalating
+                for check in &mut failed_checks {
+                    if check.output.is_none() || check.output.as_deref() == Some("") {
+                        if let Ok(Some(logs)) =
+                            fetch_check_logs(host, owner, repo, &check.name, pr_number, branch)
+                                .await
+                        {
+                            check.output = Some(logs);
+                        }
+                    }
+                }
+
                 eprintln!(
                     "🚨 Max fix attempts ({}) reached, escalating to human",
                     MAX_CI_FIX_ATTEMPTS


### PR DESCRIPTION
## Summary
- Extracted CI escalation decision logic from `monitor_and_fix_ci` into two pure functions: `decide_ci_action` and `decide_after_no_commits`
- Added `CiFixAction` and `EscalationReason` enums to represent decision outcomes
- Refactored `monitor_and_fix_ci` to use the new decision functions while preserving all original behavior
- Added 12 tests covering all decision branches: pass, no-checks, timeout escalation, timeout retry, failed escalation, failed fix attempt, single-attempt max, no-commits escalation, and no-commits retry

## Test plan
- All 954 existing tests pass
- 12 new tests specifically for `decide_ci_action` and `decide_after_no_commits`
- Commands run: `just check` (fmt + lint + test + build)

## Notes
- The `decide_ci_action` function handles the first decision point: what to do when CI results come back
- The `decide_after_no_commits` function handles the second decision point: what to do when a fix attempt produced no new commits
- Both functions are pure (no I/O) and fully testable in isolation
- Log enrichment is preserved in both the `AttemptFix` and `Escalate(ChecksFailed)` paths to maintain escalation comment quality

Fixes #555

<sub>🤖 M110</sub>