### PR TITLE
Fixes #626: Add #[ignore] to 6 live-network unit tests

### DIFF
--- a/src/commands/fix/pr.rs
+++ b/src/commands/fix/pr.rs
@@ -420,6 +420,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[ignore]
     async fn test_is_branch_pushed_nonexistent() {
         // Test with a nonexistent branch — gh api should return 404 → Ok(false)
         let result = is_branch_pushed(
@@ -447,6 +448,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn test_get_pr_number_state_all_nonexistent_branch() {
         // A branch that has never had a PR should return Ok(None)
         let result = crate::ci::get_pr_number(


### PR DESCRIPTION
## Summary
- Add `#[ignore]` to 2 live-network tests in `src/commands/fix/pr.rs`: `test_is_branch_pushed_nonexistent` and `test_get_pr_number_state_all_nonexistent_branch`
- The 4 tests in `src/github.rs` already had `#[ignore]` applied

## Test plan
- `just test` passes (948 tests, 8 skipped) with no live network calls
- Ignored tests can still be run with `cargo test -- --ignored`

## Notes
- Only 2 of the 6 tests listed in the issue needed changes; the other 4 in `src/github.rs` were already annotated with `#[ignore]`

Fixes #626

<sub>🤖 M139</sub>