### PR TITLE
Fixes #773: Add `--cache` to `is_pr_merged_via_cli`, `is_pr_open_via_cli`, and `is_issue_closed_via_cli`

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -698,6 +698,14 @@ pub async fn is_issue_closed_via_cli(
     .await?;
 
     let state = stdout.trim().to_string();
+    if state.is_empty() {
+        return Err(anyhow!(
+            "gh api returned empty state for issue #{} in {}/{}",
+            number,
+            owner,
+            repo
+        ));
+    }
     Ok(state == "closed")
 }
 


### PR DESCRIPTION
## Summary
- Rewrite `is_issue_closed_via_cli` and `is_pr_open_via_cli` to use `gh api` with `--cache 300s`
- `--cache` is only supported by `gh api`, not `gh issue view` or `gh pr view` — the original approach would have broken these functions at runtime
- Update state comparisons from GraphQL enum values (`CLOSED`/`OPEN`) to REST API lowercase values (`closed`/`open`)

## Test plan
- `just check` passes: fmt, clippy (-D warnings), 955 tests, build
- Note: `is_pr_merged_via_cli` mentioned in the issue does not exist in the codebase; only the two functions above needed changes

## Notes
- The REST API returns `"closed"` for both closed-without-merge and merged PRs, so `is_pr_open_via_cli` returning `false` for a merged PR remains correct
- 300s is appropriate for these terminal states (issue closed, PR merged/closed) — they are immutable once reached

Fixes #773

<sub>🤖 M18o</sub>