### PR TITLE
Fixes #546: Fix pr_monitor.rs phantom helper tests

### DIFF
--- a/src/pr_monitor.rs
+++ b/src/pr_monitor.rs
@@ -569,7 +569,9 @@ pub(crate) fn determine_pr_terminal_state(state: &str, merged: bool) -> Option<M
 /// other than the PR author.
 ///
 /// This excludes self-reviews (to prevent feedback loops) and old reviews
-/// (already processed in a previous poll cycle).
+/// (already processed in a previous poll cycle). Uses inclusive `>=` so that
+/// a review landing exactly at `since` is captured; contrast with
+/// `count_unaddressed_reviews` which uses exclusive `>` for a different purpose.
 pub(crate) fn filter_new_external_reviews(
     reviews: &[Review],
     since: DateTime<Utc>,
@@ -1492,6 +1494,9 @@ mod tests {
             id,
             submitted_at: timestamp.parse().unwrap(),
             user: User {
+                // Timestamp-only tests pass pr_author="not-reviewer" so this
+                // login must differ from that sentinel to keep the author
+                // filter a no-op.
                 login: "reviewer".to_string(),
             },
         }


### PR DESCRIPTION
## Summary
- Extracted `determine_pr_terminal_state` and `filter_new_external_reviews` as `pub(crate)` production functions in `pr_monitor.rs`
- Updated `poll_once` to use the extracted functions instead of inline logic, simplifying the review-filtering path from two passes (`.any()` + `.filter()`) to one
- Added `Clone` derive to `Review` and `User` structs to support the new `&[Review]` → `Vec<Review>` filtering API
- Redirected all ~11 phantom tests to call the real production functions instead of test-only re-implementations
- Deleted 3 phantom helper functions that duplicated production logic inside `#[cfg(test)]`

## Test plan
- All 970 tests pass: `just test`
- Full check suite passes: `just lint`, `just fmt-check`
- Pre-commit hooks pass (format + clippy + tests)

## Notes
- The `filter_reviews_since` phantom (timestamp-only filter) had no production equivalent, so its 5 tests were rewritten to exercise `filter_new_external_reviews` with a non-matching `pr_author` to isolate timestamp behavior
- `count_unaddressed_reviews` (line 843) intentionally uses `>` (strict) rather than `>=` — this is a separate function with different semantics and was not changed

Fixes #546

<sub>🤖 M11m</sub>