### PR TITLE
Fixes #721: Deduplicate PR/reviews/check-runs fetches in poll cycle

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -40,6 +40,17 @@ pub(crate) enum CheckStatus {
     Unknown,
 }
 
+impl fmt::Display for CheckStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CheckStatus::Queued => write!(f, "queued"),
+            CheckStatus::InProgress => write!(f, "in_progress"),
+            CheckStatus::Completed => write!(f, "completed"),
+            CheckStatus::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
 /// The conclusion of a completed check run
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/merge_readiness.rs
+++ b/src/merge_readiness.rs
@@ -1074,6 +1074,10 @@ mod tests {
 
     /// Helper to evaluate merge readiness from pre-fetched data synchronously
     /// (skips the combined_status API call by testing the pure evaluation functions).
+    ///
+    /// NOTE: This mirrors the logic in `check_merge_readiness_with_data` minus the
+    /// async `get_combined_status` call. If that function's evaluation logic changes,
+    /// update this helper to match.
     fn evaluate_from_prefetched(data: &PreFetchedData) -> MergeReadiness {
         if data.pr.draft {
             return MergeReadiness {

--- a/src/pr_monitor.rs
+++ b/src/pr_monitor.rs
@@ -536,19 +536,16 @@ async fn poll_once(
             })
             .collect(),
         // Convert ci::CheckRun to PreFetchedCheckRun strings matching the raw
-        // GitHub API format that evaluate_ci expects. Unknown conclusions become
-        // "unknown" (rejected by evaluate_ci), Unknown status becomes None
-        // (also rejected, since evaluate_ci requires status == "completed").
+        // GitHub API format that evaluate_ci expects. Uses Display impls on
+        // CheckConclusion/CheckStatus to stay in sync with serde rename_all.
+        // Unknown conclusions become "unknown" (rejected by evaluate_ci).
+        // Unknown status becomes "unknown" (also rejected, since evaluate_ci
+        // requires status == "completed").
         check_runs: check_runs
             .iter()
             .map(|cr| merge_readiness::PreFetchedCheckRun {
                 conclusion: cr.conclusion.as_ref().map(|c| c.to_string()),
-                status: match &cr.status {
-                    crate::ci::CheckStatus::Completed => Some("completed".to_string()),
-                    crate::ci::CheckStatus::InProgress => Some("in_progress".to_string()),
-                    crate::ci::CheckStatus::Queued => Some("queued".to_string()),
-                    crate::ci::CheckStatus::Unknown => None,
-                },
+                status: Some(cr.status.to_string()),
             })
             .collect(),
     };
@@ -676,7 +673,11 @@ async fn get_review_feedback(
         // Collect review body text (non-empty bodies that aren't just whitespace).
         // Skip DISMISSED reviews — their body is the dismissal reason, not
         // actionable feedback for the implementer.
-        let state = if review.state.is_empty() { "COMMENTED" } else { &review.state };
+        let state = if review.state.is_empty() {
+            "COMMENTED"
+        } else {
+            &review.state
+        };
         if state != "DISMISSED" {
             if let Some(ref body) = review.body {
                 let trimmed = body.trim();


### PR DESCRIPTION
## Summary
- Add `PreFetchedData` struct to `merge_readiness.rs` that bundles PR details, reviews, and check runs already fetched by `poll_once()`
- Add `check_merge_readiness_with_data()` that accepts pre-fetched data, skipping 3 duplicate API calls per poll cycle (PR details, reviews, check runs)
- The only remaining API call in `check_merge_readiness_with_data()` is `get_combined_status()` (legacy Statuses API), which is unique to merge-readiness and not fetched by `poll_once()`
- Thread pre-fetched data from `poll_once()` → `update_readiness_label()` → `check_merge_readiness_with_data()`, eliminating ~360 wasted API calls/hour per Minion
- Preserve the original `check_merge_readiness()` as a fallback when pre-fetched data is not available

## Test plan
- Added 6 new tests for the pre-fetched data evaluation path covering: all-passing, draft PR, CI failure, review not approved, merge conflict, and check-run conversion equivalence
- All 961 existing tests pass unchanged
- `just check` passes (format + lint + test + build)

## Notes
- `pr_monitor::Review` now deserializes the `state` field from the GitHub API (previously ignored) to enable reuse by merge-readiness evaluation
- `pr_monitor::PullRequest` now deserializes the `draft` field (previously ignored) to pass to merge-readiness
- `ci::CheckStatus` and `ci::CheckConclusion` enums are converted to raw strings for the pre-fetched path; `Unknown` variants are handled correctly (rejected by `evaluate_ci`)

Fixes #721

<sub>🤖 M16d</sub>