### PR TITLE
Fixes #699: Registry parse errors in finalize_pr should be non-fatal

### DIFF
--- a/src/commands/fix/pr.rs
+++ b/src/commands/fix/pr.rs
@@ -564,7 +564,7 @@ mod tests {
             owner: "test-owner".to_string(),
             repo: "test-repo".to_string(),
             host: "github.com".to_string(),
-            issue_num: 99999,
+            issue_num: Some(99999),
             details: None,
         };
 


### PR DESCRIPTION
## Summary
- Make the `with_registry` call in `finalize_pr` best-effort: log a warning on failure instead of propagating the error with `?`
- Make all three `finalize_pr` call sites in `handle_pr_creation` consistent — all now treat failures as non-fatal since the PR already exists on GitHub
- Add a test verifying `finalize_pr` returns `Ok` even when the registry update fails

## Test plan
- New test `test_finalize_pr_survives_registry_failure` exercises the failure path with a nonexistent minion ID
- `just check` passes (fmt, clippy, 956 tests, build)

## Notes
- Root cause: In the M14g incident, another minion wrote a newer schema to `minions.json` that the older binary couldn't parse, killing the worker after the PR was already created
- The `PrState::save` (local file write) still propagates errors since that's the restart-recovery mechanism, but even that is now caught at the call site level
- Matches the existing pattern used by `update_orchestration_phase` in `helpers.rs`

Fixes #699

<sub>🤖 M15j</sub>