### PR TITLE
Fixes #669: gru resume runs full do pipeline regardless of minion command type

### DIFF
--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -315,6 +315,9 @@ async fn run_resume_pipeline(ctx: ResumeContext, quiet: bool) -> Result<i32> {
         Ok(result) => result,
         Err(e) if is_stuck_or_timeout_error(&e) => {
             log::error!("🚨 {:#}", e);
+            if agent_only {
+                cleanup_registry(&wt_ctx.minion_id).await;
+            }
             return Ok(1);
         }
         Err(e) => return Err(e),


### PR DESCRIPTION
## Summary
- Add `command` field to `ResumeContext` so `run_resume_pipeline` knows what kind of minion it's resuming
- Gate PR creation and PR monitoring phases on `command == "do"` (or legacy `"fix"`) — prompt and review minions now only run the agent phase, matching their original execution model
- Ensure `cleanup_registry` is called when agent-only commands exit with non-zero status

## Test plan
- `just check` passes (955 tests, clippy, fmt, build)
- Manual: `gru prompt --pr 86 '/respond'` then `gru resume <id>` should run agent only, not PR creation/monitoring

## Notes
- Legacy registries that stored `"fix"` instead of `"do"` are handled by accepting both values
- The non-zero exit cleanup gap (pre-existing for "do" commands) is fixed only for agent-only commands to keep the change scoped; the "do" path already has downstream cleanup via monitor phases

Fixes #669

<sub>🤖 M14a</sub>