### PR TITLE
Fixes #548: Extract truncate_string/shorten_path to shared module (4 duplicate copies)

### DIFF
--- a/src/claude_backend.rs
+++ b/src/claude_backend.rs
@@ -9,6 +9,7 @@
 
 use crate::agent::{AgentBackend, AgentEvent, TokenUsage as AgentTokenUsage};
 use crate::claude_runner;
+use crate::display_utils::{shorten_path, truncate_string};
 use crate::stream::{self, ClaudeEvent, ContentBlock, ContentDelta, StreamOutput};
 use std::path::Path;
 use std::sync::Mutex;
@@ -266,35 +267,6 @@ fn format_tool_summary(tool_name: &str, input_json: &str) -> String {
         "TodoWrite" => "Update todos".to_string(),
         "AskUserQuestion" => "Asking question...".to_string(),
         _ => format!("Tool: {}", tool_name),
-    }
-}
-
-/// Truncate a string to a maximum number of characters (not bytes).
-fn truncate_string(s: &str, max_chars: usize) -> String {
-    let chars: Vec<char> = s.chars().take(max_chars + 1).collect();
-    if chars.len() > max_chars {
-        format!("{}...", chars[..max_chars].iter().collect::<String>())
-    } else {
-        s.to_string()
-    }
-}
-
-/// Shorten a file path for display, showing the last 3 components.
-fn shorten_path(path: &str) -> String {
-    let path_obj = std::path::Path::new(path);
-    let components: Vec<_> = path_obj.components().collect();
-
-    if components.len() <= 3 {
-        path.to_string()
-    } else {
-        let last_parts: Vec<_> = components
-            .iter()
-            .rev()
-            .take(3)
-            .rev()
-            .map(|c| c.as_os_str().to_string_lossy())
-            .collect();
-        format!(".../{}", last_parts.join("/"))
     }
 }
 
@@ -707,18 +679,5 @@ mod tests {
     fn test_format_tool_summary_invalid_json() {
         let result = format_tool_summary("Bash", "not valid json");
         assert_eq!(result, "Tool: Bash");
-    }
-
-    #[test]
-    fn test_shorten_path_short() {
-        assert_eq!(shorten_path("src/main.rs"), "src/main.rs");
-    }
-
-    #[test]
-    fn test_shorten_path_long() {
-        assert_eq!(
-            shorten_path("/Users/test/projects/gru/src/commands/fix.rs"),
-            ".../src/commands/fix.rs"
-        );
     }
 }

--- a/src/codex_backend.rs
+++ b/src/codex_backend.rs
@@ -12,6 +12,7 @@
 //! - `error` → `AgentEvent::Error`
 
 use crate::agent::{AgentBackend, AgentEvent, TokenUsage};
+use crate::display_utils::{shorten_path, truncate_string};
 use serde::Deserialize;
 use std::path::Path;
 use tokio::process::Command as TokioCommand;
@@ -340,35 +341,6 @@ fn extract_message_text(content: &Option<serde_json::Value>) -> Option<String> {
             }
         }
         _ => None,
-    }
-}
-
-/// Truncate a string to a maximum number of characters.
-fn truncate_string(s: &str, max_chars: usize) -> String {
-    let chars: Vec<char> = s.chars().take(max_chars + 1).collect();
-    if chars.len() > max_chars {
-        format!("{}...", chars[..max_chars].iter().collect::<String>())
-    } else {
-        s.to_string()
-    }
-}
-
-/// Shorten a file path for display, showing the last 3 components.
-fn shorten_path(path: &str) -> String {
-    let path_obj = std::path::Path::new(path);
-    let components: Vec<_> = path_obj.components().collect();
-
-    if components.len() <= 3 {
-        path.to_string()
-    } else {
-        let last_parts: Vec<_> = components
-            .iter()
-            .rev()
-            .take(3)
-            .rev()
-            .map(|c| c.as_os_str().to_string_lossy())
-            .collect();
-        format!(".../{}", last_parts.join("/"))
     }
 }
 
@@ -764,19 +736,6 @@ mod tests {
         let result = format_codex_command_summary(&long_cmd);
         assert!(result.ends_with("..."));
         assert!(result.starts_with("Run: "));
-    }
-
-    #[test]
-    fn test_shorten_path_short() {
-        assert_eq!(shorten_path("src/main.rs"), "src/main.rs");
-    }
-
-    #[test]
-    fn test_shorten_path_long() {
-        assert_eq!(
-            shorten_path("/Users/test/projects/gru/src/commands/fix.rs"),
-            ".../src/commands/fix.rs"
-        );
     }
 
     #[test]

--- a/src/display_utils.rs
+++ b/src/display_utils.rs
@@ -1,0 +1,66 @@
+//! Shared display formatting utilities for truncating strings and paths.
+
+/// Truncate a string to a maximum number of characters (not bytes).
+pub(crate) fn truncate_string(s: &str, max_chars: usize) -> String {
+    let chars: Vec<char> = s.chars().take(max_chars + 1).collect();
+    if chars.len() > max_chars {
+        format!("{}...", chars[..max_chars].iter().collect::<String>())
+    } else {
+        s.to_string()
+    }
+}
+
+/// Shorten a file path for display, showing the last 3 components.
+///
+/// Note: This differs from `commands::clean::shorten_path` which replaces
+/// the home directory prefix with `~`.
+pub(crate) fn shorten_path(path: &str) -> String {
+    let path_obj = std::path::Path::new(path);
+    let components: Vec<_> = path_obj.components().collect();
+
+    if components.len() <= 3 {
+        path.to_string()
+    } else {
+        let last_parts: Vec<_> = components
+            .iter()
+            .rev()
+            .take(3)
+            .rev()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect();
+        format!(".../{}", last_parts.join("/"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_string_short() {
+        assert_eq!(truncate_string("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_string_exact() {
+        assert_eq!(truncate_string("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_truncate_string_long() {
+        assert_eq!(truncate_string("hello world", 5), "hello...");
+    }
+
+    #[test]
+    fn test_shorten_path_short() {
+        assert_eq!(shorten_path("src/main.rs"), "src/main.rs");
+    }
+
+    #[test]
+    fn test_shorten_path_long() {
+        assert_eq!(
+            shorten_path("/Users/test/projects/gru/src/commands/fix.rs"),
+            ".../src/commands/fix.rs"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod codex_backend;
 mod commands;
 mod config;
 mod dependencies;
+mod display_utils;
 mod file_lock;
 mod git;
 mod github;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,4 +1,5 @@
 use crate::agent::AgentEvent;
+use crate::display_utils::truncate_string;
 use crate::text_buffer::TextBuffer;
 use chrono::{DateTime, Local};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -141,7 +142,7 @@ impl ProgressDisplay {
             AgentEvent::Started { .. } => {
                 // Flush any buffered text from a previous turn
                 if let Some(flushed_text) = self.text_buffer.flush() {
-                    let truncated = Self::truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
+                    let truncated = truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
                     self.print_event(&truncated);
                 }
                 self.update_status("💭 Thinking...");
@@ -157,7 +158,7 @@ impl ProgressDisplay {
             } => {
                 // Flush any buffered text before showing tool
                 if let Some(flushed_text) = self.text_buffer.flush() {
-                    let truncated = Self::truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
+                    let truncated = truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
                     self.print_event(&truncated);
                 }
 
@@ -194,7 +195,7 @@ impl ProgressDisplay {
 
                 let formatted = if *is_error {
                     let first_line = content.lines().next().unwrap_or(content);
-                    let truncated = Self::truncate_string(first_line, 60);
+                    let truncated = truncate_string(first_line, 60);
                     if let Some(name) = tool_name {
                         format!("[{}] ✗ {} failed: {}", timestamp, name, truncated)
                     } else {
@@ -215,14 +216,14 @@ impl ProgressDisplay {
                 self.update_status("📝 Responding...");
                 // Add text to buffer; flush if ready
                 if let Some(flushed_text) = self.text_buffer.add(text) {
-                    let truncated = Self::truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
+                    let truncated = truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
                     self.print_event(&truncated);
                 }
             }
             AgentEvent::MessageComplete { stop_reason, .. } => {
                 // Flush any remaining buffered text
                 if let Some(flushed_text) = self.text_buffer.flush() {
-                    let truncated = Self::truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
+                    let truncated = truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
                     self.print_event(&truncated);
                 }
 
@@ -246,7 +247,7 @@ impl ProgressDisplay {
             AgentEvent::Finished { .. } => {
                 // Flush any remaining buffered text
                 if let Some(flushed_text) = self.text_buffer.flush() {
-                    let truncated = Self::truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
+                    let truncated = truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
                     self.print_event(&truncated);
                 }
                 self.update_status("✅ Finished");
@@ -254,7 +255,7 @@ impl ProgressDisplay {
             AgentEvent::Error { message } => {
                 // Flush any buffered text before showing error
                 if let Some(flushed_text) = self.text_buffer.flush() {
-                    let truncated = Self::truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
+                    let truncated = truncate_string(&flushed_text, MAX_DISPLAY_CHARS);
                     self.print_event(&truncated);
                 }
 
@@ -274,19 +275,6 @@ impl ProgressDisplay {
 
         // Tick the spinner to show activity
         self.status_bar.tick();
-    }
-
-    /// Truncate a string to a maximum number of characters (not bytes)
-    fn truncate_string(s: &str, max_chars: usize) -> String {
-        // Collect up to max_chars + 1 characters to determine if truncation is needed
-        let chars: Vec<char> = s.chars().take(max_chars + 1).collect();
-        if chars.len() > max_chars {
-            // String is too long, truncate it
-            format!("{}...", chars[..max_chars].iter().collect::<String>())
-        } else {
-            // String is max_chars or shorter, return as-is
-            s.to_string()
-        }
     }
 
     /// Finish the progress display and show a final message


### PR DESCRIPTION
## Summary
- Created new `src/display_utils.rs` module with shared `truncate_string` and `shorten_path` functions
- Removed duplicate implementations from `claude_backend.rs`, `codex_backend.rs`, and `progress.rs` (3 copies of `truncate_string`, 2 copies of `shorten_path`)
- Left `commands/clean.rs::shorten_path` in place — it has different semantics (home dir `~` substitution vs last-3-components truncation)
- Added module-level docs and a note distinguishing the two `shorten_path` variants

## Test plan
- All 948 existing tests pass (`just check` — fmt, clippy, nextest, build)
- New `display_utils::tests` module covers `truncate_string` (short, exact, long) and `shorten_path` (short, long)
- Duplicate tests removed from `claude_backend` and `codex_backend` test modules

## Notes
- The issue mentions 4 duplicate locations but `clean.rs::shorten_path` is a different function (takes `&Path`, does `~` substitution). Only the 3 truly identical copies were consolidated.

Fixes #548

<sub>🤖 M11d</sub>