### PR TITLE
Fixes #531: Create project website (GitHub Pages)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install mdBook
+        run: |
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin
+
+      - name: Build book
+        run: mdbook build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: book
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,8 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install mdBook
-        run: |
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
 
       - name: Build book
         run: mdbook build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install mdBook
         uses: taiki-e/install-action@v2
         with:
-          tool: mdbook
+          tool: mdbook@0.4.40
 
       - name: Build book
         run: mdbook build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv/
 target/
+book/
 .claude/settings.local.json
 
 # Ephemeral Minion files

--- a/book.toml
+++ b/book.toml
@@ -9,6 +9,8 @@ src = "docs"
 build-dir = "book"
 
 [output.html]
+# site-url must match the GitHub Pages path: /gru/ for a project repo named "gru"
+# Update this if the repo is renamed or deployed under a custom domain.
 site-url = "/gru/"
 git-repository-url = "https://github.com/fotoetienne/gru"
 edit-url-template = "https://github.com/fotoetienne/gru/edit/main/docs/{path}"

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,14 @@
+[book]
+title = "Gru"
+description = "Autonomous GitHub issue resolver — turns issues into merged PRs with AI"
+authors = ["fotoetienne"]
+language = "en"
+src = "docs"
+
+[build]
+build-dir = "book"
+
+[output.html]
+site-url = "/gru/"
+git-repository-url = "https://github.com/fotoetienne/gru"
+edit-url-template = "https://github.com/fotoetienne/gru/edit/main/docs/{path}"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,20 @@
+# Summary
+
+[Introduction](introduction.md)
+
+---
+
+# User Guide
+
+- [Getting Started](GETTING_STARTED.md)
+- [Concepts](CONCEPTS.md)
+- [Agent Backends](AGENTS.md)
+- [GitHub Enterprise Setup](GHES_SETUP.md)
+
+---
+
+# Reference
+
+- [Design Architecture](DESIGN.md)
+- [Architecture Decisions](DECISIONS.md)
+- [Competitive Landscape](COMPETITIVE_LANDSCAPE.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,4 +17,9 @@
 
 - [Design Architecture](DESIGN.md)
 - [Architecture Decisions](DECISIONS.md)
+
+---
+
+# Community
+
 - [Competitive Landscape](COMPETITIVE_LANDSCAPE.md)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -14,9 +14,12 @@ Gru is **agent-agnostic**. It ships with backends for [Claude Code](https://gith
 ## Quick Start
 
 ```bash
-# Install (macOS Apple Silicon — see Getting Started for other platforms)
+# Install prebuilt binary (macOS Apple Silicon)
 curl -fL https://github.com/fotoetienne/gru/releases/latest/download/gru-aarch64-apple-darwin.tar.gz | tar xz
 sudo mv gru /usr/local/bin/
+
+# Or build from source (requires Rust 1.73+)
+cargo install --git https://github.com/fotoetienne/gru
 
 # Initialize a repo
 gru init owner/repo

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,45 @@
+# Gru
+
+[![CI](https://github.com/fotoetienne/gru/actions/workflows/ci.yml/badge.svg)](https://github.com/fotoetienne/gru/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/fotoetienne/gru/blob/main/LICENSE)
+
+**Gru turns GitHub issues into merged PRs — autonomously, locally, with the AI coding agent of your choice.**
+
+Point it at an issue and it handles the rest: implementation, PR, code review, CI fixes, rebases — all in an isolated worktree that never touches your working directory.
+
+![Animated terminal demo: running "gru do <issue>" — Gru fetches the issue, spawns an agent, and opens a PR autonomously](./demo.gif)
+
+Gru is **agent-agnostic**. It ships with backends for [Claude Code](https://github.com/anthropics/claude-code) and [OpenAI Codex](https://github.com/openai/codex), and its pluggable architecture makes it straightforward to add more.
+
+## Quick Start
+
+```bash
+# Install (macOS Apple Silicon — see Getting Started for other platforms)
+curl -fL https://github.com/fotoetienne/gru/releases/latest/download/gru-aarch64-apple-darwin.tar.gz | tar xz
+sudo mv gru /usr/local/bin/
+
+# Initialize a repo
+gru init owner/repo
+
+# Fix an issue — Gru handles the rest
+gru do 42
+```
+
+For a full walkthrough, see [Getting Started](GETTING_STARTED.md).
+
+## How It Works
+
+1. `gru init owner/repo` creates a bare git mirror at `~/.gru/repos/`
+2. `gru do 42` creates an isolated worktree, spawns the agent, and monitors progress via streaming JSON
+3. The agent reads the issue, explores the code, makes changes, and runs tests
+4. After committing, a code-reviewer subagent checks for correctness, security, and convention issues before the PR is created
+5. Gru opens a PR, watches CI, and feeds failures back to the agent for auto-fix (up to 2 attempts before escalating)
+6. Review comments are forwarded to the agent for responses
+7. Labels (`gru:todo` → `gru:in-progress` → `gru:done` / `gru:failed`) track state on GitHub
+
+## Links
+
+- [GitHub Repository](https://github.com/fotoetienne/gru)
+- [Releases](https://github.com/fotoetienne/gru/releases/latest)
+- [Contributing](https://github.com/fotoetienne/gru/blob/main/CONTRIBUTING.md)
+- [License: Apache 2.0](https://github.com/fotoetienne/gru/blob/main/LICENSE)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -18,8 +18,8 @@ Gru is **agent-agnostic**. It ships with backends for [Claude Code](https://gith
 curl -fL https://github.com/fotoetienne/gru/releases/latest/download/gru-aarch64-apple-darwin.tar.gz | tar xz
 sudo mv gru /usr/local/bin/
 
-# Or build from source (requires Rust 1.73+)
-cargo install --git https://github.com/fotoetienne/gru
+# Or install from crates.io (all platforms, requires Rust 1.73+)
+cargo install gru
 
 # Initialize a repo
 gru init owner/repo
@@ -27,6 +27,8 @@ gru init owner/repo
 # Fix an issue — Gru handles the rest
 gru do 42
 ```
+
+Prebuilt binaries for macOS x86_64 and Linux are on the [Releases page](https://github.com/fotoetienne/gru/releases/latest).
 
 For a full walkthrough, see [Getting Started](GETTING_STARTED.md).
 


### PR DESCRIPTION
## Summary

- Add `book.toml` configuring mdBook with `docs/` as source, building to `book/`
- Add `docs/SUMMARY.md` organizing existing docs into a browsable book with User Guide, Reference, and Community sections
- Add `docs/introduction.md` as the landing page with value prop, demo GIF, quick start (prebuilt binary + `cargo install`), and links to GitHub/docs/installation/CONTRIBUTING
- Add `.github/workflows/pages.yml` to auto-deploy to GitHub Pages on push to `main` using `taiki-e/install-action` (architecture-agnostic, checksum-verified)
- Add `book/` to `.gitignore`

The site deploys to `https://fotoetienne.github.io/gru/` automatically when main is updated. `workflow_dispatch` is included for manual deploys.

## Test plan

- Ran `mdbook build` locally — build succeeds, all docs render correctly, `demo.gif` copies into the output
- Ran `just check` — all 1186 tests pass, clippy clean, format clean
- Verified `introduction.html` in the build output contains the value prop text and demo GIF reference

## Notes

- Uses `taiki-e/install-action@v2` for mdBook install (same pattern as `cargo-nextest` and `cargo-audit` in `ci.yml`) — handles both x86_64 and aarch64 runners
- `site-url = "/gru/"` is documented in `book.toml` with a comment explaining it must match the repo name; update if the repo is renamed or a custom domain is added
- The GitHub Pages environment (`github-pages`) and the required permissions (`pages: write`, `id-token: write`) must be enabled in repo Settings → Pages → Source → "GitHub Actions" for the workflow to succeed on first run
- The `docs/config.example.toml` and other non-markdown files in `docs/` are copied to the book output by mdBook but not shown as chapters — this is expected behavior

Fixes #531

<sub>🤖 M1eu</sub>