### PR TITLE
Fixes #654: Fix self-review prompt: force synchronous execution and correct tool reference

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -60,7 +60,8 @@ Gru will handle:
 
 ## 5. Code Review
 - Make a commit with the changes, prefixing the commit message with your Minion ID (from the branch name), e.g. `[M042] Fix null pointer in parser`
-- Use the Task tool with `subagent_type='code-reviewer'` to perform an autonomous code review
+- Use the Agent tool with `subagent_type='code-reviewer'` to perform an autonomous code review
+- **Wait for the review agent to complete and read its full output before proceeding**
 - The code-reviewer agent will analyze the changes for:
   - Code correctness and logic errors
   - Security vulnerabilities
@@ -70,6 +71,7 @@ Gru will handle:
   - Test coverage
 - Address any issues raised by the code-reviewer before proceeding
 - If the review identifies significant problems, iterate on the implementation
+- **Do NOT push your branch or write PR_DESCRIPTION.md until you have read and addressed all review findings**
 
 ## 6. Finish Your Work
 

--- a/src/prompt_loader.rs
+++ b/src/prompt_loader.rs
@@ -69,7 +69,8 @@ URL: https://github.com/{{ repo_owner }}/{{ repo_name }}/issues/{{ issue_number 
 
 ## 4. Code Review
 - Make a commit with the changes, prefixing the commit message with your Minion ID, e.g. `[{{ minion_id }}] Fix null pointer in parser`
-- Use the Task tool with `subagent_type='code-reviewer'` to perform an autonomous code review
+- Use the Agent tool with `subagent_type='code-reviewer'` to perform an autonomous code review
+- **Wait for the review agent to complete and read its full output before proceeding**
 - The code-reviewer agent will analyze the changes for:
   - Code correctness and logic errors
   - Security vulnerabilities
@@ -79,6 +80,7 @@ URL: https://github.com/{{ repo_owner }}/{{ repo_name }}/issues/{{ issue_number 
   - Test coverage
 - Address any issues raised by the code-reviewer before proceeding
 - If the review identifies significant problems, iterate on the implementation
+- **Do NOT push your branch or write PR_DESCRIPTION.md until you have read and addressed all review findings**
 
 ## 5. Finish Your Work
 


### PR DESCRIPTION
## Summary
- Changed "Task tool" to "Agent tool" in the Code Review step of both the built-in prompt (`src/prompt_loader.rs`) and the slash command (`.claude/commands/do.md`) to match actual minion behavior (Task tool was used 0 times across 62 runs)
- Added explicit synchronous execution instruction: "Wait for the review agent to complete and read its full output before proceeding"
- Added checkpoint gate: "Do NOT push your branch or write PR_DESCRIPTION.md until you have read and addressed all review findings"

## Test plan
- All 954 tests pass (`just test`)
- Pre-commit hooks pass (fmt, clippy, tests)
- Verified both files are consistent with identical wording for the three changes

## Notes
- This is a prompt-only change — no Rust code logic changes
- Expected to improve effective review consumption from 55% to 90%+ based on issue #654 analysis
- The code reviewer noted that `decompose.md` also references "Task tool" — this is a separate command with a different agent type and could be addressed in a follow-up

Fixes #654

<sub>🤖 M13i</sub>