### PR TITLE
Fixes #826: Lab: periodic auto-recovery scan for stuck gru:in-progress issues

### DIFF
--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -76,8 +76,9 @@
 # archive_ttl_hours = 24
 
 # Minutes an issue can be gru:in-progress with no live Minion before the
-# lab auto-resets it to gru:todo. Set to 0 to disable (recommended for
-# multi-lab deployments where another machine may hold the issue).
+# lab auto-resets it to the configured daemon pickup label (`daemon.label`).
+# Set to 0 to disable (recommended for multi-lab deployments where another
+# machine may hold the issue).
 # recovery_threshold_mins = 30
 
 # ─────────────────────────────────────────────────────────────────────

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -75,6 +75,11 @@
 # to disable TTL-based archiving.
 # archive_ttl_hours = 24
 
+# Minutes an issue can be gru:in-progress with no live Minion before the
+# lab auto-resets it to gru:todo. Set to 0 to disable (recommended for
+# multi-lab deployments where another machine may hold the issue).
+# recovery_threshold_mins = 30
+
 # ─────────────────────────────────────────────────────────────────────
 # Agent backend
 # ─────────────────────────────────────────────────────────────────────

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -143,11 +143,11 @@ pub(crate) async fn handle_lab(
     // only serves to rate-limit GitHub API calls within a session.
     let mut wake_check_times: HashMap<String, DateTime<Utc>> = HashMap::new();
 
-    // Poll cycle counter for recovery scan cadence.
-    // First cycle is skipped to avoid false positives while minions are re-registering.
-    let mut poll_cycle: u64 = 0;
-    // Run recovery every ~5 minutes (at least every 1 cycle).
-    let recovery_every = std::cmp::max(1, 300 / config.daemon.poll_interval_secs);
+    // Wall-clock time of the last recovery scan. None until the second poll cycle so
+    // the first cycle is always skipped (avoids false positives while minions are
+    // re-registering after a lab restart).
+    let mut last_recovery_scan: Option<Instant> = None;
+    let mut recovery_scan_eligible = false; // set true after the first poll cycle
 
     if no_resume {
         tprintln!("⏭️  Auto-resume disabled (--no-resume)");
@@ -304,14 +304,21 @@ pub(crate) async fn handle_lab(
 
                 // Periodic recovery scan: reset orphaned gru:in-progress issues.
                 // Skips the first cycle to avoid false positives while minions are
-                // re-registering after a lab restart.
-                poll_cycle += 1;
-                if config.daemon.recovery_threshold_mins > 0
-                    && poll_cycle > 1
-                    && poll_cycle % recovery_every == 0
-                {
-                    if let Err(e) = recover_stuck_in_progress_issues(&config).await {
-                        log::warn!("⚠️  Recovery scan error: {:#}", e);
+                // re-registering after a lab restart. After that, runs every 5 minutes
+                // using wall-clock time (immune to adaptive backoff skew).
+                if config.daemon.recovery_threshold_mins > 0 {
+                    if !recovery_scan_eligible {
+                        // First cycle — mark eligible for future scans.
+                        recovery_scan_eligible = true;
+                    } else {
+                        let should_scan = last_recovery_scan
+                            .map_or(true, |t| t.elapsed() >= Duration::from_secs(300));
+                        if should_scan {
+                            last_recovery_scan = Some(Instant::now());
+                            if let Err(e) = recover_stuck_in_progress_issues(&config).await {
+                                log::warn!("⚠️  Recovery scan error: {:#}", e);
+                            }
+                        }
                     }
                 }
 
@@ -2276,11 +2283,14 @@ async fn fallback_list_issues(
 /// Scan for issues stuck at `gru:in-progress` with no live Minion and reset them.
 ///
 /// For each configured repo, queries GitHub for open `gru:in-progress` issues, then
-/// cross-checks against the local Minion registry. Issues with no live Minion are
-/// reset to `gru:todo` with an explanatory comment so the lab can retry them.
+/// cross-checks against the local Minion registry. Issues with no live Minion *and*
+/// whose `updatedAt` is older than `recovery_threshold_mins` are reset to `gru:todo`
+/// with an explanatory comment so the lab can retry them.
 ///
-/// Errors from individual repos are logged as warnings and do not abort the scan.
+/// Per-repo and per-issue errors are logged as warnings and do not abort the scan.
 async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> Result<()> {
+    let threshold = chrono::Duration::minutes(config.daemon.recovery_threshold_mins as i64);
+
     for repo_spec in &config.daemon.repos {
         let Some((host, owner, repo)) =
             crate::config::parse_repo_entry_with_hosts(repo_spec, &config.github_hosts)
@@ -2307,16 +2317,33 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
             }
         };
 
-        for issue_number in in_progress {
+        for issue in in_progress {
+            // Only reset if the issue has been in-progress for longer than the threshold.
+            let age = chrono::Utc::now().signed_duration_since(issue.updated_at);
+            if age < threshold {
+                log::debug!(
+                    "Recovery scan: skipping issue #{} in {} — only {}m old (threshold: {}m)",
+                    issue.number,
+                    repo_spec,
+                    age.num_minutes(),
+                    config.daemon.recovery_threshold_mins,
+                );
+                continue;
+            }
+
+            // Prune stale registry entries before checking, to avoid PID-recycled
+            // entries masking an orphaned issue.
+            prune_dead_entries_for_issue(&full_repo, issue.number).await;
+
             // If a live Minion holds this issue, skip it.
-            match is_issue_claimed(&full_repo, Some(issue_number)).await {
+            match is_issue_claimed(&full_repo, Some(issue.number)).await {
                 Ok(true) => continue,
                 Ok(false) => {}
                 Err(e) => {
                     log::warn!(
                         "⚠️  Recovery scan: could not check claim status for {}/issues/{}: {:#}",
                         repo_spec,
-                        issue_number,
+                        issue.number,
                         e
                     );
                     continue;
@@ -2325,16 +2352,18 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
 
             // Orphaned issue — reset to gru:todo and leave a comment.
             tprintln!(
-                "🔄 Recovery: resetting orphaned in-progress issue #{} in {} to gru:todo",
-                issue_number,
-                repo_spec
+                "🔄 Recovery: resetting orphaned in-progress issue #{} in {} to gru:todo \
+                 (stuck for {}m)",
+                issue.number,
+                repo_spec,
+                age.num_minutes(),
             );
 
             if let Err(e) = github::edit_labels_via_cli(
                 &host,
                 &owner,
                 &repo,
-                issue_number,
+                issue.number,
                 &[labels::TODO],
                 &[labels::IN_PROGRESS],
             )
@@ -2343,7 +2372,7 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
                 log::warn!(
                     "⚠️  Recovery scan: failed to reset labels for {}/issues/{}: {:#}",
                     repo_spec,
-                    issue_number,
+                    issue.number,
                     e
                 );
                 continue;
@@ -2353,7 +2382,7 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
                 &host,
                 &owner,
                 &repo,
-                issue_number,
+                issue.number,
                 "⚠️ Gru auto-recovery: issue was stuck at `gru:in-progress` with no live \
                  Minion process. Resetting to `gru:todo` so it can be retried.",
             )
@@ -2362,7 +2391,7 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
                 log::warn!(
                     "⚠️  Recovery scan: failed to post comment on {}/issues/{}: {:#}",
                     repo_spec,
-                    issue_number,
+                    issue.number,
                     e
                 );
             }

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -304,15 +304,21 @@ pub(crate) async fn handle_lab(
 
                 // Periodic recovery scan: reset orphaned gru:in-progress issues.
                 // Skips the first cycle to avoid false positives while minions are
-                // re-registering after a lab restart. After that, runs every 5 minutes
-                // using wall-clock time (immune to adaptive backoff skew).
+                // re-registering after a lab restart. The first eligible scan fires
+                // immediately on the second cycle (no 5-minute warmup), but the
+                // recovery_threshold_mins guard prevents false positives regardless.
+                // Subsequent scans use wall-clock time (immune to adaptive backoff skew).
                 if config.daemon.recovery_threshold_mins > 0 {
                     if !recovery_scan_eligible {
                         // First cycle — mark eligible for future scans.
                         recovery_scan_eligible = true;
                     } else {
-                        let should_scan = last_recovery_scan
-                            .map_or(true, |t| t.elapsed() >= Duration::from_secs(300));
+                        let should_scan = last_recovery_scan.map_or(true, |t| {
+                            t.elapsed()
+                                >= Duration::from_secs(
+                                    crate::config::RECOVERY_SCAN_INTERVAL_SECS,
+                                )
+                        });
                         if should_scan {
                             last_recovery_scan = Some(Instant::now());
                             if let Err(e) = recover_stuck_in_progress_issues(&config).await {

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -143,6 +143,12 @@ pub(crate) async fn handle_lab(
     // only serves to rate-limit GitHub API calls within a session.
     let mut wake_check_times: HashMap<String, DateTime<Utc>> = HashMap::new();
 
+    // Poll cycle counter for recovery scan cadence.
+    // First cycle is skipped to avoid false positives while minions are re-registering.
+    let mut poll_cycle: u64 = 0;
+    // Run recovery every ~5 minutes (at least every 1 cycle).
+    let recovery_every = std::cmp::max(1, 300 / config.daemon.poll_interval_secs);
+
     if no_resume {
         tprintln!("⏭️  Auto-resume disabled (--no-resume)");
         tprintln!();
@@ -294,6 +300,19 @@ pub(crate) async fn handle_lab(
                 // Log retry queue status when non-empty
                 if !retry_queue.is_empty() {
                     log_retry_queue_status(&retry_queue);
+                }
+
+                // Periodic recovery scan: reset orphaned gru:in-progress issues.
+                // Skips the first cycle to avoid false positives while minions are
+                // re-registering after a lab restart.
+                poll_cycle += 1;
+                if config.daemon.recovery_threshold_mins > 0
+                    && poll_cycle > 1
+                    && poll_cycle % recovery_every == 0
+                {
+                    if let Err(e) = recover_stuck_in_progress_issues(&config).await {
+                        log::warn!("⚠️  Recovery scan error: {:#}", e);
+                    }
                 }
 
                 // Check if a signal arrived during poll_and_spawn
@@ -2252,6 +2271,105 @@ async fn fallback_list_issues(
         .collect();
 
     Ok(filtered)
+}
+
+/// Scan for issues stuck at `gru:in-progress` with no live Minion and reset them.
+///
+/// For each configured repo, queries GitHub for open `gru:in-progress` issues, then
+/// cross-checks against the local Minion registry. Issues with no live Minion are
+/// reset to `gru:todo` with an explanatory comment so the lab can retry them.
+///
+/// Errors from individual repos are logged as warnings and do not abort the scan.
+async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> Result<()> {
+    for repo_spec in &config.daemon.repos {
+        let Some((host, owner, repo)) =
+            crate::config::parse_repo_entry_with_hosts(repo_spec, &config.github_hosts)
+        else {
+            log::warn!(
+                "⚠️  Recovery scan: could not parse repo spec '{}'",
+                repo_spec
+            );
+            continue;
+        };
+
+        let full_repo = crate::github::repo_slug(&owner, &repo);
+
+        let in_progress = match github::list_in_progress_issues_via_cli(&host, &owner, &repo).await
+        {
+            Ok(issues) => issues,
+            Err(e) => {
+                log::warn!(
+                    "⚠️  Recovery scan: failed to list in-progress issues for {}: {:#}",
+                    repo_spec,
+                    e
+                );
+                continue;
+            }
+        };
+
+        for issue_number in in_progress {
+            // If a live Minion holds this issue, skip it.
+            match is_issue_claimed(&full_repo, Some(issue_number)).await {
+                Ok(true) => continue,
+                Ok(false) => {}
+                Err(e) => {
+                    log::warn!(
+                        "⚠️  Recovery scan: could not check claim status for {}/issues/{}: {:#}",
+                        repo_spec,
+                        issue_number,
+                        e
+                    );
+                    continue;
+                }
+            }
+
+            // Orphaned issue — reset to gru:todo and leave a comment.
+            tprintln!(
+                "🔄 Recovery: resetting orphaned in-progress issue #{} in {} to gru:todo",
+                issue_number,
+                repo_spec
+            );
+
+            if let Err(e) = github::edit_labels_via_cli(
+                &host,
+                &owner,
+                &repo,
+                issue_number,
+                &[labels::TODO],
+                &[labels::IN_PROGRESS],
+            )
+            .await
+            {
+                log::warn!(
+                    "⚠️  Recovery scan: failed to reset labels for {}/issues/{}: {:#}",
+                    repo_spec,
+                    issue_number,
+                    e
+                );
+                continue;
+            }
+
+            if let Err(e) = github::post_comment_via_cli(
+                &host,
+                &owner,
+                &repo,
+                issue_number,
+                "⚠️ Gru auto-recovery: issue was stuck at `gru:in-progress` with no live \
+                 Minion process. Resetting to `gru:todo` so it can be retried.",
+            )
+            .await
+            {
+                log::warn!(
+                    "⚠️  Recovery scan: failed to post comment on {}/issues/{}: {:#}",
+                    repo_spec,
+                    issue_number,
+                    e
+                );
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -34,6 +34,10 @@ macro_rules! tprintln {
 /// causing processes that exited at ~35s to bypass label restoration.
 const EARLY_EXIT_THRESHOLD: Duration = Duration::from_secs(120);
 
+/// How often the lab runs the periodic recovery scan for orphaned in-progress issues.
+/// Not user-configurable — this is an implementation cadence, not a config knob.
+const RECOVERY_SCAN_INTERVAL: Duration = Duration::from_secs(300);
+
 /// A child process tracked by the lab, with optional metadata for label restoration.
 struct SpawnedChild {
     child: Child,
@@ -143,11 +147,11 @@ pub(crate) async fn handle_lab(
     // only serves to rate-limit GitHub API calls within a session.
     let mut wake_check_times: HashMap<String, DateTime<Utc>> = HashMap::new();
 
-    // Wall-clock time of the last recovery scan. None until the second poll cycle so
-    // the first cycle is always skipped (avoids false positives while minions are
-    // re-registering after a lab restart).
+    // Recovery scan timer. Uses a single Option<Instant>:
+    //   None  → first cycle; set to Some(now) to start the 5-min timer without scanning.
+    //   Some  → scan when elapsed >= RECOVERY_SCAN_INTERVAL, then reset.
+    // The first cycle skip avoids false positives while minions re-register after restart.
     let mut last_recovery_scan: Option<Instant> = None;
-    let mut recovery_scan_eligible = false; // set true after the first poll cycle
 
     if no_resume {
         tprintln!("⏭️  Auto-resume disabled (--no-resume)");
@@ -303,29 +307,22 @@ pub(crate) async fn handle_lab(
                 }
 
                 // Periodic recovery scan: reset orphaned gru:in-progress issues.
-                // Skips the first cycle to avoid false positives while minions are
-                // re-registering after a lab restart. On the second cycle the timer
-                // is initialised, so the first actual scan runs RECOVERY_SCAN_INTERVAL_SECS
-                // later (not immediately). Subsequent scans use wall-clock time
-                // (immune to adaptive backoff skew).
+                // None  → first cycle: start the timer without scanning (skip to let
+                //         minions re-register after a lab restart).
+                // Some  → scan when RECOVERY_SCAN_INTERVAL has elapsed, then reset.
                 if config.daemon.recovery_threshold_mins > 0 {
-                    if !recovery_scan_eligible {
-                        // First cycle — start the wall-clock timer for future scans.
-                        recovery_scan_eligible = true;
-                        last_recovery_scan = Some(Instant::now());
-                    } else {
-                        let should_scan = last_recovery_scan.is_some_and(|t| {
-                            t.elapsed()
-                                >= Duration::from_secs(
-                                    crate::config::RECOVERY_SCAN_INTERVAL_SECS,
-                                )
-                        });
-                        if should_scan {
+                    match last_recovery_scan {
+                        None => {
+                            // First cycle — start the wall-clock timer without scanning.
+                            last_recovery_scan = Some(Instant::now());
+                        }
+                        Some(t) if t.elapsed() >= RECOVERY_SCAN_INTERVAL => {
                             last_recovery_scan = Some(Instant::now());
                             if let Err(e) = recover_stuck_in_progress_issues(&config).await {
                                 log::warn!("⚠️  Recovery scan error: {:#}", e);
                             }
                         }
+                        Some(_) => {}
                     }
                 }
 

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -148,9 +148,12 @@ pub(crate) async fn handle_lab(
     let mut wake_check_times: HashMap<String, DateTime<Utc>> = HashMap::new();
 
     // Recovery scan timer. Uses a single Option<Instant>:
-    //   None  → first cycle; set to Some(now) to start the 5-min timer without scanning.
-    //   Some  → scan when elapsed >= RECOVERY_SCAN_INTERVAL, then reset.
-    // The first cycle skip avoids false positives while minions re-register after restart.
+    //   None  → first main-loop iteration (after the initial startup poll): set to
+    //           Some(now) to start the 5-minute timer without scanning.
+    //   Some  → on later main-loop iterations, scan when elapsed >= RECOVERY_SCAN_INTERVAL,
+    //           then reset.
+    // Skipping a scan on the first main-loop iteration (after the initial startup poll)
+    // avoids false positives while minions re-register after a lab restart.
     let mut last_recovery_scan: Option<Instant> = None;
 
     if no_resume {
@@ -307,13 +310,15 @@ pub(crate) async fn handle_lab(
                 }
 
                 // Periodic recovery scan: reset orphaned gru:in-progress issues.
-                // None  → first cycle: start the timer without scanning (skip to let
-                //         minions re-register after a lab restart).
+                // None  → first main-loop iteration after the initial startup poll:
+                //         start the timer without scanning so minions can re-register
+                //         after a lab restart.
                 // Some  → scan when RECOVERY_SCAN_INTERVAL has elapsed, then reset.
                 if config.daemon.recovery_threshold_mins > 0 {
                     match last_recovery_scan {
                         None => {
-                            // First cycle — start the wall-clock timer without scanning.
+                            // First main-loop iteration after the initial startup poll:
+                            // start the wall-clock timer without scanning.
                             last_recovery_scan = Some(Instant::now());
                         }
                         Some(t) if t.elapsed() >= RECOVERY_SCAN_INTERVAL => {
@@ -2288,8 +2293,9 @@ async fn fallback_list_issues(
 ///
 /// For each configured repo, queries GitHub for open `gru:in-progress` issues, then
 /// cross-checks against the local Minion registry. Issues with no live Minion *and*
-/// whose `updatedAt` is older than `recovery_threshold_mins` are reset to `gru:todo`
-/// with an explanatory comment so the lab can retry them.
+/// whose `updatedAt` is older than `recovery_threshold_mins` are reset to the
+/// configured daemon pickup label (`daemon.label`) with an explanatory comment so
+/// the lab can retry them.
 ///
 /// Per-repo and per-issue errors are logged as warnings and do not abort the scan.
 async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> Result<()> {
@@ -2356,12 +2362,14 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
                 }
             }
 
-            // Orphaned issue — reset to gru:todo and leave a comment.
+            // Orphaned issue — reset to the configured pickup label and leave a comment.
+            let ready_label = &config.daemon.label;
             tprintln!(
-                "🔄 Recovery: resetting orphaned in-progress issue #{} in {} to gru:todo \
+                "🔄 Recovery: resetting orphaned in-progress issue #{} in {} to {} \
                  (stuck for {}m)",
                 issue.number,
                 repo_spec,
+                ready_label,
                 age.num_minutes(),
             );
 
@@ -2370,7 +2378,7 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
                 &owner,
                 &repo,
                 issue.number,
-                &[labels::TODO],
+                &[ready_label.as_str()],
                 &[labels::IN_PROGRESS],
             )
             .await
@@ -2384,15 +2392,13 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
                 continue;
             }
 
-            if let Err(e) = github::post_comment_via_cli(
-                &host,
-                &owner,
-                &repo,
-                issue.number,
+            let comment = format!(
                 "⚠️ Gru auto-recovery: issue was stuck at `gru:in-progress` with no live \
-                 Minion process. Resetting to `gru:todo` so it can be retried.",
-            )
-            .await
+                 Minion process. Resetting to `{}` so it can be retried.",
+                ready_label
+            );
+            if let Err(e) =
+                github::post_comment_via_cli(&host, &owner, &repo, issue.number, &comment).await
             {
                 log::warn!(
                     "⚠️  Recovery scan: failed to post comment on {}/issues/{}: {:#}",

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -304,16 +304,17 @@ pub(crate) async fn handle_lab(
 
                 // Periodic recovery scan: reset orphaned gru:in-progress issues.
                 // Skips the first cycle to avoid false positives while minions are
-                // re-registering after a lab restart. The first eligible scan fires
-                // immediately on the second cycle (no 5-minute warmup), but the
-                // recovery_threshold_mins guard prevents false positives regardless.
-                // Subsequent scans use wall-clock time (immune to adaptive backoff skew).
+                // re-registering after a lab restart. On the second cycle the timer
+                // is initialised, so the first actual scan runs RECOVERY_SCAN_INTERVAL_SECS
+                // later (not immediately). Subsequent scans use wall-clock time
+                // (immune to adaptive backoff skew).
                 if config.daemon.recovery_threshold_mins > 0 {
                     if !recovery_scan_eligible {
-                        // First cycle — mark eligible for future scans.
+                        // First cycle — start the wall-clock timer for future scans.
                         recovery_scan_eligible = true;
+                        last_recovery_scan = Some(Instant::now());
                     } else {
-                        let should_scan = last_recovery_scan.map_or(true, |t| {
+                        let should_scan = last_recovery_scan.is_some_and(|t| {
                             t.elapsed()
                                 >= Duration::from_secs(
                                     crate::config::RECOVERY_SCAN_INTERVAL_SECS,
@@ -2295,7 +2296,9 @@ async fn fallback_list_issues(
 ///
 /// Per-repo and per-issue errors are logged as warnings and do not abort the scan.
 async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> Result<()> {
-    let threshold = chrono::Duration::minutes(config.daemon.recovery_threshold_mins as i64);
+    let threshold_mins = i64::try_from(config.daemon.recovery_threshold_mins)
+        .context("daemon.recovery_threshold_mins exceeds the maximum supported value")?;
+    let threshold = chrono::Duration::minutes(threshold_mins);
 
     for repo_spec in &config.daemon.repos {
         let Some((host, owner, repo)) =

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,8 +132,12 @@ pub(crate) struct DaemonConfig {
     /// for multi-lab deployments where another machine may hold the issue).
     /// Default: 30 minutes.
     ///
-    /// Note: the recovery scan runs every `RECOVERY_SCAN_INTERVAL_SECS` (5 min),
-    /// so values smaller than 5 are accepted but offer no finer detection granularity.
+    /// Note: the recovery scan runs every 5 minutes, so values smaller than 5
+    /// are accepted but offer no finer detection granularity.
+    ///
+    /// Note: `updatedAt` is used as a proxy for when the issue was claimed.
+    /// Any activity on the issue (including manual comments) will reset this
+    /// clock and delay auto-recovery by the threshold duration.
     #[serde(default = "default_recovery_threshold_mins")]
     pub(crate) recovery_threshold_mins: u64,
 }
@@ -264,11 +268,6 @@ fn default_archive_ttl_hours() -> u64 {
 
 /// Default recovery threshold in minutes before a stuck gru:in-progress issue is reset.
 pub(crate) const DEFAULT_RECOVERY_THRESHOLD_MINS: u64 = 30;
-
-/// How often (in seconds) the lab runs the recovery scan. Values of
-/// `recovery_threshold_mins` smaller than this divided by 60 will still work
-/// correctly — the scan just won't run more frequently than this interval.
-pub(crate) const RECOVERY_SCAN_INTERVAL_SECS: u64 = 300;
 
 fn default_recovery_threshold_mins() -> u64 {
     DEFAULT_RECOVERY_THRESHOLD_MINS

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,6 +126,13 @@ pub(crate) struct DaemonConfig {
     /// Set to 0 to disable TTL-based archiving.
     #[serde(default = "default_archive_ttl_hours")]
     pub(crate) archive_ttl_hours: u64,
+
+    /// Minutes an issue can be gru:in-progress without a live Minion before
+    /// auto-recovery resets it to gru:todo. Set to 0 to disable (recommended
+    /// for multi-lab deployments where another machine may hold the issue).
+    /// Default: 30 minutes.
+    #[serde(default = "default_recovery_threshold_mins")]
+    pub(crate) recovery_threshold_mins: u64,
 }
 
 impl Default for DaemonConfig {
@@ -140,6 +147,7 @@ impl Default for DaemonConfig {
             max_retry_backoff_secs: default_max_retry_backoff_secs(),
             poll_interval_max_secs: default_poll_interval_max(),
             archive_ttl_hours: default_archive_ttl_hours(),
+            recovery_threshold_mins: default_recovery_threshold_mins(),
         }
     }
 }
@@ -249,6 +257,13 @@ pub(crate) const DEFAULT_ARCHIVE_TTL_HOURS: u64 = 24;
 
 fn default_archive_ttl_hours() -> u64 {
     DEFAULT_ARCHIVE_TTL_HOURS
+}
+
+/// Default recovery threshold in minutes before a stuck gru:in-progress issue is reset.
+pub(crate) const DEFAULT_RECOVERY_THRESHOLD_MINS: u64 = 30;
+
+fn default_recovery_threshold_mins() -> u64 {
+    DEFAULT_RECOVERY_THRESHOLD_MINS
 }
 
 /// Parse a repo entry from the config into `(host, owner, repo)`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,6 +131,9 @@ pub(crate) struct DaemonConfig {
     /// auto-recovery resets it to gru:todo. Set to 0 to disable (recommended
     /// for multi-lab deployments where another machine may hold the issue).
     /// Default: 30 minutes.
+    ///
+    /// Note: the recovery scan runs every `RECOVERY_SCAN_INTERVAL_SECS` (5 min),
+    /// so values smaller than 5 are accepted but offer no finer detection granularity.
     #[serde(default = "default_recovery_threshold_mins")]
     pub(crate) recovery_threshold_mins: u64,
 }
@@ -261,6 +264,11 @@ fn default_archive_ttl_hours() -> u64 {
 
 /// Default recovery threshold in minutes before a stuck gru:in-progress issue is reset.
 pub(crate) const DEFAULT_RECOVERY_THRESHOLD_MINS: u64 = 30;
+
+/// How often (in seconds) the lab runs the recovery scan. Values of
+/// `recovery_threshold_mins` smaller than this divided by 60 will still work
+/// correctly — the scan just won't run more frequently than this interval.
+pub(crate) const RECOVERY_SCAN_INTERVAL_SECS: u64 = 300;
 
 fn default_recovery_threshold_mins() -> u64 {
     DEFAULT_RECOVERY_THRESHOLD_MINS

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,9 +128,9 @@ pub(crate) struct DaemonConfig {
     pub(crate) archive_ttl_hours: u64,
 
     /// Minutes an issue can be gru:in-progress without a live Minion before
-    /// auto-recovery resets it to gru:todo. Set to 0 to disable (recommended
-    /// for multi-lab deployments where another machine may hold the issue).
-    /// Default: 30 minutes.
+    /// auto-recovery resets it to the configured daemon pickup label (`daemon.label`).
+    /// Set to 0 to disable (recommended for multi-lab deployments where another
+    /// machine may hold the issue). Default: 30 minutes.
     ///
     /// Note: the recovery scan runs every 5 minutes, so values smaller than 5
     /// are accepted but offer no finer detection granularity.

--- a/src/github.rs
+++ b/src/github.rs
@@ -522,6 +522,46 @@ pub(crate) async fn list_ready_issues_via_cli(
     Ok(items)
 }
 
+/// List open issues with the `gru:in-progress` label using gh CLI.
+///
+/// Returns a list of issue numbers. Used by the lab recovery scan to find
+/// orphaned issues that have no live Minion process.
+pub(crate) async fn list_in_progress_issues_via_cli(
+    host: &str,
+    owner: &str,
+    repo: &str,
+) -> Result<Vec<u64>> {
+    let repo_full = repo_slug(owner, repo);
+    let stdout = run_gh(
+        host,
+        &[
+            "issue",
+            "list",
+            "--repo",
+            &repo_full,
+            "--label",
+            labels::IN_PROGRESS,
+            "--state",
+            "open",
+            "--json",
+            "number",
+            "--limit",
+            "100",
+        ],
+    )
+    .await?;
+
+    #[derive(serde::Deserialize)]
+    struct NumberOnly {
+        number: u64,
+    }
+
+    let items: Vec<NumberOnly> =
+        serde_json::from_str(&stdout).context("Failed to parse gh issue list JSON output")?;
+
+    Ok(items.into_iter().map(|i| i.number).collect())
+}
+
 /// Issue candidate returned by list queries, with optional body for dependency checking
 #[derive(Debug, Clone, serde::Deserialize)]
 pub(crate) struct CandidateIssue {

--- a/src/github.rs
+++ b/src/github.rs
@@ -523,6 +523,7 @@ pub(crate) async fn list_ready_issues_via_cli(
 }
 
 /// An in-progress issue returned by the recovery scan query.
+#[derive(Debug)]
 pub(crate) struct InProgressIssue {
     pub(crate) number: u64,
     /// When the issue was last updated (proxy for when it was claimed).

--- a/src/github.rs
+++ b/src/github.rs
@@ -522,16 +522,25 @@ pub(crate) async fn list_ready_issues_via_cli(
     Ok(items)
 }
 
+/// An in-progress issue returned by the recovery scan query.
+pub(crate) struct InProgressIssue {
+    pub(crate) number: u64,
+    /// When the issue was last updated (proxy for when it was claimed).
+    pub(crate) updated_at: chrono::DateTime<chrono::Utc>,
+}
+
 /// List open issues with the `gru:in-progress` label using gh CLI.
 ///
-/// Returns a list of issue numbers. Used by the lab recovery scan to find
-/// orphaned issues that have no live Minion process.
+/// Returns issue numbers and their `updatedAt` timestamps so callers can filter
+/// by how long the issue has been in-progress. Used by the lab recovery scan.
 pub(crate) async fn list_in_progress_issues_via_cli(
     host: &str,
     owner: &str,
     repo: &str,
-) -> Result<Vec<u64>> {
+) -> Result<Vec<InProgressIssue>> {
+    const LIMIT: usize = 100;
     let repo_full = repo_slug(owner, repo);
+    let limit_str = LIMIT.to_string();
     let stdout = run_gh(
         host,
         &[
@@ -544,22 +553,40 @@ pub(crate) async fn list_in_progress_issues_via_cli(
             "--state",
             "open",
             "--json",
-            "number",
+            "number,updatedAt",
             "--limit",
-            "100",
+            &limit_str,
         ],
     )
     .await?;
 
     #[derive(serde::Deserialize)]
-    struct NumberOnly {
+    #[serde(rename_all = "camelCase")]
+    struct IssueRow {
         number: u64,
+        updated_at: chrono::DateTime<chrono::Utc>,
     }
 
-    let items: Vec<NumberOnly> =
-        serde_json::from_str(&stdout).context("Failed to parse gh issue list JSON output")?;
+    let items: Vec<IssueRow> = serde_json::from_str(&stdout)
+        .context("Failed to parse gh issue list (in-progress) JSON output")?;
 
-    Ok(items.into_iter().map(|i| i.number).collect())
+    if items.len() == LIMIT {
+        log::warn!(
+            "⚠️  Recovery scan: gh issue list returned exactly {} results for {}/{} — \
+             some in-progress issues may have been truncated",
+            LIMIT,
+            owner,
+            repo
+        );
+    }
+
+    Ok(items
+        .into_iter()
+        .map(|i| InProgressIssue {
+            number: i.number,
+            updated_at: i.updated_at,
+        })
+        .collect())
 }
 
 /// Issue candidate returned by list queries, with optional body for dependency checking

--- a/src/github.rs
+++ b/src/github.rs
@@ -530,6 +530,46 @@ pub(crate) struct InProgressIssue {
     pub(crate) updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// Parse the JSON output of `gh issue list --json number,updatedAt` into
+/// `InProgressIssue` values.
+///
+/// Exposed for unit testing. Returns an error if the JSON is malformed.
+/// Logs a warning when the result count equals `limit` (possible truncation).
+pub(crate) fn parse_in_progress_issues(
+    json: &str,
+    owner: &str,
+    repo: &str,
+    limit: usize,
+) -> Result<Vec<InProgressIssue>> {
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct IssueRow {
+        number: u64,
+        updated_at: chrono::DateTime<chrono::Utc>,
+    }
+
+    let items: Vec<IssueRow> = serde_json::from_str(json)
+        .context("Failed to parse gh issue list (in-progress) JSON output")?;
+
+    if items.len() == limit {
+        log::warn!(
+            "⚠️  Recovery scan: gh issue list returned exactly {} results for {}/{} — \
+             some in-progress issues may have been truncated",
+            limit,
+            owner,
+            repo
+        );
+    }
+
+    Ok(items
+        .into_iter()
+        .map(|i| InProgressIssue {
+            number: i.number,
+            updated_at: i.updated_at,
+        })
+        .collect())
+}
+
 /// List open issues with the `gru:in-progress` label using gh CLI.
 ///
 /// Returns issue numbers and their `updatedAt` timestamps so callers can filter
@@ -561,33 +601,7 @@ pub(crate) async fn list_in_progress_issues_via_cli(
     )
     .await?;
 
-    #[derive(serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct IssueRow {
-        number: u64,
-        updated_at: chrono::DateTime<chrono::Utc>,
-    }
-
-    let items: Vec<IssueRow> = serde_json::from_str(&stdout)
-        .context("Failed to parse gh issue list (in-progress) JSON output")?;
-
-    if items.len() == LIMIT {
-        log::warn!(
-            "⚠️  Recovery scan: gh issue list returned exactly {} results for {}/{} — \
-             some in-progress issues may have been truncated",
-            LIMIT,
-            owner,
-            repo
-        );
-    }
-
-    Ok(items
-        .into_iter()
-        .map(|i| InProgressIssue {
-            number: i.number,
-            updated_at: i.updated_at,
-        })
-        .collect())
+    parse_in_progress_issues(&stdout, owner, repo, LIMIT)
 }
 
 /// Issue candidate returned by list queries, with optional body for dependency checking
@@ -2384,5 +2398,69 @@ mod tests {
         let order: Vec<u64> = candidates.iter().map(|c| c.number).collect();
         // Stable sort preserves original order within same priority tier
         assert_eq!(order, vec![10, 20, 30]);
+    }
+
+    // --- parse_in_progress_issues tests ---
+
+    #[test]
+    fn test_parse_in_progress_issues_empty() {
+        let result = parse_in_progress_issues("[]", "owner", "repo", 100).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_in_progress_issues_single() {
+        let json = r#"[{"number":42,"updatedAt":"2024-01-15T10:30:00Z"}]"#;
+        let result = parse_in_progress_issues(json, "owner", "repo", 100).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].number, 42);
+        assert_eq!(
+            result[0].updated_at,
+            "2024-01-15T10:30:00Z"
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_parse_in_progress_issues_multiple() {
+        let json = r#"[
+            {"number":1,"updatedAt":"2024-01-01T00:00:00Z"},
+            {"number":2,"updatedAt":"2024-01-02T00:00:00Z"}
+        ]"#;
+        let result = parse_in_progress_issues(json, "owner", "repo", 100).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].number, 1);
+        assert_eq!(result[1].number, 2);
+    }
+
+    #[test]
+    fn test_parse_in_progress_issues_invalid_json() {
+        let err = parse_in_progress_issues("not json", "owner", "repo", 100).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Failed to parse gh issue list (in-progress) JSON output"));
+    }
+
+    #[test]
+    fn test_parse_in_progress_issues_at_limit_logs_warning() {
+        // Build a JSON array of exactly LIMIT items; the function should succeed
+        // (the warning is logged, not returned as an error).
+        let limit = 3usize;
+        let rows: Vec<String> = (1..=limit)
+            .map(|n| format!(r#"{{"number":{},"updatedAt":"2024-01-01T00:00:00Z"}}"#, n))
+            .collect();
+        let json = format!("[{}]", rows.join(","));
+        let result = parse_in_progress_issues(&json, "owner", "repo", limit).unwrap();
+        assert_eq!(result.len(), limit);
+    }
+
+    #[test]
+    fn test_parse_in_progress_issues_below_limit_no_warning() {
+        let json = r#"[{"number":7,"updatedAt":"2024-06-01T12:00:00Z"}]"#;
+        // limit=100, only 1 item — no truncation
+        let result = parse_in_progress_issues(json, "owner", "repo", 100).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].number, 7);
     }
 }


### PR DESCRIPTION
## Summary
- Add `recovery_threshold_mins` config field to `DaemonConfig` (default: 30 min, 0 = disabled)
- Add `list_in_progress_issues_via_cli` in `src/github.rs` — queries GitHub for open `gru:in-progress` issues including `updatedAt` timestamps
- Add `recover_stuck_in_progress_issues` in `src/commands/lab.rs` that cross-checks `gru:in-progress` issues against the local Minion registry and resets orphans to `gru:todo` with a comment
- Integrate recovery scan into the lab main loop using wall-clock time (every 5 min, skipping first cycle to avoid false positives at startup)
- Guard each reset with the `recovery_threshold_mins` time check: only reset issues whose `updatedAt` is older than the threshold
- Call `prune_dead_entries_for_issue` before `is_issue_claimed` in the recovery loop to prevent PID-recycled/crashed minions from masking orphaned issues
- Warn when `gh issue list` returns exactly 100 results (possible truncation)
- Update `docs/config.example.toml` with the new field

## Test plan
- `just check` — all 1186 tests pass, linter and formatter clean
- Manual: lab with `recovery_threshold_mins = 0` → recovery scan never runs
- Manual: lab with default config → recovery log messages appear after ~5 min for orphaned in-progress issues

## Notes
- Multi-lab users should set `recovery_threshold_mins = 0` to disable — documented in config.example.toml
- The time threshold uses issue `updatedAt` as proxy for "last claimed at" — safe because the claim operation (label edit) updates the issue timestamp
- Recovery cadence uses `Instant`-based wall-clock time rather than a poll-cycle counter, so adaptive backoff doesn't affect the scan frequency

Fixes #826

<sub>🤖 M1fe</sub>