### PR TITLE
Fixes #637: Split monitor_and_fix_ci and extract run_gh_parallel helper

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -891,7 +891,7 @@ pub(crate) async fn monitor_and_fix_ci(
         }
     }
 
-    // Should not reach here, but handle gracefully
+    // Reached when the fix attempt breaks the loop (e.g., git push failure).
     Ok(false)
 }
 

--- a/src/merge_judge.rs
+++ b/src/merge_judge.rs
@@ -189,7 +189,7 @@ async fn run_gh_parallel(host: &str, arg_sets: Vec<Vec<String>>) -> Result<Vec<S
 
     let mut results: Vec<Option<String>> = (0..count).map(|_| None).collect();
     while let Some(join_result) = set.join_next().await {
-        match join_result.context("gh task panicked")? {
+        match join_result.context("gh task failed (panic or cancellation)")? {
             Ok((idx, output)) => {
                 results[idx] = Some(output);
             }


### PR DESCRIPTION
## Summary
- Split `monitor_and_fix_ci` (~220 lines) into focused helper functions: `enrich_check_logs`, `escalate_timeout`, `escalate_checks_failed`, `escalate_exhaustion`, and `run_ci_fix_attempt`
- Introduced `CiFixLoopAction` enum for clear loop control signaling between the extracted function and the main loop
- Extracted `run_gh_parallel` helper in `merge_judge.rs` using `JoinSet` to replace 8 hand-rolled parallel `gh` call patterns in `get_pr_fingerprint` and `fetch_pr_context`
- `run_gh_parallel` preserves `try_join!` short-circuit semantics via `abort_all()` on first error

## Test plan
- All 955 existing tests pass (`just check` — format, lint, test, build)
- No behavioral changes — pure refactoring of internal structure
- Code review agent verified behavioral equivalence and identified the `try_join!` vs `JoinSet` cancellation difference, which was addressed with `abort_all()`

## Notes
- The `run_ci_fix_attempt` function has 10 parameters (with `#[allow(clippy::too_many_arguments)]`). A future PR could introduce a `CiContext` struct to group the common parameters (`host`, `owner`, `repo`, etc.) that are threaded through many functions in ci.rs
- CQIP 2026-03-20 items L4 + D6, Phase 4

Fixes #637

<sub>🤖 M14n</sub>