### PR TITLE
Fixes #554: Extract PR recovery logic in handle_pr_creation

### DIFF
--- a/src/commands/fix/pr.rs
+++ b/src/commands/fix/pr.rs
@@ -239,6 +239,9 @@ async fn finalize_pr(
 ///
 /// Looks up the PR via `gh pr list --head <branch>`, finalizes state if found,
 /// and returns the PR number. Used by error-recovery paths in `handle_pr_creation`.
+///
+/// This function always returns `Ok(_)`: internal lookup errors are logged as
+/// warnings and mapped to `Ok(None)`, so callers can use `?` safely.
 async fn recover_existing_pr(
     issue_ctx: &IssueContext,
     wt_ctx: &WorktreeContext,
@@ -255,6 +258,9 @@ async fn recover_existing_pr(
         Ok(Some(pr_num)) => {
             let pr_number = pr_num.to_string();
 
+            // Best-effort: log warnings instead of propagating errors,
+            // since losing the recovered PR number would be worse than
+            // missing metadata (which can be recovered on next resume).
             if let Err(e) = finalize_pr(issue_ctx, wt_ctx, &pr_number).await {
                 log::warn!("⚠️  Failed to finalize recovered PR state: {}", e);
             }


### PR DESCRIPTION
## Summary
- Extracted `recover_existing_pr()` function from two nearly-identical recovery blocks in `handle_pr_creation` (lines 320-355 and 373-419)
- Both blocks searched for an existing PR via `gh pr list --head`, finalized state, and returned the PR number — now consolidated into one function
- Callers retain their context-specific log messages (transient API warning vs manual PR link)
- Net reduction: 46 insertions, 58 deletions (12 fewer lines)

## Test plan
- All 942 existing tests pass (`just check` — format, lint, test, build)
- Code review verified behavior is preserved across all three match arms (found, not found, lookup error)
- No new tests needed — this is a pure refactor with no logic changes

## Notes
- `recover_existing_pr` is documented as always returning `Ok(_)` — lookup errors are absorbed and logged, matching the original best-effort semantics
- The best-effort rationale comment (explaining why `finalize_pr` errors are logged not propagated) has been preserved in the extracted function

Fixes #554

<sub>🤖 M115</sub>