### PR TITLE
Fixes #730: gru attach: add -y short flag for --yolo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,7 @@ enum Commands {
         id: String,
 
         #[arg(
+            short = 'y',
             long,
             help = "Skip permission prompts (adds --dangerously-skip-permissions)"
         )]


### PR DESCRIPTION
## Summary
- Add `short = 'y'` to the `--yolo` flag on the `Attach` command, enabling `gru at -y <id>` as shorthand for `gru attach --yolo <id>`
- One-line change in `src/main.rs`; no conflicts with other short flags on the `Attach` subcommand

## Test plan
- `just check` passes (format, lint, 955 tests, build)
- Verified `-y` does not conflict with any other short flag on the `Attach` command
- Clap enforces short flag uniqueness at compile time

## Notes
- The `Rebase` subcommand also has a `-y` (for `--yes`), but Clap scopes short flags per-subcommand so there is no conflict

Fixes #730

<sub>🤖 M16q</sub>