### PR TITLE
Fixes #648: Review minions lack role guardrails — respond to third-party comments as fixer

### DIFF
--- a/src/prompt_loader.rs
+++ b/src/prompt_loader.rs
@@ -129,11 +129,11 @@ URL: https://github.com/{{ repo_owner }}/{{ repo_name }}/pull/{{ pr_number }}
 
 # Instructions
 
-Review this pull request: fetch details, analyze changes, and provide code review feedback.
+**You are a CODE REVIEWER.** Your ONLY job is to analyze the code changes and submit your own review. You must NOT reply to, address, or fix existing review comments from other reviewers or tools (e.g., Copilot, other bots, or human reviewers). Do NOT post "Fixed", "Addressed", or similar responses to any existing comments. Do NOT push code changes.
 
 ## 1. Fetch PR Details
 - The PR title, description, and URL are provided above. Use `gh pr view {{ pr_number }} --repo {{ repo_owner }}/{{ repo_name }} --json files,author,closingIssuesReferences --jq '{author: .author.login, files: [.files[].path], closingIssues: [.closingIssuesReferences[].number]}'` to get changed files, author, and issues this PR closes in a single call.
-- Fetch existing review comments: `gh api --paginate repos/{{ repo_owner }}/{{ repo_name }}/pulls/{{ pr_number }}/comments`
+- Fetch existing review comments for context only: `gh api --paginate repos/{{ repo_owner }}/{{ repo_name }}/pulls/{{ pr_number }}/comments` — these are for understanding prior discussion. Do NOT respond to, act on, or fix any of these comments. They belong to other reviewers.
 - Understand the scope and intent of the PR, and any prior discussion
 - The code should already be checked out in the current directory
 - If this PR is addressing an Issue, read Issue details to understand the problem and context. Does this PR address the issue completely? Are there any missing details or assumptions?
@@ -155,6 +155,7 @@ Review this pull request: fetch details, analyze changes, and provide code revie
 - List any issues found (bugs, security concerns, style problems)
 - Suggest improvements if applicable
 - Give an overall assessment (approve, request changes, or needs discussion)
+- Your feedback should be your OWN independent review — do not duplicate or respond to points already raised by other reviewers
 
 ## 4. Submit Review
 - BEFORE submitting: Check if this is your own PR:


### PR DESCRIPTION
## Summary
- Added explicit role framing to the built-in review prompt: "You are a CODE REVIEWER" with clear prohibitions against replying to, addressing, or fixing existing review comments from other reviewers or tools
- Reframed the "Fetch existing review comments" step as context-only with instruction not to respond to them
- Added guidance in the feedback section to provide independent review without duplicating other reviewers' points

## Test plan
- All 950 tests pass (`just test`)
- Clippy clean (`just lint`)
- Formatting clean (`just fmt-check`)
- Verified the review prompt content in `test_builtin_review_prompt_has_content` and `test_build_review_prompt_with_details` tests still pass

## Notes
- The fix is prompt-only — no code logic changes, just updated the review prompt text in `src/prompt_loader.rs`
- The `/pr_review` slash command already has tool restrictions (`allowed-tools`); this fix addresses the autonomous review path which uses the built-in review prompt
- Tool restrictions for autonomous review minions (matching `/pr_review`'s `Bash(gh:*), Read, Glob, Grep` limits) could be a follow-up enhancement but are not strictly needed since the prompt guardrails address the observed behavior

Fixes #648

<sub>🤖 M134</sub>