### PR TITLE
Fixes #833: Agent rebase fails: git-rebase skill's plain `git fetch origin` hits same configured-refmap conflict as #822

### DIFF
--- a/src/commands/rebase.rs
+++ b/src/commands/rebase.rs
@@ -180,12 +180,10 @@ pub(crate) async fn check_clean_worktree(worktree_path: &Path) -> Result<()> {
 
 /// Builds the argument list (after `git -C <path>`) used by [`fetch_base_branch`].
 ///
-/// `--refmap=` (empty string) disables the configured remote refmap
-/// (`+refs/heads/*:refs/heads/*`).  Without it, git applies both the explicit
-/// refspec **and** the configured refmap, and the refmap still tries to update
-/// `refs/heads/<branch>` — which git refuses when that branch is checked out in
-/// another worktree.  With `--refmap=` only our explicit refspec runs, which
-/// writes to `refs/remotes/origin/<branch>` and is never subject to that check.
+/// `--refmap=` (empty string) ensures only our explicit refspec runs, regardless
+/// of what `remote.origin.fetch` is configured to.  The configured refmap now
+/// uses `refs/remotes/origin/*` (safe), but `--refmap=` is kept as defense-in-depth
+/// and to avoid fetching all branches when only one is needed.
 fn make_fetch_args(base_branch: &str) -> Vec<String> {
     vec![
         "fetch".to_string(),
@@ -197,11 +195,8 @@ fn make_fetch_args(base_branch: &str) -> Vec<String> {
 
 /// Fetches only the specified base branch from origin.
 ///
-/// Uses an explicit refspec that writes to `refs/remotes/origin/<base_branch>`
-/// rather than `refs/heads/<base_branch>`, combined with `--refmap=` to
-/// suppress the configured remote refmap.  Together these ensure git never
-/// tries to update `refs/heads/*`, which would fail when another worktree has
-/// the base branch checked out.
+/// Uses an explicit refspec that writes to `refs/remotes/origin/<base_branch>`,
+/// combined with `--refmap=` to ensure only the named branch is fetched.
 pub(crate) async fn fetch_base_branch(worktree_path: &Path, base_branch: &str) -> Result<()> {
     let args = make_fetch_args(base_branch);
     let output = Command::new("git")
@@ -782,10 +777,8 @@ mod tests {
     #[test]
     fn test_fetch_base_branch_refspec_format() {
         // Verify the full argument list: --refmap= appears before the refspec
-        // to suppress the configured remote refmap (+refs/heads/*:refs/heads/*).
-        // Without it, git applies both our explicit refspec and the configured
-        // refmap; the refmap would still try to update refs/heads/<branch>, which
-        // git refuses when that branch is checked out in another worktree.
+        // to ensure only our explicit refspec runs (defense-in-depth and avoids
+        // fetching all branches when only one is needed).
         // The refspec writes to refs/remotes/origin/* (never checked against
         // worktree state).  The leading '+' forces the update after a force-push.
         assert_eq!(

--- a/src/git.rs
+++ b/src/git.rs
@@ -438,25 +438,39 @@ impl GitRepo {
 
         // Check if the bare repository already exists
         if self.bare_path.exists() {
-            // Migrate the fetch refspec to refs/remotes/origin/* if it still uses the
-            // legacy refs/heads/* mapping. This ensures `git fetch origin` (with no
-            // explicit refspec, e.g. run by agents) never tries to update a ref checked
-            // out in a worktree. Failure is non-fatal — the repo remains usable.
-            let migrate_output = Command::new("git")
+            // Ensure the fetch refspec maps remote branches into refs/remotes/origin/*
+            // (the standard git tracking convention). This is set unconditionally so
+            // that repos cloned before this convention was adopted are also corrected.
+            // With this refmap, plain `git fetch origin` (e.g. run by agents) never
+            // tries to update a ref checked out in a worktree. Failure is non-fatal —
+            // the repo remains usable, but agents running plain `git fetch origin`
+            // may still hit the worktree-checkout conflict on that repo.
+            match Command::new("git")
                 .arg("-C")
                 .arg(&self.bare_path)
                 .arg("config")
                 .arg("remote.origin.fetch")
                 .arg("+refs/heads/*:refs/remotes/origin/*")
                 .output()
-                .await;
-            if let Err(e) = migrate_output {
-                log::warn!(
-                    "{}/{}: could not migrate fetch refspec: {}",
+                .await
+            {
+                Err(e) => log::warn!(
+                    "{}/{}: could not update fetch refspec: {}",
                     self.owner,
                     self.repo,
                     e
-                );
+                ),
+                Ok(out) if !out.status.success() => {
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    log::warn!(
+                        "{}/{}: git config for fetch refspec exited {:?}: {}",
+                        self.owner,
+                        self.repo,
+                        out.status.code(),
+                        stderr.trim()
+                    );
+                }
+                Ok(_) => {}
             }
 
             // Fetch only the default branch to keep it up to date for new worktree creation.
@@ -1771,5 +1785,106 @@ mod tests {
         // Clean up test directories
         let _ = fs::remove_dir_all(&bare_path);
         let _ = fs::remove_dir_all(&worktree_path);
+    }
+
+    /// Verifies that `ensure_bare_clone` rewrites `remote.origin.fetch` to the
+    /// `refs/remotes/origin/*` convention for an existing bare repo that still
+    /// has the legacy `refs/heads/*:refs/heads/*` mapping.
+    ///
+    /// This is a local-only test: it creates a minimal bare repo with a dummy
+    /// remote URL, plants the old config, and confirms the migration runs
+    /// without needing a real network connection.  The subsequent fetch attempt
+    /// will fail (the remote URL is not reachable) but the config update happens
+    /// before the fetch and its result is visible regardless.
+    #[tokio::test]
+    #[ignore = "local only: no network required, but requires git binary"]
+    async fn test_ensure_bare_clone_migrates_fetch_refspec() {
+        use tokio::process::Command;
+
+        let temp_dir = env::temp_dir();
+        let bare_path = temp_dir.join("test-gru-migrate-refspec.git");
+        let _ = tokio::fs::remove_dir_all(&bare_path).await;
+
+        // Set up a local bare repo that looks like it was cloned with the old refmap.
+        Command::new("git")
+            .args(["init", "--bare"])
+            .arg(&bare_path)
+            .output()
+            .await
+            .expect("git init --bare failed");
+
+        // Plant a fake remote so git config has something to write to.
+        Command::new("git")
+            .arg("-C")
+            .arg(&bare_path)
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.example.com/owner/repo.git",
+            ])
+            .output()
+            .await
+            .expect("git remote add failed");
+
+        // Simulate the legacy refmap.
+        Command::new("git")
+            .arg("-C")
+            .arg(&bare_path)
+            .args([
+                "config",
+                "remote.origin.fetch",
+                "+refs/heads/*:refs/heads/*",
+            ])
+            .output()
+            .await
+            .expect("git config failed");
+
+        // Confirm the old value is in place.
+        let before = Command::new("git")
+            .arg("-C")
+            .arg(&bare_path)
+            .args(["config", "remote.origin.fetch"])
+            .output()
+            .await
+            .expect("git config read failed");
+        assert_eq!(
+            String::from_utf8_lossy(&before.stdout).trim(),
+            "+refs/heads/*:refs/heads/*",
+            "pre-condition: old refmap should be set"
+        );
+
+        // Now call the migration path directly (same command ensure_bare_clone runs).
+        let result = Command::new("git")
+            .arg("-C")
+            .arg(&bare_path)
+            .args([
+                "config",
+                "remote.origin.fetch",
+                "+refs/heads/*:refs/remotes/origin/*",
+            ])
+            .output()
+            .await
+            .expect("migration command failed");
+        assert!(
+            result.status.success(),
+            "migration git config should succeed"
+        );
+
+        // Verify the config was updated.
+        let after = Command::new("git")
+            .arg("-C")
+            .arg(&bare_path)
+            .args(["config", "remote.origin.fetch"])
+            .output()
+            .await
+            .expect("git config read failed");
+        assert_eq!(
+            String::from_utf8_lossy(&after.stdout).trim(),
+            "+refs/heads/*:refs/remotes/origin/*",
+            "fetch refspec should be updated to refs/remotes/origin/*"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&bare_path).await;
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -438,9 +438,28 @@ impl GitRepo {
 
         // Check if the bare repository already exists
         if self.bare_path.exists() {
+            // Migrate the fetch refspec to refs/remotes/origin/* if it still uses the
+            // legacy refs/heads/* mapping. This ensures `git fetch origin` (with no
+            // explicit refspec, e.g. run by agents) never tries to update a ref checked
+            // out in a worktree. Failure is non-fatal — the repo remains usable.
+            let migrate_output = Command::new("git")
+                .arg("-C")
+                .arg(&self.bare_path)
+                .arg("config")
+                .arg("remote.origin.fetch")
+                .arg("+refs/heads/*:refs/remotes/origin/*")
+                .output()
+                .await;
+            if let Err(e) = migrate_output {
+                log::warn!(
+                    "{}/{}: could not migrate fetch refspec: {}",
+                    self.owner,
+                    self.repo,
+                    e
+                );
+            }
+
             // Fetch only the default branch to keep it up to date for new worktree creation.
-            // We avoid fetching all branches (refs/heads/*) because git refuses to update
-            // any ref that is checked out in a worktree, causing the entire fetch to fail.
             // Feature branches are fetched on demand via fetch_branch().
             let mut fetched = false;
             for branch in DEFAULT_BRANCHES {
@@ -550,14 +569,18 @@ impl GitRepo {
                 );
             }
 
-            // Configure fetch refspec so future fetches update local branches directly
-            // (git clone --bare doesn't set this by default)
+            // Configure fetch refspec to map remote branches into refs/remotes/origin/*
+            // (the standard git convention). Using refs/remotes/origin/* instead of
+            // refs/heads/* means `git fetch origin` (with no explicit refspec) never tries
+            // to update a ref that may be checked out in a worktree, eliminating the
+            // "refusing to fetch into branch" error that occurs when another worktree has
+            // the default branch checked out.
             let output = Command::new("git")
                 .arg("-C")
                 .arg(&self.bare_path)
                 .arg("config")
                 .arg("remote.origin.fetch")
-                .arg("+refs/heads/*:refs/heads/*")
+                .arg("+refs/heads/*:refs/remotes/origin/*")
                 .output()
                 .await
                 .context("Failed to execute git config for remote.origin.fetch")?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -451,6 +451,9 @@ impl GitRepo {
                 .arg("config")
                 .arg("remote.origin.fetch")
                 .arg("+refs/heads/*:refs/remotes/origin/*")
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_WORK_TREE")
+                .env_remove("GIT_INDEX_FILE")
                 .output()
                 .await
             {
@@ -1801,14 +1804,12 @@ mod tests {
     async fn test_ensure_bare_clone_migrates_fetch_refspec() {
         use tokio::process::Command;
 
-        let temp_dir = env::temp_dir();
-        let work_path = temp_dir.join("test-gru-migrate-work");
-        let source_path = temp_dir.join("test-gru-migrate-source.git");
-        let clone_path = temp_dir.join("test-gru-migrate-clone.git");
-
-        for p in [&work_path, &source_path, &clone_path] {
-            let _ = tokio::fs::remove_dir_all(p).await;
-        }
+        // Use tempfile::tempdir() for a unique, auto-cleaned directory so
+        // concurrent runs or leftover directories don't cause collisions.
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let work_path = tmp.path().join("work");
+        let source_path = tmp.path().join("source.git");
+        let clone_path = tmp.path().join("clone.git");
 
         // Create a working directory with an initial commit so the source bare
         // repo has at least one branch (required for a successful fetch later).
@@ -1907,9 +1908,6 @@ mod tests {
             "+refs/heads/*:refs/remotes/origin/*",
             "fetch refspec should be updated to refs/remotes/origin/* after ensure_bare_clone"
         );
-
-        for p in [&work_path, &source_path, &clone_path] {
-            let _ = tokio::fs::remove_dir_all(p).await;
-        }
+        // `tmp` drops here, cleaning up all directories automatically.
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1788,49 +1788,75 @@ mod tests {
     }
 
     /// Verifies that `ensure_bare_clone` rewrites `remote.origin.fetch` to the
-    /// `refs/remotes/origin/*` convention for an existing bare repo that still
-    /// has the legacy `refs/heads/*:refs/heads/*` mapping.
+    /// `refs/remotes/origin/*` convention when called on a bare repo that still
+    /// has the legacy `+refs/heads/*:refs/heads/*` mapping.
     ///
-    /// This is a local-only test: it creates a minimal bare repo with a dummy
-    /// remote URL, plants the old config, and confirms the migration runs
-    /// without needing a real network connection.  The subsequent fetch attempt
-    /// will fail (the remote URL is not reachable) but the config update happens
-    /// before the fetch and its result is visible regardless.
+    /// Uses a fully local setup (no network): a "source" bare repo with a real
+    /// branch is created, a "clone" bare repo is set up pointing at it, the old
+    /// refmap is planted on the clone, and then `ensure_bare_clone` is called.
+    /// Because the local source is reachable, the fetch inside `ensure_bare_clone`
+    /// also succeeds, exercising the full code path.
     #[tokio::test]
     #[ignore = "local only: no network required, but requires git binary"]
     async fn test_ensure_bare_clone_migrates_fetch_refspec() {
         use tokio::process::Command;
 
         let temp_dir = env::temp_dir();
-        let bare_path = temp_dir.join("test-gru-migrate-refspec.git");
-        let _ = tokio::fs::remove_dir_all(&bare_path).await;
+        let work_path = temp_dir.join("test-gru-migrate-work");
+        let source_path = temp_dir.join("test-gru-migrate-source.git");
+        let clone_path = temp_dir.join("test-gru-migrate-clone.git");
 
-        // Set up a local bare repo that looks like it was cloned with the old refmap.
+        for p in [&work_path, &source_path, &clone_path] {
+            let _ = tokio::fs::remove_dir_all(p).await;
+        }
+
+        // Create a working directory with an initial commit so the source bare
+        // repo has at least one branch (required for a successful fetch later).
         Command::new("git")
-            .args(["init", "--bare"])
-            .arg(&bare_path)
+            .args(["init"])
+            .arg(&work_path)
             .output()
             .await
-            .expect("git init --bare failed");
-
-        // Plant a fake remote so git config has something to write to.
+            .expect("git init failed");
+        for (k, v) in [("user.email", "test@test.com"), ("user.name", "Test")] {
+            Command::new("git")
+                .arg("-C")
+                .arg(&work_path)
+                .args(["config", k, v])
+                .output()
+                .await
+                .expect("git config failed");
+        }
         Command::new("git")
             .arg("-C")
-            .arg(&bare_path)
-            .args([
-                "remote",
-                "add",
-                "origin",
-                "https://github.example.com/owner/repo.git",
-            ])
+            .arg(&work_path)
+            .args(["commit", "--allow-empty", "-m", "init"])
             .output()
             .await
-            .expect("git remote add failed");
+            .expect("git commit failed");
 
-        // Simulate the legacy refmap.
+        // Create the "source" bare repo from the working directory.
+        Command::new("git")
+            .args(["clone", "--bare"])
+            .arg(&work_path)
+            .arg(&source_path)
+            .output()
+            .await
+            .expect("git clone --bare failed");
+
+        // Create the "clone" bare repo from the source.
+        Command::new("git")
+            .args(["clone", "--bare"])
+            .arg(&source_path)
+            .arg(&clone_path)
+            .output()
+            .await
+            .expect("git clone --bare (clone) failed");
+
+        // Plant the legacy refmap on the clone to simulate a pre-fix repo.
         Command::new("git")
             .arg("-C")
-            .arg(&bare_path)
+            .arg(&clone_path)
             .args([
                 "config",
                 "remote.origin.fetch",
@@ -1840,10 +1866,10 @@ mod tests {
             .await
             .expect("git config failed");
 
-        // Confirm the old value is in place.
+        // Pre-condition: verify old refmap is set.
         let before = Command::new("git")
             .arg("-C")
-            .arg(&bare_path)
+            .arg(&clone_path)
             .args(["config", "remote.origin.fetch"])
             .output()
             .await
@@ -1851,30 +1877,27 @@ mod tests {
         assert_eq!(
             String::from_utf8_lossy(&before.stdout).trim(),
             "+refs/heads/*:refs/heads/*",
-            "pre-condition: old refmap should be set"
+            "pre-condition: old refmap should be set before calling ensure_bare_clone"
         );
 
-        // Now call the migration path directly (same command ensure_bare_clone runs).
-        let result = Command::new("git")
-            .arg("-C")
-            .arg(&bare_path)
-            .args([
-                "config",
-                "remote.origin.fetch",
-                "+refs/heads/*:refs/remotes/origin/*",
-            ])
-            .output()
-            .await
-            .expect("migration command failed");
+        // Call ensure_bare_clone — this should migrate the refmap.
+        let repo = GitRepo::new(
+            "test-owner",
+            "test-repo",
+            "github.example.com",
+            clone_path.clone(),
+        );
+        let result = repo.ensure_bare_clone().await;
         assert!(
-            result.status.success(),
-            "migration git config should succeed"
+            result.is_ok(),
+            "ensure_bare_clone should succeed on a local repo: {:?}",
+            result
         );
 
-        // Verify the config was updated.
+        // Post-condition: refmap must be updated.
         let after = Command::new("git")
             .arg("-C")
-            .arg(&bare_path)
+            .arg(&clone_path)
             .args(["config", "remote.origin.fetch"])
             .output()
             .await
@@ -1882,9 +1905,11 @@ mod tests {
         assert_eq!(
             String::from_utf8_lossy(&after.stdout).trim(),
             "+refs/heads/*:refs/remotes/origin/*",
-            "fetch refspec should be updated to refs/remotes/origin/*"
+            "fetch refspec should be updated to refs/remotes/origin/* after ensure_bare_clone"
         );
 
-        let _ = tokio::fs::remove_dir_all(&bare_path).await;
+        for p in [&work_path, &source_path, &clone_path] {
+            let _ = tokio::fs::remove_dir_all(p).await;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Change `remote.origin.fetch` configured in bare repos from `+refs/heads/*:refs/heads/*` to `+refs/heads/*:refs/remotes/origin/*` (standard git tracking convention)
- Add a migration step in `ensure_bare_clone`'s existing-repo path so that repos cloned before this change are corrected on the next `gru do` invocation
- Update stale comments in `rebase.rs` that referenced the old configured refmap
- Add a local-only `#[ignore]` test verifying the refmap migration command works end-to-end

**Root cause:** With the old refmap, any plain `git fetch origin` — including those run by the git-rebase skill during agent-assisted conflict resolution — would try to update `refs/heads/main`. Git refuses this when `main` is checked out in a worktree, causing the agent to exit 0 without completing the rebase and Gru to report `ConflictUnresolved`.

**Fix:** With `+refs/heads/*:refs/remotes/origin/*`, plain `git fetch origin` writes to `refs/remotes/origin/*`, which are never checked out in worktrees. Gru's own explicit-refspec fetches (`+refs/heads/branch:refs/heads/branch`) are unaffected — explicit refspecs on the command line replace the configured refmap.

## Test plan

- `just check` passes (fmt + lint + 1186 tests)
- New `#[ignore]` test `test_ensure_bare_clone_migrates_fetch_refspec` passes when run explicitly: `cargo nextest run --run-ignored all git::tests::test_ensure_bare_clone_migrates_fetch_refspec`
- Existing integration test `test_git_operations_integration` still verifies that `refs/remotes/origin/HEAD` is set correctly after clone

## Notes

- The `--refmap=` flag in `fetch_base_branch` (added in #822) is kept as defense-in-depth; its comments are updated to reflect that the configured refmap is now already safe
- The `fetch_default_branch_for_worktree` and `fetch_branch` methods still use explicit `+refs/heads/{}:refs/heads/{}` refspecs — these are unaffected by the configured refmap change and correctly keep `refs/heads/main` up-to-date for worktree creation

Fixes #833

<sub>🤖 M1fm</sub>