### PR TITLE
Fixes #552: Add tests for check_and_claim_session (critical untested function)

### DIFF
--- a/src/session_claim.rs
+++ b/src/session_claim.rs
@@ -1,6 +1,4 @@
 use crate::minion_registry::{with_registry, MinionInfo, MinionMode, MinionRegistry};
-#[cfg(test)]
-use anyhow::Context;
 use anyhow::Result;
 use chrono::Utc;
 
@@ -162,6 +160,7 @@ pub(crate) async fn check_and_claim_session_with_dir(
     target_mode: MinionMode,
     graceful: bool,
 ) -> Result<Option<MinionInfo>> {
+    use anyhow::Context as _;
     let id = minion_id.to_string();
     let dir = state_dir.to_path_buf();
     let result = tokio::task::spawn_blocking(move || {
@@ -315,7 +314,8 @@ mod tests {
     #[tokio::test]
     async fn test_dead_pid_resets_and_claims() {
         let tmp = tempdir().unwrap();
-        // Use a PID that definitely doesn't exist
+        // PID 4,194,304 (2^22) exceeds Linux's PID_MAX_LIMIT and typical macOS
+        // pid_max, so it is guaranteed never to be assigned to a live process.
         let dead_pid = 4_194_304_u32;
         let info = MinionInfo {
             mode: MinionMode::Autonomous,


### PR DESCRIPTION
## Summary
- Extract core claim logic into `claim_session_in_registry` and error handling into `handle_claim_result` to enable testing with isolated temp-dir registries
- Add test-only `check_and_claim_session_with_dir` that bypasses the global workspace thread-local (needed because `with_registry` uses `spawn_blocking` on a different thread)
- Add 7 async tests covering all branches of `check_and_claim_session`:
  - Stopped minion → claim succeeds, returns pre-claim snapshot
  - AlreadyRunning with live PID (uses current process PID) → `SessionClaimError::AlreadyRunning`
  - Dead PID in non-Stopped mode → resets to Stopped, claims successfully
  - InconsistentState (non-Stopped, PID=None) → `SessionClaimError::InconsistentState`
  - `graceful=true` swallows registry IO errors → `Ok(None)`
  - `graceful=false` propagates registry IO errors
  - Nonexistent minion → `Ok(None)`

## Test plan
- `cargo test session_claim` — all 10 tests pass (3 existing + 7 new)
- `just check` — format, lint, all 949 tests, and build all pass

## Notes
- The refactoring is behavior-preserving: `check_and_claim_session` delegates to the same extracted functions
- Tests use real temp-dir registries (via `tempfile::tempdir`), not mocks
- The dead-PID test uses PID 4,194,304 (exceeds typical OS PID max) to guarantee the process doesn't exist

Fixes #552

<sub>🤖 M116</sub>