### PR TITLE
Fixes #771: `gru status` is slow due to sequential git and GitHub API calls

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -93,7 +93,9 @@ fn get_current_branch(worktree_path: &std::path::Path, registry_branch: &str) ->
                         let gitdir_path = if std::path::Path::new(gitdir).is_absolute() {
                             std::path::PathBuf::from(gitdir)
                         } else {
-                            worktree_path.join(gitdir)
+                            // Per the git spec, relative gitdir paths are resolved
+                            // relative to the directory containing the .git file.
+                            dot_git.parent().unwrap_or(worktree_path).join(gitdir)
                         };
                         gitdir_path.join("HEAD")
                     }
@@ -122,7 +124,8 @@ fn get_current_branch(worktree_path: &std::path::Path, registry_branch: &str) ->
             } else if trimmed.is_empty() {
                 "(error)".to_string()
             } else {
-                // Bare commit hash → detached HEAD.
+                // Not a branch ref (tag checkout, remote ref, or bare commit hash) →
+                // treat as detached HEAD.
                 "(detached)".to_string()
             }
         }
@@ -764,6 +767,21 @@ mod tests {
             get_current_branch(tmp.path(), "minion/issue-42-M001"),
             "minion/issue-42-M001"
         );
+    }
+
+    #[test]
+    fn test_get_current_branch_worktree_relative_gitdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Create a sibling "gitdir" directory relative to the worktree root.
+        let gitdir = tmp.path().join("actual_gitdir");
+        std::fs::create_dir(&gitdir).unwrap();
+        std::fs::write(gitdir.join("HEAD"), "ref: refs/heads/feature/foo\n").unwrap();
+
+        // Write a .git file with a relative path (relative to checkout/, which is tmp.path()).
+        // The relative path "actual_gitdir" resolves to tmp.path()/actual_gitdir.
+        std::fs::write(tmp.path().join(".git"), "gitdir: actual_gitdir\n").unwrap();
+
+        assert_eq!(get_current_branch(tmp.path(), "feature/foo"), "feature/foo");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **RC1 (status.rs)**: Replace `git branch --show-current` subprocess call (~100ms each) with direct `.git/HEAD` file reading. For N minions this reduces Phase 2 from O(N×100ms) to O(N×file_read_time). With 10 minions: ~1s → ~10ms. Handles both linked worktrees (`.git` is a file with `gitdir:` pointer, per the git spec) and regular repos (`.git` is a directory).
- **RC2 (minion_registry.rs)**: Parallelize `prune_stale_entries` Phase 2 using `tokio::task::JoinSet`. Previously, each `is_pr_open_via_cli` call (30s timeout) ran sequentially. Now all PR-open checks run concurrently, reducing worst-case from N×30s to ~30s.
- Added unit tests for the new HEAD-file parsing logic (regular repo, detached HEAD, linked worktree with absolute gitdir, linked worktree with relative gitdir, missing `.git`, malformed gitdir pointer).

## Test plan

- `just test` — 961 tests, all pass
- `just lint` — clean
- `just fmt-check` — clean

## Notes

- RC3 (`auto_archive_stopped_minions`) and RC4/RC5/RC6 from the issue description reference functions that don't exist in the current codebase. The two root causes addressed here (sequential git subprocesses and sequential GitHub API calls in `prune_stale_entries`) are the actual bottlenecks present in the current code.
- The relative gitdir path resolution uses `dot_git.parent()` as the base (per the git spec), though for all current Gru worktrees this resolves to the same path as `worktree_path`.

Fixes #771

<sub>🤖 M18l</sub>