### PR TITLE
Add just release recipe and update release docs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,11 +9,10 @@ Gru uses [Semantic Versioning](https://semver.org/) with a `0.x.y` scheme until 
 
 ## Prerequisites
 
-Install git-cliff for changelog generation:
+- [GitHub CLI](https://cli.github.com/) (`gh`), authenticated — used for changelog generation
+- [git-cliff](https://git-cliff.org/) — `cargo install git-cliff`
 
-```bash
-cargo install git-cliff
-```
+Alternatively, set `GITHUB_TOKEN` manually instead of using `gh`.
 
 ## Quick Release
 

--- a/justfile
+++ b/justfile
@@ -68,9 +68,11 @@ changelog-preview:
 # Tag and push a release (usage: just release 0.2.0)
 release version:
     @echo "Releasing v{{version}}..."
-    @grep -q 'version = "{{version}}"' Cargo.toml || (echo "ERROR: Cargo.toml version doesn't match {{version}}" && exit 1)
+    @grep -q '^version = "{{version}}"' Cargo.toml || (echo "ERROR: Cargo.toml [package].version doesn't match {{version}}" && exit 1)
+    @git diff --quiet && git diff --cached --quiet || (echo "ERROR: working tree is dirty — commit or stash first" && exit 1)
+    @! git rev-parse "v{{version}}" >/dev/null 2>&1 || (echo "ERROR: tag v{{version}} already exists" && exit 1)
     cargo check
-    GITHUB_TOKEN=$(gh auth token) git-cliff --github-repo fotoetienne/gru --tag v{{version}} -o CHANGELOG.md
+    GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token)}" git-cliff --github-repo fotoetienne/gru --tag v{{version}} -o CHANGELOG.md
     git add Cargo.toml Cargo.lock CHANGELOG.md
     git commit -m "Release v{{version}}"
     git tag v{{version}}


### PR DESCRIPTION
## Summary
- Add `just release <version>` that validates Cargo.toml version, runs cargo check, generates changelog, commits, tags, and pushes
- Update RELEASING.md to document the quick path alongside manual steps
- Remove stale "Future Automation" section (CI already handles this)

## Test plan
- [ ] `just release` with mismatched Cargo.toml version fails with clear error
- [ ] Full release flow works end-to-end (next patch release)