### PR TITLE
Fixes #629: Fix fragile test assertions: format strings, exact equality, negative-only checks

### DIFF
--- a/src/progress_comments.rs
+++ b/src/progress_comments.rs
@@ -128,6 +128,10 @@ mod tests {
         assert!(comment.contains("## 🚨 CI Fix Escalation"));
         assert!(comment.contains("Something went wrong."));
         assert!(comment.contains("<sub>🤖 M042</sub>"));
+        // Detail appears before signature (structural ordering)
+        let detail_pos = comment.find("Something went wrong.").unwrap();
+        let sig_pos = comment.find("<sub>🤖 M042</sub>").unwrap();
+        assert!(detail_pos < sig_pos);
         // Trailing newline in detail is trimmed so the signature lands cleanly
         assert!(!comment.contains("Something went wrong.\n\n\n"));
     }
@@ -139,6 +143,10 @@ mod tests {
         assert!(comment.contains("## 🚨 Minion Escalation"));
         assert!(comment.contains("Rebase failed."));
         assert!(comment.contains("<sub>🤖 M001</sub>"));
+        // Detail appears before signature (structural ordering)
+        let detail_pos = comment.find("Rebase failed.").unwrap();
+        let sig_pos = comment.find("<sub>🤖 M001</sub>").unwrap();
+        assert!(detail_pos < sig_pos);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace `assert_eq!` against full rendered strings with structural `contains()` checks in `progress_comments.rs` escalation tests, including `<sub>` tag verification (T12)
- Keep exact `assert_eq!(prompt, "/do 42")` in `test_build_fix_prompt_without_details` since the `details: None` path is a deterministic early return (T13 — reverted after code review)
- Confirmed `test_build_fix_prompt_uses_template_variables` already has positive assertions for substituted values (T14 — no changes needed)
- Keep `backend.name()` assertion in `test_resolve_claude` since `name()` is a public trait contract and maintains symmetry with `test_resolve_codex` (T15 — reverted after code review)

## Test plan
- `just check` passes (fmt, clippy, 948 tests, build)
- All modified tests verify structural properties without coupling to exact format strings

## Notes
- T13 and T15 were initially loosened but restored after code review found the original assertions were testing deterministic/public contracts, not fragile format strings
- T14 already had positive assertions so no code change was needed

Fixes #629

<sub>🤖 M12y</sub>