### PR TITLE
Fixes #714: Fix tmux race: use $TMUX_PANE to resolve window ID

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -159,12 +159,13 @@ fn current_window_id() -> Option<String> {
         return None;
     }
     let mut cmd = Command::new("tmux");
-    cmd.args(["display-message", "-p", "#{window_id}"]);
+    cmd.args(["display-message", "-p"]);
     if let Ok(pane) = std::env::var("TMUX_PANE") {
         if is_valid_tmux_pane(&pane) {
             cmd.args(["-t", &pane]);
         }
     }
+    cmd.arg("#{window_id}");
     let output = cmd.output().ok()?;
     if output.status.success() {
         let id = String::from_utf8_lossy(&output.stdout).trim().to_string();


### PR DESCRIPTION
## Summary
- Use `$TMUX_PANE` with `-t` flag in `current_window_id()` so the query targets the pane the Gru process owns, not the currently focused window
- Fall back to previous behavior (no `-t`) when `$TMUX_PANE` is unset
- Validate `$TMUX_PANE` matches expected `%<digits>` format before using it as a target
- Add unit tests for pane ID validation

## Test plan
- All 956 tests pass (`just check` clean)
- New `test_is_valid_tmux_pane` test covers valid/invalid pane IDs
- Manual test: start `gru do`, switch tmux windows immediately — correct window is renamed

## Notes
- `rename_window`, `set_automatic_rename`, and the signal handler already target the stored window ID, so no changes needed there
- `lab.rs` already strips `$TMUX_PANE` from spawned Minion child processes, so this fix doesn't affect lab-spawned subprocesses

Fixes #714

<sub>🤖 M164</sub>