### PR TITLE
Fixes #825: Fix: gru:in-progress label orphaned when minion exits after EARLY_EXIT_THRESHOLD

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -407,23 +407,78 @@ async fn reap_children(children: &mut Vec<SpawnedChild>, retry_queue: &mut Retry
                             }
                         } else {
                             // Non-early failure: restore labels first, then enqueue for retry.
-                            // This prevents the issue from being orphaned if lab restarts
-                            // before the retry fires.
-                            if let Err(e) = github::edit_labels_via_cli(
+                            // Check for terminal labels before restoring to avoid overwriting
+                            // gru:done/failed — a long-running minion may have finished
+                            // successfully before the process crashed.
+                            let terminal_label = match github::has_any_label_via_cli(
                                 &meta.host,
                                 &meta.owner,
                                 &meta.repo,
                                 meta.issue_number,
-                                &[&meta.ready_label],
-                                &[labels::IN_PROGRESS],
+                                &[labels::DONE, labels::FAILED],
                             )
                             .await
                             {
-                                log::warn!(
-                                    "⚠️  Failed to restore labels on issue #{} after non-early exit: {}",
+                                Ok(label) => label,
+                                Err(e) => {
+                                    log::warn!(
+                                        "⚠️  Failed to check labels on issue #{}: {} \
+                                         — proceeding with label restoration (fail-open)",
+                                        meta.issue_number,
+                                        e
+                                    );
+                                    None
+                                }
+                            };
+
+                            if let Some(label) = terminal_label {
+                                log::info!(
+                                    "⏭️  Issue #{} already has {} — skipping gru:todo restoration, \
+                                     removing gru:in-progress only",
                                     meta.issue_number,
-                                    e
+                                    label
                                 );
+                                if let Err(e) = github::edit_labels_via_cli(
+                                    &meta.host,
+                                    &meta.owner,
+                                    &meta.repo,
+                                    meta.issue_number,
+                                    &[],
+                                    &[labels::IN_PROGRESS],
+                                )
+                                .await
+                                {
+                                    log::warn!(
+                                        "⚠️  Failed to remove gru:in-progress from issue #{}: {}",
+                                        meta.issue_number,
+                                        e
+                                    );
+                                }
+                            } else {
+                                log::warn!(
+                                    "⚠️  Spawned gru do for issue #{} exited with {} after {:.1}s \
+                                     — restoring label before retry",
+                                    meta.issue_number,
+                                    status,
+                                    elapsed.as_secs_f64()
+                                );
+                                if let Err(e) = github::edit_labels_via_cli(
+                                    &meta.host,
+                                    &meta.owner,
+                                    &meta.repo,
+                                    meta.issue_number,
+                                    &[&meta.ready_label],
+                                    &[labels::IN_PROGRESS],
+                                )
+                                .await
+                                {
+                                    log::warn!(
+                                        "⚠️  Failed to restore labels on issue #{} after non-early exit: {} \
+                                         — issue may need manual label fix",
+                                        meta.issue_number,
+                                        e
+                                    );
+                                }
                             }
                             let reason = format!(
                                 "exited with {} after {:.0}s",
@@ -2409,11 +2464,11 @@ mod tests {
 
     #[test]
     fn test_should_restore_label_beyond_threshold() {
-        // A process spawned well before the threshold should not qualify
-        let spawned_at = Instant::now() - Duration::from_secs(180);
+        // A process spawned well past the threshold should not qualify
+        let spawned_at = Instant::now() - EARLY_EXIT_THRESHOLD - Duration::from_secs(60);
         assert!(
             !should_restore_label(spawned_at),
-            "Process spawned 180s ago should not qualify for label restoration"
+            "Process spawned past EARLY_EXIT_THRESHOLD should not qualify for label restoration"
         );
     }
 

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -28,7 +28,11 @@ macro_rules! tprintln {
 /// Maximum age of a spawn to be considered an "early exit" eligible for label restoration.
 /// Processes that fail within this window likely never started meaningful work, so the
 /// issue label should be restored to the ready state rather than left as in-progress.
-const EARLY_EXIT_THRESHOLD: Duration = Duration::from_secs(30);
+///
+/// 120s covers observed startup/auth/lock-wait delays (registry file lock contention can
+/// cause up to ~42s of backoff in file_lock.rs). The previous 30s threshold was too low,
+/// causing processes that exited at ~35s to bypass label restoration.
+const EARLY_EXIT_THRESHOLD: Duration = Duration::from_secs(120);
 
 /// A child process tracked by the lab, with optional metadata for label restoration.
 struct SpawnedChild {
@@ -402,7 +406,25 @@ async fn reap_children(children: &mut Vec<SpawnedChild>, retry_queue: &mut Retry
                                 }
                             }
                         } else {
-                            // Non-early failure: enqueue for retry with backoff
+                            // Non-early failure: restore labels first, then enqueue for retry.
+                            // This prevents the issue from being orphaned if lab restarts
+                            // before the retry fires.
+                            if let Err(e) = github::edit_labels_via_cli(
+                                &meta.host,
+                                &meta.owner,
+                                &meta.repo,
+                                meta.issue_number,
+                                &[&meta.ready_label],
+                                &[labels::IN_PROGRESS],
+                            )
+                            .await
+                            {
+                                log::warn!(
+                                    "⚠️  Failed to restore labels on issue #{} after non-early exit: {}",
+                                    meta.issue_number,
+                                    e
+                                );
+                            }
                             let reason = format!(
                                 "exited with {} after {:.0}s",
                                 status,
@@ -1792,6 +1814,24 @@ async fn dispatch_due_retries(
                     entry.issue_number,
                     e
                 );
+                // Restore the label so the issue isn't orphaned at gru:in-progress
+                // if lab restarts between retry attempts.
+                if let Err(re) = github::edit_labels_via_cli(
+                    &entry.host,
+                    &entry.owner,
+                    &entry.repo,
+                    entry.issue_number,
+                    &[labels::TODO],
+                    &[labels::IN_PROGRESS],
+                )
+                .await
+                {
+                    log::warn!(
+                        "⚠️  Failed to restore labels for retry issue #{}: {}",
+                        entry.issue_number,
+                        re
+                    );
+                }
                 // Reinsert so a transient spawn failure doesn't permanently drop retry state.
                 retry_queue.reinsert(entry);
             }
@@ -2370,10 +2410,10 @@ mod tests {
     #[test]
     fn test_should_restore_label_beyond_threshold() {
         // A process spawned well before the threshold should not qualify
-        let spawned_at = Instant::now() - Duration::from_secs(60);
+        let spawned_at = Instant::now() - Duration::from_secs(180);
         assert!(
             !should_restore_label(spawned_at),
-            "Process spawned 60s ago should not qualify for label restoration"
+            "Process spawned 180s ago should not qualify for label restoration"
         );
     }
 

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -454,6 +454,7 @@ async fn reap_children(children: &mut Vec<SpawnedChild>, retry_queue: &mut Retry
                                         e
                                     );
                                 }
+                                // Issue is already done/failed — no retry needed.
                             } else {
                                 log::warn!(
                                     "⚠️  Spawned gru do for issue #{} exited with {} after {:.1}s \
@@ -479,26 +480,26 @@ async fn reap_children(children: &mut Vec<SpawnedChild>, retry_queue: &mut Retry
                                         e
                                     );
                                 }
-                            }
-                            let reason = format!(
-                                "exited with {} after {:.0}s",
-                                status,
-                                elapsed.as_secs_f64()
-                            );
-                            if !retry_queue.enqueue_failure(
-                                &meta.host,
-                                &meta.owner,
-                                &meta.repo,
-                                meta.issue_number,
-                                meta.retry_attempt,
-                                &reason,
-                                None,
-                                None,
-                            ) {
-                                log::warn!(
-                                    "⚠️  Issue #{} exceeded max retry attempts — not retrying",
-                                    meta.issue_number,
+                                let reason = format!(
+                                    "exited with {} after {:.0}s",
+                                    status,
+                                    elapsed.as_secs_f64()
                                 );
+                                if !retry_queue.enqueue_failure(
+                                    &meta.host,
+                                    &meta.owner,
+                                    &meta.repo,
+                                    meta.issue_number,
+                                    meta.retry_attempt,
+                                    &reason,
+                                    None,
+                                    None,
+                                ) {
+                                    log::warn!(
+                                        "⚠️  Issue #{} exceeded max retry attempts — not retrying",
+                                        meta.issue_number,
+                                    );
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

- Raise `EARLY_EXIT_THRESHOLD` from 30s to 120s so that processes exiting at ~35s (due to registry file lock backoff) are correctly treated as early exits and have their labels restored
- In `reap_children`, restore `gru:in-progress → ready_label` in the non-early exit path before enqueuing a failure retry, preventing permanent label orphaning if lab restarts before the retry fires; includes terminal label guard to avoid overwriting `gru:done`/`gru:failed` if the minion completed before crashing
- In `dispatch_due_retries`, restore `gru:in-progress → gru:todo` when `spawn_minion` fails at retry time, before reinserting the entry into the retry queue

## Test plan

- `just test` — all 1186 tests pass
- `just lint` — no warnings
- Updated `test_should_restore_label_beyond_threshold` to use `EARLY_EXIT_THRESHOLD + 60s` instead of a hardcoded value so the test remains correct if the threshold changes again

## Notes

- Fix 3 (`dispatch_due_retries` spawn failure) hardcodes `labels::TODO`. The issue description explicitly notes this is acceptable if all repos use `gru:todo`. Repos using custom labels would need `RetryEntry` to carry a `ready_label` field — that is a follow-up, not part of this fix.
- The terminal label check in the non-early exit path mirrors the existing guard in the early exit path, preventing a scenario where a minion runs for >120s, sets `gru:done`, crashes, and then has its terminal label overwritten with `gru:todo`.

Fixes #825

<sub>🤖 M1f4</sub>