### PR TITLE
Fixes #834: /rebase skill exits 0 on failure — exit code not usable for success/failure signaling

### DIFF
--- a/src/commands/rebase.rs
+++ b/src/commands/rebase.rs
@@ -89,6 +89,19 @@ pub(crate) async fn handle_rebase(
                 // Agent succeeded: enforce branch recovery (any failure is a real error).
                 ensure_on_branch(&worktree_path, &local_branch).await?;
 
+                // Postcondition: verify the rebase actually completed.
+                // Claude Code exits 0 by default even when the rebase fails, so
+                // we check independently that origin/<base_branch> is now an ancestor
+                // of HEAD — the canonical proof that the rebase landed.
+                if !is_up_to_date(&worktree_path, &base_branch).await? {
+                    println!(
+                        "❌ Agent exited 0 but origin/{} is not an ancestor of HEAD — rebase did not complete.\n\
+                         You can retry with `gru rebase`, or perform the rebase manually with `git rebase origin/{}`.",
+                        base_branch, base_branch
+                    );
+                    return Ok(1);
+                }
+
                 if push {
                     // Defensively force push in case the /rebase skill didn't push
                     if !maybe_force_push(&worktree_path, yes).await? {

--- a/src/prompt_loader.rs
+++ b/src/prompt_loader.rs
@@ -260,6 +260,7 @@ After resolving each conflict:
 ## 6. If Something Goes Wrong
 - If the rebase cannot be completed, abort with `git rebase --abort`
 - Report what went wrong and suggest next steps
+- Signal failure by running `bash -c 'exit 1'` so gru records a non-zero exit code
 "#,
     },
 ];

--- a/src/prompt_loader.rs
+++ b/src/prompt_loader.rs
@@ -251,6 +251,8 @@ After resolving each conflict:
 
 ## 5. After Rebase Completes
 - Review the changes: `git log --oneline origin/<base_branch>..HEAD`
+- Verify the rebase succeeded: `git merge-base --is-ancestor origin/<base_branch> HEAD`
+  - If this command exits non-zero, the rebase did not complete — report what went wrong and run `bash -c 'exit 1'`
 - Run the project's test suite to ensure nothing broke (check CLAUDE.md for test commands, if present)
 - Force push the rebased branch: `git push --force-with-lease`
 - Report the result to the user
@@ -1631,6 +1633,8 @@ Repo content"#,
         assert!(prompt.content.contains("Fetch and Rebase"));
         assert!(prompt.content.contains("Resolve Conflicts"));
         assert!(prompt.content.contains("force-with-lease"));
+        assert!(prompt.content.contains("merge-base --is-ancestor"));
+        assert!(prompt.content.contains("bash -c 'exit 1'"));
 
         // Template should NOT hardcode origin/ before {{ base_branch }}
         // to avoid double-prefixing when base_branch is "origin/main"


### PR DESCRIPTION
## Summary

- **Prompt fix (defense-in-depth):** Added a `git merge-base --is-ancestor` postcondition to the `/rebase` skill prompt. After the rebase completes, the agent now verifies that `origin/<base_branch>` is an ancestor of HEAD before force-pushing. If the check fails, the agent runs `bash -c 'exit 1'` to exit non-zero — making `run_agent_rebase`'s exit-code check meaningful for any future failure mode.
- **Rust-side fix:** Added the same `is_up_to_date` postcondition guard to `handle_rebase` (`gru rebase` interactive path). This mirrors the guard already present in `auto_rebase_pr` (added in #831), so both paths now independently verify the rebase landed before proceeding.

## Test plan

- All 1192 existing tests pass (`just test`)
- Lint clean (`just lint`)
- New prompt assertions verify the `merge-base --is-ancestor` check and `bash -c 'exit 1'` escape hatch are present in the prompt template

## Notes

- The `bash -c 'exit 1'` mechanism in the prompt is documented in the issue as the way to cause Claude Code to exit non-zero from a tool call. The Rust-side `is_up_to_date` check provides an independent safety net in case prompt instructions are not followed.
- The `is_up_to_date` function in `rebase.rs` already uses the same `git merge-base --is-ancestor` invocation, so both layers check the identical postcondition.
- Closes #834. Related: #830 (Rust-side check for `auto_rebase_pr`), #833 (root cause of the verso#225 incident).

Fixes #834

<sub>🤖 M1fp</sub>