### PR TITLE
Fixes #720: Lab daemon resumed_this_session blocks re-resume of monitoring_pr minions

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -1158,7 +1158,7 @@ fn is_blocked_by_session_guard(
     phase: &OrchestrationPhase,
     resumed_this_session: &HashSet<String>,
 ) -> bool {
-    resumed_this_session.contains(minion_id) && *phase != OrchestrationPhase::MonitoringPr
+    resumed_this_session.contains(minion_id) && phase != &OrchestrationPhase::MonitoringPr
 }
 
 /// Resume interrupted minions, filling available slots before new issue claims.
@@ -1179,12 +1179,12 @@ async fn resume_interrupted_minions(
         .await?
         .into_iter()
         .filter(|c| {
-            let dominated = is_blocked_by_session_guard(
+            let blocked = is_blocked_by_session_guard(
                 &c.minion_id,
                 &c.info.orchestration_phase,
                 resumed_this_session,
             );
-            if dominated {
+            if blocked {
                 log::debug!(
                     "Skipping {} (issue #{}, {}): already resumed this session",
                     c.minion_id,
@@ -1192,7 +1192,7 @@ async fn resume_interrupted_minions(
                     c.info.repo,
                 );
             }
-            !dominated
+            !blocked
         })
         .collect();
     if resumable.is_empty() {


### PR DESCRIPTION
## Summary
- `MonitoringPr`-phase minions that die after being resumed are now re-resumed on subsequent poll cycles, up to the `max_attempts` limit
- Non-monitoring minions (`RunningAgent`, `CreatingPr`) retain the `resumed_this_session` guard to prevent rapid retry loops
- Extracted `is_blocked_by_session_guard()` as a named, testable predicate with doc comments explaining the design rationale
- Added test covering all three cases: MonitoringPr in set (allowed), RunningAgent in set (blocked), MonitoringPr not in set (allowed)

## Test plan
- `just check` passes (fmt, clippy, 956 tests, build)
- New test `test_monitoring_pr_minion_bypasses_resumed_this_session` exercises the production `is_blocked_by_session_guard` function directly

## Notes
- The `attempt_count > max_attempts` check in `should_resume_candidate` (incremented by `resume.rs` on every re-entry) remains the proper circuit breaker for crash-looping MonitoringPr minions
- Fixes #720

<sub>🤖 M16a</sub>