### PR TITLE
Fixes #551: Sweep pub to pub(crate) across the binary

### DIFF
--- a/src/agent_runner.rs
+++ b/src/agent_runner.rs
@@ -16,16 +16,16 @@ use tokio::time::{timeout, Duration};
 
 /// Timeout in seconds for each line read from the agent's output stream.
 /// Set to 5 minutes to accommodate long-running LLM operations.
-pub const STREAM_TIMEOUT_SECS: u64 = 300;
+pub(crate) const STREAM_TIMEOUT_SECS: u64 = 300;
 
 /// Duration of inactivity before warning the user.
-pub const INACTIVITY_WARNING_SECS: u64 = 300; // 5 minutes
+pub(crate) const INACTIVITY_WARNING_SECS: u64 = 300; // 5 minutes
 
 /// Duration of inactivity before considering the task stuck.
-pub const INACTIVITY_STUCK_SECS: u64 = 900; // 15 minutes
+pub(crate) const INACTIVITY_STUCK_SECS: u64 = 900; // 15 minutes
 
 /// Exit code returned when a process is terminated by a signal (shell convention).
-pub const EXIT_CODE_SIGNAL_TERMINATED: i32 = 128;
+pub(crate) const EXIT_CODE_SIGNAL_TERMINATED: i32 = 128;
 
 /// Errors from the agent runner that indicate the task is stuck or timed out.
 ///
@@ -82,7 +82,7 @@ pub struct AgentRunResult {
 
 /// Parses a timeout string into a Duration.
 /// Supports formats like "10s", "5m", "1h", "30".
-pub fn parse_timeout(timeout_str: &str) -> Result<Duration> {
+pub(crate) fn parse_timeout(timeout_str: &str) -> Result<Duration> {
     let timeout_str = timeout_str.trim();
 
     // Try to parse as plain seconds first

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -9,7 +9,7 @@ use crate::workspace::Workspace;
 
 /// Repository source type for initialization
 #[derive(Debug, Clone)]
-pub enum RepoSource {
+pub(crate) enum RepoSource {
     /// GitHub repository in "owner/repo" format
     GitHub(String),
     /// Local filesystem path (not yet implemented)
@@ -20,7 +20,7 @@ pub enum RepoSource {
 }
 
 /// Parse repository source from command line argument
-pub fn parse_repo_source(arg: &str) -> Result<RepoSource> {
+pub(crate) fn parse_repo_source(arg: &str) -> Result<RepoSource> {
     // Explicit path markers
     if arg.starts_with("./") || arg.starts_with("../") || arg.starts_with('/') {
         return Ok(RepoSource::LocalPath(PathBuf::from(arg)));

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -7,7 +7,7 @@ use crate::github::gh_cli_command;
 /// are skipped with a log warning.
 ///
 /// Returns a list of issue numbers found in the body text.
-pub fn parse_blockers_from_body(body: &str) -> Vec<u64> {
+pub(crate) fn parse_blockers_from_body(body: &str) -> Vec<u64> {
     let marker = "**Blocked by:**";
     let start = match body.find(marker) {
         Some(pos) => pos + marker.len(),
@@ -59,7 +59,7 @@ pub fn parse_blockers_from_body(body: &str) -> Vec<u64> {
 ///
 /// Separates "API supported and returned a result" from "API not available or errored".
 #[derive(Debug, PartialEq)]
-pub enum ApiResult {
+pub(crate) enum ApiResult {
     /// API returned 200 — the contained list is the set of open blocker issue numbers.
     Supported(Vec<u64>),
     /// API is not available (404/GHES) or returned an error (403/5xx/spawn failure).
@@ -70,7 +70,12 @@ pub enum ApiResult {
 ///
 /// This is a pure function extracted for testability. It interprets the exit status,
 /// stderr, and stdout of the `gh api` call.
-pub fn parse_api_output(success: bool, stdout: &str, stderr: &str, issue_number: u64) -> ApiResult {
+pub(crate) fn parse_api_output(
+    success: bool,
+    stdout: &str,
+    stderr: &str,
+    issue_number: u64,
+) -> ApiResult {
     if !success {
         if stderr.contains("404") || stderr.contains("Not Found") {
             log::debug!(
@@ -119,7 +124,7 @@ pub fn parse_api_output(success: bool, stdout: &str, stderr: &str, issue_number:
 ///
 /// Extracted for testability — handles both spawn failures (`Err`) and
 /// output parsing (`Ok`). The `Ok` variant carries `(success, stdout, stderr)`.
-pub fn interpret_api_call(
+pub(crate) fn interpret_api_call(
     output: Result<(bool, String, String), String>,
     issue_number: u64,
 ) -> Option<Vec<u64>> {
@@ -145,7 +150,7 @@ pub fn interpret_api_call(
 /// Returns `Some(blockers)` when the API is supported and returns 200.
 /// Returns `None` on 404 (GHES), 403, 5xx, or any other error — the caller
 /// should fall back to body parsing.
-pub async fn get_blockers_via_api(
+pub(crate) async fn get_blockers_via_api(
     host: &str,
     owner: &str,
     repo: &str,
@@ -186,7 +191,7 @@ pub async fn get_blockers_via_api(
 /// - Native API wins when it returns `Some` (even if the list is empty)
 /// - Body text is the sole source when the API is unavailable (`None`)
 /// - Results are never combined across sources
-pub fn resolve_blockers(body: &str, api_result: Option<Vec<u64>>) -> Vec<u64> {
+pub(crate) fn resolve_blockers(body: &str, api_result: Option<Vec<u64>>) -> Vec<u64> {
     match api_result {
         Some(api_blockers) => api_blockers,
         None => parse_blockers_from_body(body),
@@ -199,7 +204,7 @@ pub fn resolve_blockers(body: &str, api_result: Option<Vec<u64>>) -> Vec<u64> {
 /// - Native API wins when it returns 200 (even if the list is empty)
 /// - Body text is the sole source when the API is unavailable (404/error)
 /// - Results are never combined across sources
-pub async fn get_blockers(
+pub(crate) async fn get_blockers(
     host: &str,
     owner: &str,
     repo: &str,

--- a/src/github.rs
+++ b/src/github.rs
@@ -44,7 +44,7 @@ pub(crate) fn infer_github_host(owner: &str) -> String {
 /// Always uses the `gh` binary and sets `GH_HOST` to the provided host
 /// so authentication targets the correct server. This ensures deterministic
 /// host selection even when the parent process has `GH_HOST` set.
-pub fn gh_cli_command(host: &str) -> Command {
+pub(crate) fn gh_cli_command(host: &str) -> Command {
     let mut cmd = Command::new("gh");
     cmd.env("GH_HOST", host);
     cmd

--- a/src/merge_judge.rs
+++ b/src/merge_judge.rs
@@ -20,7 +20,7 @@ use crate::github;
 use crate::labels;
 
 /// Default confidence threshold (1-10). Only merge when confidence >= this.
-pub const DEFAULT_CONFIDENCE_THRESHOLD: u8 = 8;
+pub(crate) const DEFAULT_CONFIDENCE_THRESHOLD: u8 = 8;
 
 /// Maximum consecutive wait responses before the judge must decide merge or escalate.
 const MAX_CONSECUTIVE_WAITS: u32 = 3;
@@ -33,7 +33,7 @@ const NEEDS_HUMAN_REVIEW_LABEL: &str = labels::NEEDS_HUMAN_REVIEW;
 
 /// Action the judge can take.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum JudgeAction {
+pub(crate) enum JudgeAction {
     /// All feedback genuinely addressed — proceed with merge.
     Merge,
     /// Not confident yet — re-evaluate after the given duration.
@@ -54,7 +54,7 @@ struct JudgeResponseRaw {
 
 /// Parsed judge response with typed action.
 #[derive(Debug, Clone)]
-pub struct JudgeResponse {
+pub(crate) struct JudgeResponse {
     pub confidence: u8,
     pub action: JudgeAction,
     pub reasoning: String,
@@ -62,14 +62,14 @@ pub struct JudgeResponse {
 
 /// Fingerprint of PR state used to avoid redundant judge invocations.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PrStateFingerprint {
+pub(crate) struct PrStateFingerprint {
     pub head_sha: String,
     pub comment_count: usize,
 }
 
 /// Tracks the judge's state across poll iterations.
 #[derive(Debug)]
-pub struct JudgeState {
+pub(crate) struct JudgeState {
     /// Last PR state we evaluated.
     last_fingerprint: Option<PrStateFingerprint>,
     /// Number of consecutive "wait" responses with no state change.
@@ -81,7 +81,7 @@ pub struct JudgeState {
 }
 
 impl JudgeState {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             last_fingerprint: None,
             consecutive_waits: 0,
@@ -91,7 +91,7 @@ impl JudgeState {
     }
 
     /// Returns true if the judge should be invoked for the given PR state.
-    pub fn should_invoke(&self, fingerprint: &PrStateFingerprint) -> bool {
+    pub(crate) fn should_invoke(&self, fingerprint: &PrStateFingerprint) -> bool {
         // If PR state changed, always re-invoke.
         if self.last_fingerprint.as_ref() != Some(fingerprint) {
             return true;
@@ -107,7 +107,11 @@ impl JudgeState {
     }
 
     /// Record the judge's response and update internal state.
-    pub fn record_response(&mut self, fingerprint: PrStateFingerprint, response: &JudgeResponse) {
+    pub(crate) fn record_response(
+        &mut self,
+        fingerprint: PrStateFingerprint,
+        response: &JudgeResponse,
+    ) {
         let state_changed = self.last_fingerprint.as_ref() != Some(&fingerprint);
 
         if state_changed {
@@ -139,23 +143,23 @@ impl JudgeState {
     }
 
     /// Returns the number of consecutive waits with no state change.
-    pub fn consecutive_waits(&self) -> u32 {
+    pub(crate) fn consecutive_waits(&self) -> u32 {
         self.consecutive_waits
     }
 
     /// Mark that the escalation label was successfully applied.
-    pub fn mark_label_applied(&mut self) {
+    pub(crate) fn mark_label_applied(&mut self) {
         self.label_applied = true;
     }
 
     /// Returns true if the label was previously applied by the judge.
-    pub fn label_was_applied(&self) -> bool {
+    pub(crate) fn label_was_applied(&self) -> bool {
         self.label_applied
     }
 
     /// Note that `gru:needs-human-review` was cleared by a human.
     /// Only has effect if the label was previously applied.
-    pub fn mark_escalation_cleared(&mut self) {
+    pub(crate) fn mark_escalation_cleared(&mut self) {
         if self.label_applied {
             self.label_applied = false;
             // Reset fingerprint so the judge re-evaluates on next check.
@@ -166,7 +170,7 @@ impl JudgeState {
 
 /// Lightweight fingerprint fetch — only head SHA + comment counts.
 /// Used to check `should_invoke` before fetching full context.
-pub async fn get_pr_fingerprint(
+pub(crate) async fn get_pr_fingerprint(
     host: &str,
     owner: &str,
     repo: &str,
@@ -547,7 +551,7 @@ fn extract_json(text: &str) -> Option<&str> {
 /// 3. Builds the judge prompt and invokes the LLM
 /// 4. Enforces max consecutive waits (coerces to escalate)
 /// 5. Returns the response
-pub async fn evaluate(
+pub(crate) async fn evaluate(
     host: &str,
     owner: &str,
     repo: &str,
@@ -611,7 +615,7 @@ pub async fn evaluate(
 }
 
 /// Apply the `gru:needs-human-review` label to a PR.
-pub async fn add_needs_human_review_label(
+pub(crate) async fn add_needs_human_review_label(
     host: &str,
     owner: &str,
     repo: &str,
@@ -636,7 +640,11 @@ pub async fn add_needs_human_review_label(
 }
 
 /// Ensure the `gru:needs-human-review` label exists in the repository.
-pub async fn ensure_needs_human_review_label(host: &str, owner: &str, repo: &str) -> Result<()> {
+pub(crate) async fn ensure_needs_human_review_label(
+    host: &str,
+    owner: &str,
+    repo: &str,
+) -> Result<()> {
     let (color, description) = labels::get_label_info(NEEDS_HUMAN_REVIEW_LABEL)
         .expect("NEEDS_HUMAN_REVIEW must be in ALL_LABELS");
     let repo_full = github::repo_slug(owner, repo);
@@ -679,7 +687,7 @@ pub async fn ensure_needs_human_review_label(host: &str, owner: &str, repo: &str
 ///
 /// Returns `Err` on API failures — the caller should treat errors
 /// conservatively (do not proceed with merge if the check fails).
-pub async fn has_needs_human_review_label(
+pub(crate) async fn has_needs_human_review_label(
     host: &str,
     owner: &str,
     repo: &str,
@@ -701,7 +709,7 @@ pub async fn has_needs_human_review_label(
 }
 
 /// Post an escalation comment explaining why the judge escalated.
-pub async fn post_judge_escalation_comment(
+pub(crate) async fn post_judge_escalation_comment(
     host: &str,
     owner: &str,
     repo: &str,

--- a/src/merge_readiness.rs
+++ b/src/merge_readiness.rs
@@ -25,7 +25,7 @@ const MAX_DELAY_SECS: u64 = 60;
 /// Each field represents one prerequisite for merging. The PR is ready
 /// to merge only when all fields are `true`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MergeReadiness {
+pub(crate) struct MergeReadiness {
     /// PR is not a draft.
     pub not_draft: bool,
     /// All CI check runs passed (success, skipped, or neutral), none pending/in-progress.
@@ -81,7 +81,7 @@ impl fmt::Display for MergeReadiness {
 ///
 /// This is a pure query function — it reads GitHub state and returns a
 /// deterministic result. Same API state always produces the same output.
-pub async fn check_merge_readiness(
+pub(crate) async fn check_merge_readiness(
     host: &str,
     owner: &str,
     repo: &str,

--- a/src/minion_resolver.rs
+++ b/src/minion_resolver.rs
@@ -15,7 +15,7 @@ static ISSUE_LINK_REGEX: Lazy<Regex> = Lazy::new(|| {
 
 /// Information about a resolved Minion worktree
 #[derive(Debug, Clone)]
-pub struct MinionInfo {
+pub(crate) struct MinionInfo {
     pub minion_id: String,
     pub issue_number: Option<u64>,
     #[allow(dead_code)]
@@ -55,7 +55,7 @@ impl MinionInfo {
 /// 2. Try with M prefix (e.g., 12 -> M12)
 /// 3. Parse as number, search local minions by issue number
 /// 4. Fallback to GitHub API for PRs (if online)
-pub async fn resolve_minion(id: &str) -> Result<MinionInfo> {
+pub(crate) async fn resolve_minion(id: &str) -> Result<MinionInfo> {
     // Load minions from registry (primary source, consistent with gru status).
     // Returns empty vec on error — registry is best-effort, errors logged at debug level.
     let registry_minions = tokio::task::spawn_blocking(load_from_registry)
@@ -223,7 +223,7 @@ fn find_by_issue_number_from_list(issue_num: u64, minions: &[MinionInfo]) -> Opt
 }
 
 /// Scans all minion worktrees and returns MinionInfo structs
-pub fn scan_all_minions() -> Result<Vec<MinionInfo>> {
+pub(crate) fn scan_all_minions() -> Result<Vec<MinionInfo>> {
     let workspace = workspace::Workspace::new().context("Failed to initialize workspace")?;
     let work_path = workspace.work();
 

--- a/src/pr_monitor.rs
+++ b/src/pr_monitor.rs
@@ -150,7 +150,7 @@ pub(crate) struct User {
 
 /// A review comment with file location and content
 #[derive(Debug, Clone)]
-pub struct ReviewComment {
+pub(crate) struct ReviewComment {
     pub file: String,
     pub line: Option<u64>,
     pub body: String,
@@ -201,7 +201,7 @@ const READY_TO_MERGE_LABEL: &str = labels::READY_TO_MERGE;
 const AUTO_MERGE_LABEL: &str = labels::AUTO_MERGE;
 
 /// Ensure the `gru:ready-to-merge` label exists in the repository, creating it if needed.
-pub async fn ensure_ready_to_merge_label(host: &str, owner: &str, repo: &str) -> Result<()> {
+pub(crate) async fn ensure_ready_to_merge_label(host: &str, owner: &str, repo: &str) -> Result<()> {
     let (color, description) =
         labels::get_label_info(READY_TO_MERGE_LABEL).expect("READY_TO_MERGE must be in ALL_LABELS");
     let repo_full = github::repo_slug(owner, repo);
@@ -291,7 +291,7 @@ async fn has_auto_merge_label(
 }
 
 /// Ensure the `gru:auto-merge` label exists in the repository, creating it if needed.
-pub async fn ensure_auto_merge_label(host: &str, owner: &str, repo: &str) -> Result<()> {
+pub(crate) async fn ensure_auto_merge_label(host: &str, owner: &str, repo: &str) -> Result<()> {
     let (color, description) =
         labels::get_label_info(AUTO_MERGE_LABEL).expect("AUTO_MERGE must be in ALL_LABELS");
     let repo_full = github::repo_slug(owner, repo);
@@ -334,7 +334,7 @@ pub async fn ensure_auto_merge_label(host: &str, owner: &str, repo: &str) -> Res
 }
 
 /// Add the `gru:auto-merge` label to a PR.
-pub async fn add_auto_merge_label(
+pub(crate) async fn add_auto_merge_label(
     host: &str,
     owner: &str,
     repo: &str,
@@ -495,7 +495,7 @@ struct CheckRunsResponse {
 /// should pass this value as `baseline` on the next invocation so that:
 /// - Already-handled reviews are not re-fetched.
 /// - Reviews posted during event handling (rebase, review response) are caught.
-pub async fn monitor_pr(
+pub(crate) async fn monitor_pr(
     host: &str,
     owner: &str,
     repo: &str,
@@ -651,7 +651,7 @@ async fn poll_once(
 
 /// Result of monitoring a PR
 #[derive(Debug)]
-pub enum MonitorResult {
+pub(crate) enum MonitorResult {
     /// PR was successfully merged
     Merged,
     /// PR was closed without merging
@@ -769,7 +769,7 @@ async fn get_review_comments(
 }
 
 /// Format review comments into a prompt for Claude
-pub fn format_review_prompt(
+pub(crate) fn format_review_prompt(
     issue_num: u64,
     pr_number: &str,
     comments: &[ReviewComment],

--- a/src/prompt_loader.rs
+++ b/src/prompt_loader.rs
@@ -28,7 +28,7 @@ use crate::reserved_commands;
 /// built-in with the same name has non-empty `content`, it is inserted and
 /// will shadow the global prompt. A global prompt therefore only takes effect
 /// when there is no corresponding built-in with content for that name.
-pub const BUILT_IN_PROMPTS: &[BuiltInPrompt] = &[
+pub(crate) const BUILT_IN_PROMPTS: &[BuiltInPrompt] = &[
     BuiltInPrompt {
         name: "do",
         description: "Work on a GitHub issue with tests and PR",
@@ -242,7 +242,7 @@ After resolving each conflict:
 
 /// A built-in prompt definition compiled into the binary
 #[derive(Debug)]
-pub struct BuiltInPrompt {
+pub(crate) struct BuiltInPrompt {
     pub name: &'static str,
     pub description: &'static str,
     pub requires: &'static [&'static str],
@@ -252,7 +252,7 @@ pub struct BuiltInPrompt {
 impl BuiltInPrompt {
     /// Converts this built-in definition into a `Prompt` struct.
     /// Returns `None` if the built-in has no content (placeholder for future implementation).
-    pub fn to_prompt(&self) -> Option<Prompt> {
+    pub(crate) fn to_prompt(&self) -> Option<Prompt> {
         if self.content.trim().is_empty() {
             return None;
         }
@@ -270,7 +270,7 @@ impl BuiltInPrompt {
 }
 
 /// Prompts grouped by their source, for display in `gru prompts`
-pub struct PromptsBySource {
+pub(crate) struct PromptsBySource {
     pub built_in: Vec<(String, String)>,
     pub repo: Vec<Prompt>,
     pub global: Vec<Prompt>,
@@ -278,7 +278,7 @@ pub struct PromptsBySource {
 
 /// Metadata for a prompt file, parsed from YAML frontmatter
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct PromptMetadata {
+pub(crate) struct PromptMetadata {
     /// Short description of what the prompt does
     pub description: Option<String>,
 
@@ -293,7 +293,7 @@ pub struct PromptMetadata {
 
 /// Definition of a prompt parameter
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct PromptParam {
+pub(crate) struct PromptParam {
     /// Parameter name
     pub name: String,
 
@@ -307,7 +307,7 @@ pub struct PromptParam {
 
 /// A loaded prompt with metadata and content
 #[derive(Debug, Clone)]
-pub struct Prompt {
+pub(crate) struct Prompt {
     /// Name of the prompt (filename without .md extension)
     pub name: String,
 
@@ -323,7 +323,7 @@ pub struct Prompt {
 
 /// Location where a prompt was loaded from
 #[derive(Debug, Clone, PartialEq)]
-pub enum PromptSource {
+pub(crate) enum PromptSource {
     /// Repo-specific prompt (.gru/prompts/)
     Repo(PathBuf),
 
@@ -341,7 +341,7 @@ impl PromptSource {
     /// - Repo: `.gru/prompts/<filename>`
     /// - Built-in: `built-in`
     /// - Global: `~/.gru/prompts/<filename>`
-    pub fn display(&self) -> String {
+    pub(crate) fn display(&self) -> String {
         match self {
             PromptSource::Repo(path) => {
                 let filename = path
@@ -475,7 +475,7 @@ fn scan_prompt_directory(dir: &Path) -> Result<HashMap<String, PathBuf>> {
 /// correct priority while being efficient (no need to check existence before insert).
 ///
 /// Reserved system commands are validated separately and never loaded.
-pub fn load_prompts(repo_root: Option<&Path>) -> Result<HashMap<String, Prompt>> {
+pub(crate) fn load_prompts(repo_root: Option<&Path>) -> Result<HashMap<String, Prompt>> {
     load_prompts_internal(repo_root, dirs::home_dir().as_deref())
 }
 
@@ -561,7 +561,7 @@ fn load_prompts_internal(
 /// prompt count grows significantly.
 ///
 /// Returns `None` if no prompt with that name exists (neither built-in nor custom).
-pub fn resolve_prompt(name: &str, repo_root: Option<&Path>) -> Result<Option<Prompt>> {
+pub(crate) fn resolve_prompt(name: &str, repo_root: Option<&Path>) -> Result<Option<Prompt>> {
     let mut prompts = load_prompts(repo_root)?;
 
     let prompt = prompts.remove(name);
@@ -621,7 +621,7 @@ fn collect_missing_params<'a>(
 /// validate_required_params(&metadata, &provided)?;
 /// ```
 #[cfg_attr(not(test), allow(dead_code))]
-pub fn validate_required_params(
+pub(crate) fn validate_required_params(
     metadata: &PromptMetadata,
     provided: &HashMap<String, String>,
 ) -> Result<()> {
@@ -648,7 +648,7 @@ pub fn validate_required_params(
 ///
 /// Unlike `load_prompts()` which merges by priority, this function returns
 /// prompts in separate collections for display in `gru prompts`.
-pub fn list_prompts_by_source(repo_root: Option<&Path>) -> Result<PromptsBySource> {
+pub(crate) fn list_prompts_by_source(repo_root: Option<&Path>) -> Result<PromptsBySource> {
     list_prompts_by_source_internal(repo_root, dirs::home_dir().as_deref())
 }
 
@@ -727,7 +727,7 @@ const KNOWN_REQUIREMENTS: &[&str] = &["issue", "pr"];
 ///
 /// # Returns
 /// A list of (requirement_name, flag_hint) pairs for any missing requirements
-pub fn validate_requires(
+pub(crate) fn validate_requires(
     requires: &[String],
     issue_provided: bool,
     pr_provided: bool,
@@ -769,7 +769,7 @@ pub fn validate_requires(
 /// * `issue_provided` - Whether `--issue` was provided
 /// * `pr_provided` - Whether `--pr` was provided
 /// * `provided_params` - The parameters provided via `--param` flags
-pub fn validate_prompt_requirements(
+pub(crate) fn validate_prompt_requirements(
     prompt_name: &str,
     metadata: &PromptMetadata,
     issue_provided: bool,
@@ -808,7 +808,7 @@ pub fn validate_prompt_requirements(
 /// Currently checks:
 /// - Prompt content is not empty
 /// - Parameter names are valid identifiers
-pub fn validate_prompt(prompt: &Prompt) -> Result<()> {
+pub(crate) fn validate_prompt(prompt: &Prompt) -> Result<()> {
     // Check content is not empty
     if prompt.content.trim().is_empty() {
         bail!("Prompt '{}' has empty content", prompt.name);

--- a/src/worktree_scanner.rs
+++ b/src/worktree_scanner.rs
@@ -6,7 +6,7 @@ use tokio::process::Command;
 
 /// Represents a discovered worktree
 #[derive(Debug, Clone)]
-pub struct Worktree {
+pub(crate) struct Worktree {
     /// Path to the worktree directory
     pub path: PathBuf,
     /// Branch name associated with this worktree
@@ -21,7 +21,7 @@ pub struct Worktree {
 
 /// Status of a worktree indicating whether it can be cleaned
 #[derive(Debug, PartialEq)]
-pub enum WorktreeStatus {
+pub(crate) enum WorktreeStatus {
     /// Branch has no unmerged commits relative to the base branch (either fully
     /// merged or freshly created with no new commits yet)
     Merged,
@@ -268,7 +268,7 @@ impl Worktree {
 }
 
 /// Discover all worktrees in the given repos directory
-pub async fn discover_worktrees(repos_dir: &Path) -> Result<Vec<Worktree>> {
+pub(crate) async fn discover_worktrees(repos_dir: &Path) -> Result<Vec<Worktree>> {
     let mut worktrees = Vec::new();
 
     if !repos_dir.exists() {


### PR DESCRIPTION
## Summary
- Narrow `pub` to `pub(crate)` across 10 modules in the binary crate where items have no downstream consumers
- Files changed: `github.rs`, `agent_runner.rs`, `minion_resolver.rs`, `commands/init.rs`, `merge_judge.rs`, `pr_monitor.rs`, `prompt_loader.rs`, `worktree_scanner.rs`, `merge_readiness.rs`, `dependencies.rs`
- Mechanical change with zero behavior impact — only visibility modifiers changed

## Test plan
- `just check` passes (format + lint + test + build)
- All 970 tests pass
- No behavior changes — purely cosmetic visibility narrowing

## Notes
- Some lines were reformatted by `cargo fmt` where the longer `pub(crate)` keyword pushed function signatures past the line width limit
- Ref: plans/CQIP_2026-03-17.md Section 3.4, Phase 2 item 18

Fixes #551

<sub>🤖 M11k</sub>