### PR TITLE
Fixes #759: gru at fails with InconsistentState error on stale registry entry (mode≠Stopped, no PID)

### DIFF
--- a/src/session_claim.rs
+++ b/src/session_claim.rs
@@ -75,6 +75,7 @@ fn claim_session_in_registry(
                 );
                 reg.update(&id, |i| {
                     i.mode = MinionMode::Stopped;
+                    i.clear_pid();
                     i.last_activity = Utc::now();
                 })?;
             }
@@ -342,9 +343,11 @@ mod tests {
         assert_eq!(snapshot.mode, MinionMode::Autonomous);
         assert_eq!(snapshot.pid, None);
 
-        // Registry should now show Interactive mode
+        // Registry should now show Interactive mode with PID fields cleared
         let updated = read_minion(tmp.path(), "M001").unwrap();
         assert_eq!(updated.mode, MinionMode::Interactive);
+        assert_eq!(updated.pid, None);
+        assert_eq!(updated.pid_start_time, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Recover from stale registry entries where `mode != Stopped` but `pid = None` (e.g., process crashed before writing PID)
- The `pid = None` branch now resets the entry to `Stopped` with a warning log, matching the existing dead-PID recovery path
- Removed the `InconsistentState` variant from `SessionClaimError` as it is no longer produced
- Updated tests: replaced the `InconsistentState` error test with a stale-no-PID recovery success test

## Test plan
- `just check` passes (fmt + clippy + all 954 tests)
- New test `test_stale_no_pid_resets_and_claims` verifies the recovery path succeeds and the registry is correctly updated
- Existing tests for dead-PID reset, live-PID rejection, stopped claim, and graceful degradation all pass unchanged

## Notes
- `gru at` and `gru resume` both use `check_and_claim_session`, so both benefit from this fix
- `attach.rs` required no changes — it only matched on `AlreadyRunning`, never on `InconsistentState`

Fixes #759

<sub>🤖 M17n</sub>