### PR TITLE
Fixes #625: Delete 11 trivial/zero-signal unit tests

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -1526,12 +1526,6 @@ mod tests {
         assert_eq!(host_for_repo(&config, "other/repo"), None);
     }
 
-    #[test]
-    fn test_max_resume_attempts_default() {
-        let config = LabConfig::default();
-        assert_eq!(config.daemon.max_resume_attempts, 3);
-    }
-
     #[tokio::test]
     async fn test_reap_children_removes_exited_process() {
         // Spawn a process that exits immediately with code 1

--- a/src/config.rs
+++ b/src/config.rs
@@ -596,11 +596,6 @@ max_resume_attempts = 5
     }
 
     #[test]
-    fn test_default_max_resume_attempts_constant() {
-        assert_eq!(DEFAULT_MAX_RESUME_ATTEMPTS, 3);
-    }
-
-    #[test]
     fn test_validate_zero_max_resume_attempts() {
         let mut config = LabConfig::default();
         config.daemon.repos = vec!["owner/repo".to_string()];

--- a/src/merge_readiness.rs
+++ b/src/merge_readiness.rs
@@ -993,39 +993,4 @@ mod tests {
         };
         assert!(mr.failure_reasons().is_empty());
     }
-
-    // --- mergeable field edge cases ---
-
-    #[test]
-    fn test_mergeable_null_treated_as_not_ready() {
-        let pr = PrDetails {
-            head_sha: "abc123".into(),
-            draft: false,
-            mergeable: None,
-            author_login: "author".into(),
-        };
-        assert!(pr.mergeable != Some(true));
-    }
-
-    #[test]
-    fn test_mergeable_false_treated_as_not_ready() {
-        let pr = PrDetails {
-            head_sha: "abc123".into(),
-            draft: false,
-            mergeable: Some(false),
-            author_login: "author".into(),
-        };
-        assert!(pr.mergeable != Some(true));
-    }
-
-    #[test]
-    fn test_mergeable_true_is_ready() {
-        let pr = PrDetails {
-            head_sha: "abc123".into(),
-            draft: false,
-            mergeable: Some(true),
-            author_login: "author".into(),
-        };
-        assert!(pr.mergeable == Some(true));
-    }
 }

--- a/src/pr_monitor.rs
+++ b/src/pr_monitor.rs
@@ -1697,57 +1697,6 @@ mod tests {
     }
 
     // ========================================================================
-    // MonitorResult::Timeout Tests
-    // ========================================================================
-
-    #[test]
-    fn test_timeout_variant() {
-        let result = MonitorResult::Timeout;
-        assert!(matches!(result, MonitorResult::Timeout));
-    }
-
-    #[test]
-    fn test_timeout_variant_debug_format() {
-        let result = MonitorResult::Timeout;
-        let debug = format!("{:?}", result);
-        assert!(debug.contains("Timeout"));
-    }
-
-    // ========================================================================
-    // MonitorResult::Interrupted Tests
-    // ========================================================================
-
-    #[test]
-    fn test_interrupted_variant() {
-        let result = MonitorResult::Interrupted;
-        assert!(matches!(result, MonitorResult::Interrupted));
-    }
-
-    #[test]
-    fn test_interrupted_variant_debug_format() {
-        let result = MonitorResult::Interrupted;
-        let debug = format!("{:?}", result);
-        assert!(debug.contains("Interrupted"));
-    }
-
-    // ========================================================================
-    // MonitorResult::MergeConflict Tests
-    // ========================================================================
-
-    #[test]
-    fn test_merge_conflict_variant() {
-        let result = MonitorResult::MergeConflict;
-        assert!(matches!(result, MonitorResult::MergeConflict));
-    }
-
-    #[test]
-    fn test_merge_conflict_variant_debug_format() {
-        let result = MonitorResult::MergeConflict;
-        let debug = format!("{:?}", result);
-        assert!(debug.contains("MergeConflict"));
-    }
-
-    // ========================================================================
     // PullRequest Mergeable Field Tests
     // ========================================================================
 


### PR DESCRIPTION
## Summary
- Deleted 11 trivial zero-signal unit tests across 4 files (the issue listed 10; 2 additional same-category tests were identified during implementation)
- `pr_monitor.rs`: removed 6 variant-only and debug-format tests that only assert enum variants exist or that `#[derive(Debug)]` works
- `config.rs`: removed 1 test asserting a constant equals itself
- `commands/lab.rs`: removed 1 test asserting a default equals the constant it's derived from
- `merge_readiness.rs`: removed 3 tests that only compare struct fields without exercising any logic

## Test plan
- `just check` passes (format + lint + 939 tests + build)
- No behavioral coverage regression — all deleted tests asserted Rust type-system guarantees or constant identity

## Notes
- The issue listed 10 tests but we also removed `test_interrupted_variant_debug_format` and `test_merge_conflict_variant_debug_format` from pr_monitor.rs which are the same category of zero-signal test (asserting `#[derive(Debug)]` output)
- CQIP 2026-03-20 items T1–T4, Phase 1

Fixes #625

<sub>🤖 M13a</sub>