### PR TITLE
Fixes #752: Merge judge retries infinitely when LLM returns non-JSON response

### DIFF
--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -483,6 +483,30 @@ async fn handle_ready_to_merge(
         }
     }
 
+    // If a previous failure escalation failed to apply the label, retry now
+    // before invoking the judge (which would skip at the failure cap).
+    if state.judge_state.should_escalate_on_failure() && !state.judge_state.label_was_applied() {
+        log::info!("Retrying failed escalation label application...");
+        match merge_judge::add_needs_human_review_label(
+            &ctx.issue_ctx.host,
+            &ctx.issue_ctx.owner,
+            &ctx.issue_ctx.repo,
+            ctx.pr_number,
+        )
+        .await
+        {
+            Ok(()) => {
+                state.judge_state.mark_label_applied();
+                state.judge_state.mark_failure_escalated();
+                log::info!("Successfully applied needs-human-review label on retry");
+            }
+            Err(e) => {
+                log::warn!("Retry of needs-human-review label failed: {}", e);
+            }
+        }
+        return LoopAction::Continue;
+    }
+
     // Invoke the merge-readiness judge.
     match merge_judge::evaluate(
         ctx.backend,
@@ -624,11 +648,18 @@ async fn handle_ready_to_merge(
                     },
                 )
                 .await;
-                // Mark escalation as done so subsequent cycles don't re-post.
-                state.judge_state.mark_failure_escalated();
+                // Only mark escalation complete if the label was applied.
+                // If the label add failed, leave unmarked so we retry on
+                // the next cycle (should_invoke returns false at cap, but
+                // next fingerprint change or label retry will re-attempt).
+                if state.judge_state.label_was_applied() {
+                    state.judge_state.mark_failure_escalated();
+                }
             } else {
+                let backoff = state.judge_state.retry_backoff_minutes();
                 println!(
-                    "🔄 Will retry on next poll cycle (failure {}/{})...",
+                    "🔄 Will retry after ~{}m backoff (failure {}/{})...",
+                    backoff,
                     state.judge_state.consecutive_failures(),
                     merge_judge::MAX_CONSECUTIVE_FAILURES
                 );

--- a/src/merge_judge.rs
+++ b/src/merge_judge.rs
@@ -158,6 +158,18 @@ impl JudgeState {
         self.consecutive_failures
     }
 
+    /// Returns the retry backoff remaining in minutes (rounded up), or 0
+    /// if no backoff is active.
+    pub(crate) fn retry_backoff_minutes(&self) -> i64 {
+        match self.retry_after {
+            Some(until) => {
+                let remaining = until - Utc::now();
+                (remaining.num_seconds() + 59).max(0) / 60 // round up
+            }
+            None => 0,
+        }
+    }
+
     /// Returns true if the failure cap has been reached and escalation
     /// has not yet been performed for this fingerprint.
     pub(crate) fn should_escalate_on_failure(&self) -> bool {


### PR DESCRIPTION
## Summary
- Fix infinite retry loop when merge judge LLM returns non-JSON responses by recording the PR fingerprint on failure, preventing re-invocation on the same PR state
- Add consecutive failure tracking to `JudgeState` — after 3 failures on the same fingerprint, escalate by applying `gru:needs-human-review` label and posting a comment
- Log the raw LLM response (truncated to 500 bytes) on parse failures for diagnostics
- Reset failure counter when a human clears the escalation label, restoring retry budget

## Test plan
- Added 7 new unit tests covering failure counter increments, state-change resets, success resets, fingerprint-blocks-reinvocation, and escalation-cleared-after-failures
- All 961 tests pass: `just check` (fmt + lint + test + build) passes cleanly
- Manually verified the fix addresses the root cause described in the issue: `record_failure()` updates `last_fingerprint` so `should_invoke()` returns `false` for the same PR state

## Notes
- Renamed `invoke_judge_cli` to `invoke_judge_cli_raw` (returns raw `String`) to separate CLI invocation from JSON parsing, enabling failure tracking between the two steps
- Uses existing `truncate_if_needed()` helper for safe UTF-8-aware truncation of raw response in logs
- `MAX_CONSECUTIVE_FAILURES` is exposed as `pub(crate)` so `monitor.rs` can display retry progress (`failure 1/3`)

Fixes #752

<sub>🤖 M17c</sub>