### PR TITLE
Fixes #602: CI escalation comment code blocks are indented, breaking GitHub markdown

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -697,7 +697,7 @@ pub async fn post_escalation_comment(
 
         if let Some(output) = &check.output {
             let truncated = safe_tail(output, 2000);
-            body.push_str(&format!("  ```\n  {}\n  ```\n", truncated));
+            body.push_str(&format!("```\n{}\n```\n", truncated));
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove 2-space indentation from code fence markers and content in `post_escalation_comment` (`src/ci.rs:700`)
- GitHub markdown requires code fences to start at column 0 (or be part of a recognized indented block); the indented fences were rendering as plain text

## Test plan
- `just check` passes (format, lint, 970 tests, build)
- Verified the format string now produces unindented triple-backtick fences

## Notes
- One-line change in `src/ci.rs`
- The list item (`- **name** — ...`) before the code block is unaffected; GitHub renders the code block correctly after a list item when fences are at column 0

Fixes #602

<sub>🤖 M11r</sub>