### PR TITLE
Fixes #830: auto_rebase_pr: agent exit 0 declared success without verifying rebase completed

### DIFF
--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -200,6 +200,21 @@ async fn auto_rebase_pr(worktree_path: &Path) -> Result<AutoRebaseResult> {
             }
 
             if exit_code == 0 {
+                // Verify the agent actually completed the rebase before trusting it.
+                // An agent that exits 0 without rebasing (e.g. sees a clean worktree
+                // post-abort and does nothing) would otherwise cause a spurious
+                // RebasedAndPushed result and a force-push of the unchanged branch.
+                if let Err(e) = check_clean_worktree(worktree_path).await {
+                    log::warn!("Agent rebase left dirty worktree: {}", e);
+                    return Ok(AutoRebaseResult::ConflictUnresolved);
+                }
+                if !is_up_to_date(worktree_path, &base_branch).await? {
+                    log::warn!(
+                        "Agent rebase exited 0 but origin/{} is not an ancestor of HEAD — rebase did not complete",
+                        base_branch
+                    );
+                    return Ok(AutoRebaseResult::ConflictUnresolved);
+                }
                 // Defensively force push in case the /rebase skill didn't push
                 log::info!("Auto force-pushing after conflict resolution (autonomous mode, --force-with-lease)");
                 force_push(worktree_path).await?;

--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -204,10 +204,29 @@ async fn auto_rebase_pr(worktree_path: &Path) -> Result<AutoRebaseResult> {
                 // An agent that exits 0 without rebasing (e.g. sees a clean worktree
                 // post-abort and does nothing) would otherwise cause a spurious
                 // RebasedAndPushed result and a force-push of the unchanged branch.
-                if let Err(e) = check_clean_worktree(worktree_path).await {
-                    log::warn!("Agent rebase left dirty worktree: {}", e);
+                //
+                // Use --untracked-files=no so that untracked files (e.g. editor
+                // temp files or generated artifacts) left by the agent don't
+                // produce false positives. We only care about uncommitted tracked
+                // changes (conflict markers, staged edits) that indicate an
+                // incomplete rebase.
+                let tracked_status = TokioCommand::new("git")
+                    .arg("-C")
+                    .arg(worktree_path)
+                    .args(["status", "--porcelain", "--untracked-files=no"])
+                    .output()
+                    .await
+                    .context("Failed to check tracked-file status after agent rebase")?;
+                if !tracked_status.stdout.is_empty() {
+                    let details = String::from_utf8_lossy(&tracked_status.stdout);
+                    log::warn!(
+                        "Agent rebase left uncommitted tracked changes:\n{}",
+                        details.trim()
+                    );
                     return Ok(AutoRebaseResult::ConflictUnresolved);
                 }
+                // is_up_to_date checks that origin/<base_branch> is an ancestor of HEAD,
+                // which is the canonical proof that the rebase actually happened.
                 if !is_up_to_date(worktree_path, &base_branch).await? {
                     log::warn!(
                         "Agent rebase exited 0 but origin/{} is not an ancestor of HEAD — rebase did not complete",

--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -217,6 +217,14 @@ async fn auto_rebase_pr(worktree_path: &Path) -> Result<AutoRebaseResult> {
                     .output()
                     .await
                     .context("Failed to check tracked-file status after agent rebase")?;
+                if !tracked_status.status.success() {
+                    let stderr = String::from_utf8_lossy(&tracked_status.stderr);
+                    anyhow::bail!(
+                        "git status failed after agent rebase (exit {:?}): {}",
+                        tracked_status.status.code(),
+                        stderr.trim()
+                    );
+                }
                 if !tracked_status.stdout.is_empty() {
                     let details = String::from_utf8_lossy(&tracked_status.stdout);
                     log::warn!(


### PR DESCRIPTION
## Summary
- After the `/rebase` agent exits 0, verify that `origin/<base_branch>` is an ancestor of HEAD before force-pushing. An agent that sees a clean worktree post-`abort_rebase` and exits 0 without doing anything would otherwise trigger a spurious `RebasedAndPushed` result and force-push the unchanged branch.
- Also check for uncommitted tracked changes (conflict markers, staged edits) left by the agent, using `git status --porcelain --untracked-files=no` to avoid false positives from untracked temp files.
- Both checks return `ConflictUnresolved` on failure, which triggers the existing escalation path.

## Test plan
- `just test` — all 1186 tests pass
- `just lint` — no warnings
- The specific failure path (agent exits 0 but branch not rebased) requires a live Claude CLI so is not unit-testable; the fix follows the pattern documented in the existing test comment at `monitor.rs:1909`

## Notes
- The key check is `is_up_to_date` (`merge-base --is-ancestor origin/<base> HEAD`): this is false when the PR branch is not yet rebased onto origin/main, directly catching the failure case from fotoetienne/verso#225.
- `check_clean_worktree` is intentionally NOT reused for the post-agent check because it includes untracked files (`??` lines). The inline check with `--untracked-files=no` only catches incomplete rebases (conflict markers, staged changes).

Fixes #830

<sub>🤖 M1fd</sub>