### PR TITLE
Fixes #707: gru status: table columns misalign when content exceeds fixed width

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -123,10 +123,13 @@ const MAX_COL_WIDTH: usize = 40;
 
 /// Truncates a string to `max_width` characters, appending `…` if it exceeds the limit.
 fn truncate(s: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
     let char_count = s.chars().count();
     if char_count <= max_width {
         s.to_string()
-    } else if max_width <= 1 {
+    } else if max_width == 1 {
         "\u{2026}".to_string()
     } else {
         let cut: String = s.chars().take(max_width - 1).collect();
@@ -134,10 +137,10 @@ fn truncate(s: &str, max_width: usize) -> String {
     }
 }
 
-/// Returns the display width for a column: at least `min_width`, at most `MAX_COL_WIDTH`,
-/// and wide enough to fit the header and all values.
+/// Returns the character width for a column: at least `min_width`, at most `MAX_COL_WIDTH`,
+/// and wide enough to fit the header and all values (measured in characters).
 fn col_width(header: &str, values: impl Iterator<Item = usize>, min_width: usize) -> usize {
-    let data_max = values.fold(header.len(), max);
+    let data_max = values.fold(header.chars().count(), max);
     min(max(data_max, min_width), MAX_COL_WIDTH)
 }
 
@@ -684,6 +687,11 @@ mod tests {
     #[test]
     fn test_truncate_width_one() {
         assert_eq!(truncate("hello", 1), "\u{2026}");
+    }
+
+    #[test]
+    fn test_truncate_width_zero() {
+        assert_eq!(truncate("hello", 0), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace fixed-width format specifiers in `gru status` with dynamic column width calculation based on actual content
- Add truncation with `…` for columns exceeding 40 characters to prevent absurdly wide tables
- Extract `print_normal_table()` and `print_verbose_table()` from `handle_status` for cleaner separation
- Use char-based (not byte-based) width calculation and truncation for UTF-8 safety

## Test plan
- Added unit tests for `truncate()` (short, exact, over-width, multi-byte UTF-8, empty, width-one)
- Added unit tests for `col_width()` (header wider, data wider, capped at max, respects min width)
- All 965 existing tests pass (`cargo test`)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Notes
- `MAX_COL_WIDTH` is set to 40 chars — long repo names, branches, or mode strings get truncated with `…`
- TOKENS and PATH columns remain unbounded as the last column in their respective tables
- Both normal and verbose (`-v`) table formats use dynamic widths

Fixes #707

<sub>🤖 M15q</sub>