### PR TITLE
Fixes #839: web_url host not recognized in URL parsing (github.netflix.net vs git.netflix.net)

### DIFF
--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -81,9 +81,9 @@ async fn detect_project_context(repo_flag: Option<String>) -> Option<(PathBuf, S
 
     // Try to detect from current directory
     let repo_root = git::detect_git_repo().await.ok()?;
-    let github_hosts = crate::config::load_host_registry().all_hosts();
-    let remote_url = git::get_github_remote(&github_hosts).await.ok()?;
-    let (_host, owner, repo_name) = git::parse_github_remote(&remote_url, &github_hosts).ok()?;
+    let host_registry = crate::config::load_host_registry();
+    let remote_url = git::get_github_remote(&host_registry).await.ok()?;
+    let (_host, owner, repo_name) = git::parse_github_remote(&remote_url, &host_registry).ok()?;
     Some((repo_root, owner, repo_name))
 }
 

--- a/src/commands/fix/mod.rs
+++ b/src/commands/fix/mod.rs
@@ -187,8 +187,8 @@ async fn run_worker(minion_id: &str, issue: &str, opts: FixOptions) -> Result<i3
     let backend = agent_registry::resolve_backend(&agent_name)?;
 
     // Fetch fresh issue details for the worker
-    let github_hosts = crate::config::load_host_registry().all_hosts();
-    let issue_ctx = resolve_issue(issue, &github_hosts).await?;
+    let host_registry = crate::config::load_host_registry();
+    let issue_ctx = resolve_issue(issue, &host_registry).await?;
 
     // Determine resume phase from registry
     let start_phase = info.orchestration_phase.clone();
@@ -357,8 +357,8 @@ pub(crate) async fn handle_fix(issue: &str, opts: FixOptions) -> Result<i32> {
     let ignore_deps = opts.ignore_deps;
 
     // Phase 1: Resolve issue
-    let github_hosts = crate::config::load_host_registry().all_hosts();
-    let issue_ctx = resolve_issue(issue, &github_hosts).await?;
+    let host_registry = crate::config::load_host_registry();
+    let issue_ctx = resolve_issue(issue, &host_registry).await?;
 
     // Check for unresolved blockers (unless --ignore-deps)
     if !ignore_deps {

--- a/src/commands/fix/resolve.rs
+++ b/src/commands/fix/resolve.rs
@@ -1,4 +1,5 @@
 use super::types::{ExistingMinionCheck, IssueContext, IssueDetails};
+use crate::config::HostRegistry;
 use crate::minion_registry::{with_registry, MinionInfo, MinionMode};
 use crate::url_utils::parse_issue_info;
 use anyhow::{Context, Result};
@@ -9,8 +10,11 @@ use anyhow::{Context, Result};
 /// Note: Does NOT claim the issue — that happens after worktree setup to avoid
 /// marking issues as in-progress when setup fails.
 /// Note: Existing minion check is done in `handle_fix` to support resume logic.
-pub(crate) async fn resolve_issue(issue: &str, github_hosts: &[String]) -> Result<IssueContext> {
-    let (owner, repo, issue_num_str, host) = parse_issue_info(issue, github_hosts).await?;
+pub(crate) async fn resolve_issue(
+    issue: &str,
+    host_registry: &HostRegistry,
+) -> Result<IssueContext> {
+    let (owner, repo, issue_num_str, host) = parse_issue_info(issue, host_registry).await?;
     let issue_num: u64 = issue_num_str
         .parse()
         .context("Failed to parse issue number")?;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -339,13 +339,13 @@ async fn detect_current_repo() -> Result<(String, String, String)> {
     let _git_dir = detect_git_repo().await.context("Not in a git repository")?;
 
     // Get the remote URL (function doesn't need git_dir - it uses current directory)
-    let github_hosts = crate::config::load_host_registry().all_hosts();
-    let remote_url = get_github_remote(&github_hosts)
+    let host_registry = crate::config::load_host_registry();
+    let remote_url = get_github_remote(&host_registry)
         .await
         .context("No GitHub remote found in current repository")?;
 
     // Parse owner/repo from remote URL
-    let (host, owner, repo) = parse_github_remote(&remote_url, &github_hosts)
+    let (host, owner, repo) = parse_github_remote(&remote_url, &host_registry)
         .context("Could not parse GitHub owner/repo from remote URL")?;
 
     println!("  Detected: {}/{}", owner, repo);

--- a/src/commands/prompt.rs
+++ b/src/commands/prompt.rs
@@ -37,8 +37,8 @@ fn parse_params(params: &[String]) -> Result<HashMap<String, String>> {
 async fn fetch_issue_context(
     issue_str: &str,
 ) -> Result<(PromptContext, String, String, String, u64)> {
-    let github_hosts = crate::config::load_host_registry().all_hosts();
-    let (owner, repo, issue_num_str, host) = parse_issue_info(issue_str, &github_hosts).await?;
+    let host_registry = crate::config::load_host_registry();
+    let (owner, repo, issue_num_str, host) = parse_issue_info(issue_str, &host_registry).await?;
     let issue_number: u64 = issue_num_str
         .parse()
         .context("Failed to parse issue number")?;
@@ -73,7 +73,7 @@ async fn fetch_issue_context(
 /// For plain numbers, auto-detects the repository from the current directory.
 /// For URLs, extracts components directly.
 async fn parse_pr_arg(pr_str: &str) -> Result<(String, String, String, u64)> {
-    let github_hosts = crate::config::load_host_registry().all_hosts();
+    let host_registry = crate::config::load_host_registry();
 
     if let Ok(num) = pr_str.parse::<u64>() {
         // Auto-detect repository from current directory
@@ -81,17 +81,17 @@ async fn parse_pr_arg(pr_str: &str) -> Result<(String, String, String, u64)> {
             .await
             .context("Failed to detect git repository")?;
 
-        let remote_url = git::get_github_remote(&github_hosts)
+        let remote_url = git::get_github_remote(&host_registry)
             .await
             .context("Failed to get GitHub remote")?;
 
-        let (host, owner, repo) = git::parse_github_remote(&remote_url, &github_hosts)
+        let (host, owner, repo) = git::parse_github_remote(&remote_url, &host_registry)
             .context("Failed to parse GitHub remote URL")?;
 
         return Ok((owner, repo, host, num));
     }
 
-    if let Some(parsed) = parse_github_url(pr_str, &github_hosts) {
+    if let Some(parsed) = parse_github_url(pr_str, &host_registry) {
         if parsed.resource_type == GitHubResourceType::Pull {
             return Ok((parsed.owner, parsed.repo, parsed.host, parsed.number as u64));
         }

--- a/src/commands/rebase.rs
+++ b/src/commands/rebase.rs
@@ -283,9 +283,9 @@ pub(crate) async fn detect_base_branch(worktree_path: &Path) -> Result<String> {
     }
 
     // Query GitHub API for the default branch
-    let github_hosts = crate::config::load_host_registry().all_hosts();
+    let host_registry = crate::config::load_host_registry();
     if let Ok(remote_url) = get_remote_url(worktree_path).await {
-        match git::parse_github_remote(&remote_url, &github_hosts) {
+        match git::parse_github_remote(&remote_url, &host_registry) {
             Ok((host, owner, repo)) => {
                 match github::get_default_branch(&host, &owner, &repo).await {
                     Ok(branch_name) => return Ok(branch_name),
@@ -492,9 +492,9 @@ pub(crate) async fn ensure_on_branch(worktree_path: &Path, expected_branch: &str
 /// Tries to get the base branch from an associated PR via GitHub CLI.
 async fn get_pr_base_branch(worktree_path: &Path, branch: &str) -> Result<Option<String>> {
     // Detect repo from the worktree (not CWD) to pick gh vs ghe
-    let github_hosts = crate::config::load_host_registry().all_hosts();
+    let host_registry = crate::config::load_host_registry();
     let remote_url = get_remote_url(worktree_path).await?;
-    let (host, owner, repo) = git::parse_github_remote(&remote_url, &github_hosts)?;
+    let (host, owner, repo) = git::parse_github_remote(&remote_url, &host_registry)?;
     let repo_full = github::repo_slug(&owner, &repo);
 
     let output = github::gh_cli_command(&host)

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -441,7 +441,7 @@ pub(crate) async fn resolve_host_from_worktree(
     checkout_path: &std::path::Path,
     owner: &str,
 ) -> String {
-    let github_hosts = crate::config::load_host_registry().all_hosts();
+    let host_registry = crate::config::load_host_registry();
 
     // Try to get the host from the worktree's git remote
     let output = tokio::process::Command::new("git")
@@ -454,7 +454,7 @@ pub(crate) async fn resolve_host_from_worktree(
         if output.status.success() {
             let remote_url = String::from_utf8_lossy(&output.stdout).trim().to_string();
             // First try the full parser (validates against known hosts)
-            if let Ok((host, _, _)) = crate::git::parse_github_remote(&remote_url, &github_hosts) {
+            if let Ok((host, _, _)) = crate::git::parse_github_remote(&remote_url, &host_registry) {
                 return host;
             }
             // If the remote URL is valid but the host isn't in the registry,

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -306,8 +306,8 @@ async fn resolve_pr_from_arg(arg: &str) -> Result<(String, String, String, Strin
     }
 
     // Strategy 2: Try as PR number or URL (existing behavior)
-    let github_hosts = crate::config::load_host_registry().all_hosts();
-    match parse_pr_info(arg, &github_hosts).await {
+    let host_registry = crate::config::load_host_registry();
+    match parse_pr_info(arg, &host_registry).await {
         Ok(pr_info) => return Ok(pr_info),
         Err(e) => errors.push(format!("PR number/URL '{}': {:#}", arg, e)),
     }
@@ -363,8 +363,8 @@ async fn get_pr_info_from_number(pr_num: &str) -> Result<(String, String, String
         .with_context(|| format!("Invalid PR number format: '{}'", pr_num))?;
 
     // Use parse_pr_info which fetches metadata from GitHub
-    let github_hosts = crate::config::load_host_registry().all_hosts();
-    parse_pr_info(pr_num, &github_hosts).await
+    let host_registry = crate::config::load_host_registry();
+    parse_pr_info(pr_num, &host_registry).await
 }
 
 /// Finds a PR number associated with an issue number
@@ -374,11 +374,11 @@ async fn find_pr_for_issue(issue_num: u64) -> Result<String> {
     git::detect_git_repo()
         .await
         .context("Failed to detect git repository")?;
-    let github_hosts = crate::config::load_host_registry().all_hosts();
-    let remote_url = git::get_github_remote(&github_hosts)
+    let host_registry = crate::config::load_host_registry();
+    let remote_url = git::get_github_remote(&host_registry)
         .await
         .context("Failed to get GitHub remote")?;
-    let (host, det_owner, det_repo) = git::parse_github_remote(&remote_url, &github_hosts)
+    let (host, det_owner, det_repo) = git::parse_github_remote(&remote_url, &host_registry)
         .context("Failed to parse GitHub remote URL")?;
     let repo_full = github::repo_slug(&det_owner, &det_repo);
     // Safe: issue_num is validated as u64 by the type system, which can only contain digits.

--- a/src/config.rs
+++ b/src/config.rs
@@ -375,9 +375,65 @@ impl HostRegistry {
         Self { hosts }
     }
 
-    /// All known hostnames (always includes `github.com`).
-    pub(crate) fn all_hosts(&self) -> Vec<String> {
-        self.hosts.keys().cloned().collect()
+    /// All hostnames recognized when matching a GitHub URL: every API host plus
+    /// every configured `web_url` host.
+    ///
+    /// Web UI and API hosts may differ (e.g. Netflix has the API at
+    /// `git.netflix.net` and the web UI at `github.netflix.net`). A URL using
+    /// either form is a legitimate reference to the same repository, so URL
+    /// parsers match against this broader list. After a match, resolve the
+    /// matched host back to the API host via [`HostRegistry::canonical_host`].
+    pub(crate) fn all_url_hosts(&self) -> Vec<String> {
+        let mut result: Vec<String> = self.hosts.keys().cloned().collect();
+        for web_url in self.hosts.values().flatten() {
+            if let Some(host) = web_url_to_host(web_url) {
+                if !result.iter().any(|h| h == &host) {
+                    result.push(host);
+                }
+            }
+        }
+        result
+    }
+
+    /// Maps any recognized hostname back to its canonical API host.
+    ///
+    /// If `host` is already a known API host, returns it. If it matches a
+    /// configured `web_url` hostname, returns the associated API host. Returns
+    /// `None` when `host` is unknown.
+    pub(crate) fn canonical_host(&self, host: &str) -> Option<String> {
+        if self.hosts.contains_key(host) {
+            return Some(host.to_string());
+        }
+        for (api_host, web_url_opt) in &self.hosts {
+            if let Some(web_url) = web_url_opt {
+                if let Some(web_host) = web_url_to_host(web_url) {
+                    if web_host == host {
+                        return Some(api_host.clone());
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Extracts the hostname from a configured `web_url` value.
+///
+/// Accepts values like `"https://github.netflix.net"`,
+/// `"https://github.netflix.net/"`, or `"https://github.netflix.net:8080"`,
+/// returning `"github.netflix.net"`. Returns `None` when the value is missing
+/// an `http(s)://` prefix or the hostname is empty.
+fn web_url_to_host(web_url: &str) -> Option<String> {
+    let s = web_url.trim();
+    let rest = s
+        .strip_prefix("https://")
+        .or_else(|| s.strip_prefix("http://"))?;
+    let end = rest.find(['/', ':']).unwrap_or(rest.len());
+    let host = &rest[..end];
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_string())
     }
 }
 
@@ -1055,7 +1111,7 @@ confidence_threshold = 6
     fn test_github_hosts_default() {
         let config = LabConfig::default();
         let registry = HostRegistry::from_config(&config);
-        let mut hosts = registry.all_hosts();
+        let mut hosts = registry.all_url_hosts();
         hosts.sort();
         assert_eq!(hosts, vec!["github.com"]);
     }
@@ -1072,7 +1128,7 @@ repos = ["owner/repo", "ghe.example.com/org/service", "git.corp.net/team/app"]
 
         let config = LabConfig::load(temp_file.path()).unwrap();
         let registry = HostRegistry::from_config(&config);
-        let mut hosts = registry.all_hosts();
+        let mut hosts = registry.all_url_hosts();
         hosts.sort();
         assert_eq!(hosts, vec!["ghe.example.com", "git.corp.net", "github.com"]);
     }
@@ -1089,7 +1145,7 @@ repos = ["owner/repo1", "ghe.example.com/org/svc1", "ghe.example.com/org/svc2"]
 
         let config = LabConfig::load(temp_file.path()).unwrap();
         let registry = HostRegistry::from_config(&config);
-        let mut hosts = registry.all_hosts();
+        let mut hosts = registry.all_url_hosts();
         hosts.sort();
         assert_eq!(hosts, vec!["ghe.example.com", "github.com"]);
     }
@@ -1212,7 +1268,7 @@ repos = ["owner/repo1", "ghe.example.com/org/svc1", "ghe.example.com/org/svc2"]
     fn test_host_registry_default_config() {
         let config = LabConfig::default();
         let registry = HostRegistry::from_config(&config);
-        let mut hosts = registry.all_hosts();
+        let mut hosts = registry.all_url_hosts();
         hosts.sort();
         assert_eq!(hosts, vec!["github.com"]);
     }
@@ -1228,9 +1284,102 @@ repos = ["owner/repo1", "ghe.example.com/org/svc1", "ghe.example.com/org/svc2"]
             },
         );
         let registry = HostRegistry::from_config(&config);
-        let mut hosts = registry.all_hosts();
+        // all_url_hosts includes both API host (git.netflix.net) and web UI host (github.netflix.net)
+        let mut hosts = registry.all_url_hosts();
         hosts.sort();
-        assert_eq!(hosts, vec!["git.netflix.net", "github.com"]);
+        assert_eq!(
+            hosts,
+            vec!["git.netflix.net", "github.com", "github.netflix.net"]
+        );
+    }
+
+    #[test]
+    fn test_canonical_host_resolves_web_url_to_api_host() {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "netflix".to_string(),
+            GhHostConfig {
+                host: "git.netflix.net".to_string(),
+                web_url: Some("https://github.netflix.net".to_string()),
+            },
+        );
+        let registry = HostRegistry::from_config(&config);
+
+        // Web UI hostname resolves to API host
+        assert_eq!(
+            registry.canonical_host("github.netflix.net").as_deref(),
+            Some("git.netflix.net")
+        );
+        // API host resolves to itself
+        assert_eq!(
+            registry.canonical_host("git.netflix.net").as_deref(),
+            Some("git.netflix.net")
+        );
+        // github.com is always recognized
+        assert_eq!(
+            registry.canonical_host("github.com").as_deref(),
+            Some("github.com")
+        );
+        // Unknown hosts return None
+        assert_eq!(registry.canonical_host("unknown.example.com"), None);
+    }
+
+    #[test]
+    fn test_canonical_host_without_web_url() {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "ghe".to_string(),
+            GhHostConfig {
+                host: "ghe.example.com".to_string(),
+                web_url: None,
+            },
+        );
+        let registry = HostRegistry::from_config(&config);
+
+        // Configured API host resolves to itself
+        assert_eq!(
+            registry.canonical_host("ghe.example.com").as_deref(),
+            Some("ghe.example.com")
+        );
+        // No web URL is configured, so nothing maps here
+        assert_eq!(registry.canonical_host("ghe-web.example.com"), None);
+    }
+
+    #[test]
+    fn test_all_url_hosts_without_web_url() {
+        // Without web_url, all_url_hosts returns the same set as the API hosts
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "ghe".to_string(),
+            GhHostConfig {
+                host: "ghe.example.com".to_string(),
+                web_url: None,
+            },
+        );
+        let registry = HostRegistry::from_config(&config);
+        let mut hosts = registry.all_url_hosts();
+        hosts.sort();
+        assert_eq!(hosts, vec!["ghe.example.com", "github.com"]);
+    }
+
+    #[test]
+    fn test_all_url_hosts_web_url_with_port_and_path() {
+        // Hostname extraction strips scheme, path, and port
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "netflix".to_string(),
+            GhHostConfig {
+                host: "git.netflix.net".to_string(),
+                web_url: Some("https://github.netflix.net:443/".to_string()),
+            },
+        );
+        let registry = HostRegistry::from_config(&config);
+        let mut hosts = registry.all_url_hosts();
+        hosts.sort();
+        assert_eq!(
+            hosts,
+            vec!["git.netflix.net", "github.com", "github.netflix.net"]
+        );
     }
 
     #[test]
@@ -1238,7 +1387,7 @@ repos = ["owner/repo1", "ghe.example.com/org/svc1", "ghe.example.com/org/svc2"]
         let mut config = LabConfig::default();
         config.daemon.repos = vec!["ghe.example.com/org/repo".to_string()];
         let registry = HostRegistry::from_config(&config);
-        let mut hosts = registry.all_hosts();
+        let mut hosts = registry.all_url_hosts();
         hosts.sort();
         assert_eq!(hosts, vec!["ghe.example.com", "github.com"]);
     }
@@ -1255,7 +1404,7 @@ repos = ["owner/repo1", "ghe.example.com/org/svc1", "ghe.example.com/org/svc2"]
         );
         config.daemon.repos = vec!["netflix:corp/service".to_string()];
         let registry = HostRegistry::from_config(&config);
-        let mut hosts = registry.all_hosts();
+        let mut hosts = registry.all_url_hosts();
         hosts.sort();
         assert_eq!(hosts, vec!["git.netflix.net", "github.com"]);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -437,6 +437,33 @@ fn web_url_to_host(web_url: &str) -> Option<String> {
     }
 }
 
+/// Validates a `[github_hosts.<name>].web_url` value, failing fast on shapes
+/// that `web_url_to_host` would silently discard (missing scheme, empty
+/// hostname, no dot). Runs at config-load time so misconfigurations surface
+/// immediately instead of causing URL parsing to quietly ignore the entry.
+fn validate_web_url(host_name: &str, web_url: &str) -> Result<()> {
+    let trimmed = web_url.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("[github_hosts.{}]: 'web_url' must not be empty", host_name);
+    }
+    let host = web_url_to_host(trimmed).ok_or_else(|| {
+        anyhow::anyhow!(
+            "[github_hosts.{}]: 'web_url' value '{}' is not a valid URL \
+             (expected 'https://<hostname>' or 'http://<hostname>')",
+            host_name,
+            web_url
+        )
+    })?;
+    if !host.contains('.') {
+        anyhow::bail!(
+            "[github_hosts.{}]: 'web_url' hostname '{}' does not look like a hostname (no dot)",
+            host_name,
+            host
+        );
+    }
+    Ok(())
+}
+
 impl LabConfig {
     /// Generate default config file content with commented-out options.
     ///
@@ -610,12 +637,16 @@ impl LabConfig {
     ///
     /// Use this for non-daemon commands (e.g., `gru do`) that only need
     /// agent/merge config but may not have `[daemon].repos` configured.
+    /// Still validates `[github_hosts.*]` since those entries drive URL
+    /// parsing used by every command.
     pub(crate) fn load_partial(path: &Path) -> Result<Self> {
         let contents = fs::read_to_string(path)
             .with_context(|| format!("Failed to read config file: {}", path.display()))?;
 
         let config: LabConfig = toml::from_str(&contents)
             .with_context(|| format!("Failed to parse config file: {}", path.display()))?;
+
+        config.validate_github_hosts()?;
 
         Ok(config)
     }
@@ -654,29 +685,7 @@ impl LabConfig {
             anyhow::bail!("max_resume_attempts must be at least 1");
         }
 
-        // Validate github_hosts entries
-        let mut seen_hosts: HashMap<&str, &str> = HashMap::new();
-        for (name, gh_host) in &self.github_hosts {
-            if gh_host.host.is_empty() {
-                anyhow::bail!("[github_hosts.{}]: 'host' must not be empty", name);
-            }
-            if !gh_host.host.contains('.') {
-                anyhow::bail!(
-                    "[github_hosts.{}]: 'host' value '{}' does not look like a hostname (no dot)",
-                    name,
-                    gh_host.host
-                );
-            }
-            if let Some(existing_name) = seen_hosts.get(gh_host.host.as_str()) {
-                anyhow::bail!(
-                    "[github_hosts.{}]: duplicate host '{}' (already defined by [github_hosts.{}])",
-                    name,
-                    gh_host.host,
-                    existing_name
-                );
-            }
-            seen_hosts.insert(&gh_host.host, name);
-        }
+        self.validate_github_hosts()?;
 
         // Validate repo format and host name references
         for repo in &self.daemon.repos {
@@ -710,6 +719,42 @@ impl LabConfig {
             }
         }
 
+        Ok(())
+    }
+
+    /// Validate the `[github_hosts.*]` section.
+    ///
+    /// Runs independently of daemon validation because these entries drive
+    /// URL parsing used by every command — a misconfigured `web_url` would
+    /// silently cause web UI URLs to be rejected without the user learning
+    /// why, so this runs in both `load()` and `load_partial()`.
+    fn validate_github_hosts(&self) -> Result<()> {
+        let mut seen_hosts: HashMap<&str, &str> = HashMap::new();
+        for (name, gh_host) in &self.github_hosts {
+            if gh_host.host.is_empty() {
+                anyhow::bail!("[github_hosts.{}]: 'host' must not be empty", name);
+            }
+            if !gh_host.host.contains('.') {
+                anyhow::bail!(
+                    "[github_hosts.{}]: 'host' value '{}' does not look like a hostname (no dot)",
+                    name,
+                    gh_host.host
+                );
+            }
+            if let Some(existing_name) = seen_hosts.get(gh_host.host.as_str()) {
+                anyhow::bail!(
+                    "[github_hosts.{}]: duplicate host '{}' (already defined by [github_hosts.{}])",
+                    name,
+                    gh_host.host,
+                    existing_name
+                );
+            }
+            seen_hosts.insert(&gh_host.host, name);
+
+            if let Some(web_url) = &gh_host.web_url {
+                validate_web_url(name, web_url)?;
+            }
+        }
         Ok(())
     }
 
@@ -1491,6 +1536,111 @@ repos = ["owner/repo1", "ghe.example.com/org/svc1", "ghe.example.com/org/svc2"]
         config.daemon.repos = vec!["owner/repo".to_string()];
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("duplicate host 'ghe.example.com'"));
+    }
+
+    #[test]
+    fn test_validate_github_host_rejects_web_url_missing_scheme() {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "netflix".to_string(),
+            GhHostConfig {
+                host: "git.netflix.net".to_string(),
+                web_url: Some("github.netflix.net".to_string()),
+            },
+        );
+        config.daemon.repos = vec!["owner/repo".to_string()];
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("is not a valid URL"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_github_host_rejects_empty_web_url() {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "netflix".to_string(),
+            GhHostConfig {
+                host: "git.netflix.net".to_string(),
+                web_url: Some(String::new()),
+            },
+        );
+        config.daemon.repos = vec!["owner/repo".to_string()];
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("must not be empty"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_validate_github_host_rejects_web_url_empty_hostname() {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "netflix".to_string(),
+            GhHostConfig {
+                host: "git.netflix.net".to_string(),
+                web_url: Some("https:///path".to_string()),
+            },
+        );
+        config.daemon.repos = vec!["owner/repo".to_string()];
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("is not a valid URL"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_github_host_rejects_web_url_no_dot() {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "local".to_string(),
+            GhHostConfig {
+                host: "git.local.example.com".to_string(),
+                web_url: Some("https://localhost".to_string()),
+            },
+        );
+        config.daemon.repos = vec!["owner/repo".to_string()];
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("does not look like a hostname"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_github_host_accepts_valid_web_url() {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "netflix".to_string(),
+            GhHostConfig {
+                host: "git.netflix.net".to_string(),
+                web_url: Some("https://github.netflix.net".to_string()),
+            },
+        );
+        config.daemon.repos = vec!["owner/repo".to_string()];
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_load_partial_validates_web_url() {
+        // load_partial() must also reject a malformed web_url because URL
+        // parsing is used by non-daemon commands like `gru do`.
+        let config_toml = r#"
+[github_hosts.netflix]
+host = "git.netflix.net"
+web_url = "github.netflix.net"
+"#;
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(config_toml.as_bytes()).unwrap();
+        temp_file.flush().unwrap();
+
+        let err = LabConfig::load_partial(temp_file.path())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("is not a valid URL"),
+            "unexpected error: {err}"
+        );
     }
 
     // --- Config parsing with github_hosts ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,10 +195,15 @@ impl Drop for TestConfigGuard {
     }
 }
 
-/// Try to load the config file, returning `None` on any error.
+/// Try to load the config file, returning `None` when no config is usable.
 ///
-/// This is a convenience for callers that want to inspect config
-/// but can gracefully handle its absence.
+/// Distinguishes two cases:
+/// - The config file doesn't exist — returns `None` silently (normal for
+///   users who never ran `gru init`).
+/// - The config file exists but fails to parse or validate — logs a
+///   `warn!` with the error and returns `None`. Callers that fall back to
+///   defaults (like [`load_host_registry`]) won't exit, but the user sees
+///   why their configured `[github_hosts.*]` entries were ignored.
 ///
 /// In test builds, checks for a thread-local path override set via
 /// [`set_test_config_path`] before falling back to the default path.
@@ -207,11 +212,34 @@ pub(crate) fn try_load_config() -> Option<LabConfig> {
     {
         let override_path = TEST_CONFIG_PATH_OVERRIDE.with(|cell| cell.borrow().clone());
         if let Some(path) = override_path {
-            return LabConfig::load_partial(&path).ok();
+            return load_or_warn(&path);
         }
     }
     let path = LabConfig::default_path().ok()?;
-    LabConfig::load_partial(&path).ok()
+    load_or_warn(&path)
+}
+
+/// Loads config from `path` if it exists, logging any parse/validation error.
+///
+/// Returns `None` both when the file is absent and when loading fails —
+/// the caller can't distinguish the two, which matches the silent-fallback
+/// contract — but failures are surfaced via the log rather than swallowed.
+fn load_or_warn(path: &Path) -> Option<LabConfig> {
+    if !path.exists() {
+        return None;
+    }
+    match LabConfig::load_partial(path) {
+        Ok(cfg) => Some(cfg),
+        Err(err) => {
+            log::warn!(
+                "Failed to load config file {}: {:#}. Falling back to defaults; \
+                 configured [github_hosts.*] entries will be ignored until this is fixed.",
+                path.display(),
+                err
+            );
+            None
+        }
+    }
 }
 
 /// Load a `HostRegistry` from the default config file.
@@ -1929,6 +1957,60 @@ default = "test-agent"
         let _guard = super::set_test_config_path(temp_file.path().to_path_buf());
         let config = super::try_load_config().expect("should load from override path");
         assert_eq!(config.agent.default, "test-agent");
+    }
+
+    #[test]
+    fn test_try_load_config_missing_file_returns_none() {
+        // A path that doesn't exist returns None without any log output.
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("never-created.toml");
+
+        let _guard = super::set_test_config_path(missing);
+        assert!(super::try_load_config().is_none());
+    }
+
+    #[test]
+    fn test_try_load_config_invalid_file_returns_none_and_logs() {
+        // A file that exists but fails validation returns None. load_or_warn
+        // emits the error via log::warn rather than swallowing it silently —
+        // we can't easily capture the log in a unit test, but we can at
+        // least confirm invalid config doesn't masquerade as valid.
+        let mut temp_file = NamedTempFile::new().unwrap();
+        let bad_config = r#"
+[github_hosts.netflix]
+host = "git.netflix.net"
+web_url = "github.netflix.net"
+"#;
+        temp_file.write_all(bad_config.as_bytes()).unwrap();
+        temp_file.flush().unwrap();
+
+        let _guard = super::set_test_config_path(temp_file.path().to_path_buf());
+        assert!(
+            super::try_load_config().is_none(),
+            "try_load_config should return None when the file fails validation"
+        );
+    }
+
+    #[test]
+    fn test_load_host_registry_falls_back_when_config_invalid() {
+        // When the config file is present but invalid, load_host_registry
+        // falls back to the default registry rather than panicking.
+        let mut temp_file = NamedTempFile::new().unwrap();
+        let bad_config = r#"
+[github_hosts.netflix]
+host = "git.netflix.net"
+web_url = ""
+"#;
+        temp_file.write_all(bad_config.as_bytes()).unwrap();
+        temp_file.flush().unwrap();
+
+        let _guard = super::set_test_config_path(temp_file.path().to_path_buf());
+        let registry = super::load_host_registry();
+        // Default registry only has github.com — the malformed entry is
+        // dropped rather than silently accepted.
+        let mut hosts = registry.all_url_hosts();
+        hosts.sort();
+        assert_eq!(hosts, vec!["github.com"]);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -728,9 +728,25 @@ impl LabConfig {
     /// URL parsing used by every command — a misconfigured `web_url` would
     /// silently cause web UI URLs to be rejected without the user learning
     /// why, so this runs in both `load()` and `load_partial()`.
+    ///
+    /// Rejects:
+    /// - Empty / malformed `host` or `web_url` values.
+    /// - Two entries with the same API `host`.
+    /// - Two entries whose derived `web_url` hostnames collide — either with
+    ///   each other, or with a different entry's API `host`. Such collisions
+    ///   make [`HostRegistry::canonical_host`] ambiguous and the resolution
+    ///   order-dependent on `HashMap` iteration.
     fn validate_github_hosts(&self) -> Result<()> {
-        let mut seen_hosts: HashMap<&str, &str> = HashMap::new();
-        for (name, gh_host) in &self.github_hosts {
+        // Visit entries in sorted order so error messages are deterministic
+        // regardless of the underlying `HashMap` iteration order.
+        let mut names: Vec<&String> = self.github_hosts.keys().collect();
+        names.sort();
+
+        // Pass 1: validate each entry in isolation and collect the API host
+        // owner map.
+        let mut api_hosts: HashMap<&str, &str> = HashMap::new();
+        for name in &names {
+            let gh_host = &self.github_hosts[*name];
             if gh_host.host.is_empty() {
                 anyhow::bail!("[github_hosts.{}]: 'host' must not be empty", name);
             }
@@ -741,7 +757,7 @@ impl LabConfig {
                     gh_host.host
                 );
             }
-            if let Some(existing_name) = seen_hosts.get(gh_host.host.as_str()) {
+            if let Some(existing_name) = api_hosts.get(gh_host.host.as_str()) {
                 anyhow::bail!(
                     "[github_hosts.{}]: duplicate host '{}' (already defined by [github_hosts.{}])",
                     name,
@@ -749,12 +765,55 @@ impl LabConfig {
                     existing_name
                 );
             }
-            seen_hosts.insert(&gh_host.host, name);
+            api_hosts.insert(&gh_host.host, name);
 
             if let Some(web_url) = &gh_host.web_url {
                 validate_web_url(name, web_url)?;
             }
         }
+
+        // Pass 2: check that derived web_url hostnames don't collide with
+        // other entries' API or web_url hosts.
+        let mut web_url_hosts: HashMap<String, &str> = HashMap::new();
+        for name in &names {
+            let gh_host = &self.github_hosts[*name];
+            let Some(web_url) = &gh_host.web_url else {
+                continue;
+            };
+            // Pass 1 already validated the web_url, so the extraction succeeds.
+            let web_host = web_url_to_host(web_url)
+                .expect("validate_web_url ensures web_url_to_host returns Some");
+
+            // Trivial: a web_url whose hostname equals this entry's own API
+            // host is redundant but unambiguous — allow it.
+            if web_host == gh_host.host {
+                continue;
+            }
+
+            // Collides with a different entry's API host?
+            if let Some(other_name) = api_hosts.get(web_host.as_str()) {
+                if *other_name != name.as_str() {
+                    anyhow::bail!(
+                        "[github_hosts.{}]: 'web_url' hostname '{}' collides with the 'host' of [github_hosts.{}]",
+                        name,
+                        web_host,
+                        other_name
+                    );
+                }
+            }
+
+            // Collides with another entry's web_url hostname?
+            if let Some(other_name) = web_url_hosts.get(&web_host) {
+                anyhow::bail!(
+                    "[github_hosts.{}]: 'web_url' hostname '{}' is also used by [github_hosts.{}]",
+                    name,
+                    web_host,
+                    other_name
+                );
+            }
+            web_url_hosts.insert(web_host, name);
+        }
+
         Ok(())
     }
 
@@ -1615,6 +1674,76 @@ repos = ["owner/repo1", "ghe.example.com/org/svc1", "ghe.example.com/org/svc2"]
             GhHostConfig {
                 host: "git.netflix.net".to_string(),
                 web_url: Some("https://github.netflix.net".to_string()),
+            },
+        );
+        config.daemon.repos = vec!["owner/repo".to_string()];
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_github_host_rejects_duplicate_web_url_hosts() {
+        // Two entries claim the same web_url hostname → canonical_host()
+        // would resolve non-deterministically.
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "alpha".to_string(),
+            GhHostConfig {
+                host: "git.alpha.example.com".to_string(),
+                web_url: Some("https://web.example.com".to_string()),
+            },
+        );
+        config.github_hosts.insert(
+            "beta".to_string(),
+            GhHostConfig {
+                host: "git.beta.example.com".to_string(),
+                web_url: Some("https://web.example.com".to_string()),
+            },
+        );
+        config.daemon.repos = vec!["owner/repo".to_string()];
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("'web_url' hostname 'web.example.com' is also used by"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_github_host_rejects_web_url_colliding_with_other_api_host() {
+        // One entry's web_url hostname equals another entry's API host →
+        // ambiguous mapping.
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "alpha".to_string(),
+            GhHostConfig {
+                host: "git.netflix.net".to_string(),
+                web_url: None,
+            },
+        );
+        config.github_hosts.insert(
+            "beta".to_string(),
+            GhHostConfig {
+                host: "git.other.net".to_string(),
+                web_url: Some("https://git.netflix.net".to_string()),
+            },
+        );
+        config.daemon.repos = vec!["owner/repo".to_string()];
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("'web_url' hostname 'git.netflix.net' collides with the 'host'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_github_host_allows_web_url_equal_to_own_api_host() {
+        // Redundant but unambiguous: web_url hostname matches this entry's
+        // own API host. Allowed because it doesn't create ambiguity.
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "netflix".to_string(),
+            GhHostConfig {
+                host: "git.netflix.net".to_string(),
+                web_url: Some("https://git.netflix.net".to_string()),
             },
         );
         config.daemon.repos = vec!["owner/repo".to_string()];

--- a/src/git.rs
+++ b/src/git.rs
@@ -152,6 +152,9 @@ pub(crate) async fn get_github_remote(host_registry: &HostRegistry) -> Result<St
     let mut origin_url: Option<String> = None;
     let mut first_github_url: Option<String> = None;
 
+    // Compute once, reuse across every remote line.
+    let url_hosts = host_registry.all_url_hosts();
+
     // Each line format: <name> <url> (fetch|push)
     for line in remote_lines.lines() {
         let mut parts = line.split_whitespace();
@@ -159,7 +162,7 @@ pub(crate) async fn get_github_remote(host_registry: &HostRegistry) -> Result<St
         let remote_url = parts.next();
 
         if let (Some(name), Some(url)) = (remote_name, remote_url) {
-            if is_github_url(url, host_registry) {
+            if url_matches_any_host(url, &url_hosts) {
                 // Prioritize "origin" remote
                 if name == "origin" && origin_url.is_none() {
                     origin_url = Some(url.to_string());
@@ -185,7 +188,14 @@ pub(crate) async fn get_github_remote(host_registry: &HostRegistry) -> Result<St
 /// Matches against every API host and every configured `web_url` host in
 /// `host_registry`.
 fn is_github_url(url: &str, host_registry: &HostRegistry) -> bool {
-    for host in host_registry.all_url_hosts() {
+    url_matches_any_host(url, &host_registry.all_url_hosts())
+}
+
+/// Tests `url` against a pre-computed list of hostnames using the three
+/// supported URL shapes (https, http, SSH). Factored out so callers that check
+/// many URLs in a row can compute the host list once.
+fn url_matches_any_host(url: &str, hosts: &[String]) -> bool {
+    for host in hosts {
         if url.starts_with(&format!("https://{}/", host))
             || url.starts_with(&format!("http://{}/", host))
             || url.starts_with(&format!("git@{}:", host))

--- a/src/git.rs
+++ b/src/git.rs
@@ -202,8 +202,9 @@ fn url_matches_any_host(url: &str, hosts: &[String]) -> bool {
 
 /// Parses a GitHub remote URL to extract host, owner, and repo name.
 ///
-/// Supports both HTTPS and SSH formats for any configured GitHub host:
+/// Accepts HTTPS, HTTP, and SSH formats for any configured GitHub host:
 /// - `https://<host>/owner/repo.git`
+/// - `http://<host>/owner/repo.git`
 /// - `git@<host>:owner/repo.git`
 ///
 /// Matches against every API host and every configured `web_url` host in

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 
+use crate::config::HostRegistry;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 use tokio::process::Command;
@@ -131,7 +132,7 @@ pub(crate) async fn detect_git_repo() -> Result<PathBuf> {
 
 /// Gets the GitHub remote URL from the current git repository
 /// Tries "origin" first, then falls back to the first GitHub remote found
-pub(crate) async fn get_github_remote(github_hosts: &[String]) -> Result<String> {
+pub(crate) async fn get_github_remote(host_registry: &HostRegistry) -> Result<String> {
     // Use `git remote -v` to get all remotes and their URLs in one call
     let output = Command::new("git")
         .arg("remote")
@@ -158,7 +159,7 @@ pub(crate) async fn get_github_remote(github_hosts: &[String]) -> Result<String>
         let remote_url = parts.next();
 
         if let (Some(name), Some(url)) = (remote_name, remote_url) {
-            if is_github_url(url, github_hosts) {
+            if is_github_url(url, host_registry) {
                 // Prioritize "origin" remote
                 if name == "origin" && origin_url.is_none() {
                     origin_url = Some(url.to_string());
@@ -178,11 +179,13 @@ pub(crate) async fn get_github_remote(github_hosts: &[String]) -> Result<String>
     })
 }
 
-/// Checks if a URL is a GitHub URL (including configured GHE hosts).
+/// Checks if a URL is a GitHub URL (including configured GHE hosts and
+/// their web UI hostnames).
 ///
-/// `github_hosts` should contain all recognized hosts (e.g., `["github.com", "ghe.example.com"]`).
-fn is_github_url(url: &str, github_hosts: &[String]) -> bool {
-    for host in github_hosts {
+/// Matches against every API host and every configured `web_url` host in
+/// `host_registry`.
+fn is_github_url(url: &str, host_registry: &HostRegistry) -> bool {
+    for host in host_registry.all_url_hosts() {
         if url.starts_with(&format!("https://{}/", host))
             || url.starts_with(&format!("http://{}/", host))
             || url.starts_with(&format!("git@{}:", host))
@@ -199,22 +202,23 @@ fn is_github_url(url: &str, github_hosts: &[String]) -> bool {
 /// - `https://<host>/owner/repo.git`
 /// - `git@<host>:owner/repo.git`
 ///
-/// `github_hosts` should contain all recognized hosts (e.g., `["github.com", "ghe.example.com"]`).
+/// Matches against every API host and every configured `web_url` host in
+/// `host_registry`. The returned host is always the canonical API host, even
+/// when the input used a web UI hostname.
 pub(crate) fn parse_github_remote(
     url: &str,
-    github_hosts: &[String],
+    host_registry: &HostRegistry,
 ) -> Result<(String, String, String)> {
-    if !is_github_url(url, github_hosts) {
+    if !is_github_url(url, host_registry) {
         anyhow::bail!("Not a GitHub URL: {}", url);
     }
 
-    for host in github_hosts {
+    for host in host_registry.all_url_hosts() {
         let https_prefix = format!("https://{}/", host);
         let http_prefix = format!("http://{}/", host);
         let ssh_prefix = format!("git@{}:", host);
 
-        // Handle HTTPS format
-        if url.starts_with(&https_prefix) || url.starts_with(&http_prefix) {
+        let matched = if url.starts_with(&https_prefix) || url.starts_with(&http_prefix) {
             let path = url
                 .trim_start_matches(&https_prefix)
                 .trim_start_matches(&http_prefix)
@@ -223,12 +227,11 @@ pub(crate) fn parse_github_remote(
 
             let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
             if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-                return Ok((host.clone(), parts[0].to_string(), parts[1].to_string()));
+                Some((parts[0].to_string(), parts[1].to_string()))
+            } else {
+                None
             }
-        }
-
-        // Handle SSH format: git@<host>:owner/repo.git
-        if url.starts_with(&ssh_prefix) {
+        } else if url.starts_with(&ssh_prefix) {
             let path = url
                 .trim_start_matches(&ssh_prefix)
                 .trim_end_matches(".git")
@@ -236,8 +239,19 @@ pub(crate) fn parse_github_remote(
 
             let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
             if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-                return Ok((host.clone(), parts[0].to_string(), parts[1].to_string()));
+                Some((parts[0].to_string(), parts[1].to_string()))
+            } else {
+                None
             }
+        } else {
+            None
+        };
+
+        if let Some((owner, repo)) = matched {
+            let canonical = host_registry
+                .canonical_host(&host)
+                .with_context(|| format!("Unknown host '{}' in URL: {}", host, url))?;
+            return Ok((canonical, owner, repo));
         }
     }
 
@@ -1167,14 +1181,35 @@ impl GitRepo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{GhHostConfig, LabConfig};
     use std::env;
 
-    fn default_hosts() -> Vec<String> {
-        vec!["github.com".to_string()]
+    fn default_hosts() -> HostRegistry {
+        HostRegistry::from_config(&LabConfig::default())
     }
 
-    fn hosts_with_ghe() -> Vec<String> {
-        vec!["github.com".to_string(), "ghe.example.com".to_string()]
+    fn hosts_with_ghe() -> HostRegistry {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "ghe".to_string(),
+            GhHostConfig {
+                host: "ghe.example.com".to_string(),
+                web_url: None,
+            },
+        );
+        HostRegistry::from_config(&config)
+    }
+
+    fn hosts_with_web_url() -> HostRegistry {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "netflix".to_string(),
+            GhHostConfig {
+                host: "git.netflix.net".to_string(),
+                web_url: Some("https://github.netflix.net".to_string()),
+            },
+        );
+        HostRegistry::from_config(&config)
     }
 
     #[test]
@@ -1289,6 +1324,62 @@ mod tests {
             &hosts
         ));
         assert!(is_github_url("git@ghe.example.com:owner/repo.git", &hosts));
+    }
+
+    #[test]
+    fn test_is_github_url_recognizes_web_url_host() {
+        let hosts = hosts_with_web_url();
+        // Both the API host and the web UI host are recognized
+        assert!(is_github_url(
+            "https://git.netflix.net/corp/repo.git",
+            &hosts
+        ));
+        assert!(is_github_url(
+            "https://github.netflix.net/corp/repo.git",
+            &hosts
+        ));
+        assert!(is_github_url(
+            "git@github.netflix.net:corp/repo.git",
+            &hosts
+        ));
+    }
+
+    #[test]
+    fn test_parse_github_remote_web_url_maps_to_api_host() {
+        // HTTPS URL using the web UI host should resolve to the API host
+        let result = parse_github_remote(
+            "https://github.netflix.net/corp/service.git",
+            &hosts_with_web_url(),
+        )
+        .unwrap();
+        assert_eq!(result.0, "git.netflix.net");
+        assert_eq!(result.1, "corp");
+        assert_eq!(result.2, "service");
+    }
+
+    #[test]
+    fn test_parse_github_remote_api_host_still_works_with_web_url_config() {
+        // API host continues to work when web_url is also configured
+        let result = parse_github_remote(
+            "https://git.netflix.net/corp/service.git",
+            &hosts_with_web_url(),
+        )
+        .unwrap();
+        assert_eq!(result.0, "git.netflix.net");
+        assert_eq!(result.1, "corp");
+        assert_eq!(result.2, "service");
+    }
+
+    #[test]
+    fn test_parse_github_remote_ssh_web_url_maps_to_api_host() {
+        let result = parse_github_remote(
+            "git@github.netflix.net:corp/service.git",
+            &hosts_with_web_url(),
+        )
+        .unwrap();
+        assert_eq!(result.0, "git.netflix.net");
+        assert_eq!(result.1, "corp");
+        assert_eq!(result.2, "service");
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -182,29 +182,96 @@ pub(crate) async fn get_github_remote(host_registry: &HostRegistry) -> Result<St
     })
 }
 
-/// Checks if `url` is a GitHub URL whose hostname matches any entry in
-/// `hosts`, using the three supported URL shapes (https, http, SSH).
+/// Supported URL schemes for GitHub remotes and web URLs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitUrlScheme {
+    Https,
+    Http,
+    Ssh,
+}
+
+/// A GitHub-style URL split into scheme, hostname, and remainder.
+///
+/// The hostname has any `:port` suffix stripped so callers can compare it
+/// directly to configured host names.
+#[derive(Debug, Clone)]
+pub(crate) struct GitUrlParts<'a> {
+    pub(crate) scheme: GitUrlScheme,
+    /// Hostname with any port stripped.
+    pub(crate) host: &'a str,
+    /// Everything after the authority. For HTTPS/HTTP URLs this includes the
+    /// leading `/` (e.g. `/owner/repo.git`); for SSH (`git@host:path`) it's
+    /// the path with no leading slash.
+    pub(crate) rest: &'a str,
+}
+
+/// Splits a URL into scheme, hostname (port stripped), and remainder.
+///
+/// Accepts `https://<host>[:port]/<rest>`, `http://<host>[:port]/<rest>`, and
+/// SSH (`git@<host>:<rest>`). Returns `None` for URLs with an unsupported
+/// scheme, HTTP userinfo (`https://user@host/...`), or an empty hostname.
+pub(crate) fn split_github_url(url: &str) -> Option<GitUrlParts<'_>> {
+    if let Some(rest) = url.strip_prefix("git@") {
+        let (host, path) = rest.split_once(':')?;
+        if host.is_empty() {
+            return None;
+        }
+        return Some(GitUrlParts {
+            scheme: GitUrlScheme::Ssh,
+            host,
+            rest: path,
+        });
+    }
+    let (scheme, rest) = if let Some(r) = url.strip_prefix("https://") {
+        (GitUrlScheme::Https, r)
+    } else if let Some(r) = url.strip_prefix("http://") {
+        (GitUrlScheme::Http, r)
+    } else {
+        return None;
+    };
+    // The authority runs up to the first path/query/fragment separator.
+    let auth_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..auth_end];
+    let path = &rest[auth_end..];
+    // Reject HTTP userinfo (`user[:pass]@host`) — not in scope.
+    if authority.contains('@') {
+        return None;
+    }
+    // Strip optional `:port` from the authority.
+    let host = authority
+        .split_once(':')
+        .map(|(h, _)| h)
+        .unwrap_or(authority);
+    if host.is_empty() {
+        return None;
+    }
+    Some(GitUrlParts {
+        scheme,
+        host,
+        rest: path,
+    })
+}
+
+/// Checks whether `url`'s hostname matches any entry in `hosts`, across the
+/// supported URL shapes (HTTPS, HTTP, SSH) and with any `:port` stripped.
 ///
 /// Takes a pre-computed slice so callers that check many URLs in a row can
 /// build the host list once via [`HostRegistry::all_url_hosts`]. Recognises
 /// every API host and every configured `web_url` host in the registry.
 fn url_matches_any_host(url: &str, hosts: &[String]) -> bool {
-    for host in hosts {
-        if url.starts_with(&format!("https://{}/", host))
-            || url.starts_with(&format!("http://{}/", host))
-            || url.starts_with(&format!("git@{}:", host))
-        {
-            return true;
-        }
-    }
-    false
+    let Some(parts) = split_github_url(url) else {
+        return false;
+    };
+    hosts.iter().any(|h| h == parts.host)
 }
 
 /// Parses a GitHub remote URL to extract host, owner, and repo name.
 ///
-/// Accepts HTTPS, HTTP, and SSH formats for any configured GitHub host:
-/// - `https://<host>/owner/repo.git`
-/// - `http://<host>/owner/repo.git`
+/// Accepts HTTPS, HTTP, and SSH formats for any configured GitHub host,
+/// including URLs with an explicit port (e.g.
+/// `https://ghe.example.com:8443/owner/repo.git`):
+/// - `https://<host>[:port]/owner/repo.git`
+/// - `http://<host>[:port]/owner/repo.git`
 /// - `git@<host>:owner/repo.git`
 ///
 /// Matches against every API host and every configured `web_url` host in
@@ -214,40 +281,28 @@ pub(crate) fn parse_github_remote(
     url: &str,
     host_registry: &HostRegistry,
 ) -> Result<(String, String, String)> {
-    // Compute the host list once and use it for both the membership check and
-    // the per-host prefix strip below.
+    let parts =
+        split_github_url(url).ok_or_else(|| anyhow::anyhow!("Not a GitHub URL: {}", url))?;
+
     let url_hosts = host_registry.all_url_hosts();
-    if !url_matches_any_host(url, &url_hosts) {
+    if !url_hosts.iter().any(|h| h == parts.host) {
         anyhow::bail!("Not a GitHub URL: {}", url);
     }
 
-    for host in &url_hosts {
-        let https_prefix = format!("https://{}/", host);
-        let http_prefix = format!("http://{}/", host);
-        let ssh_prefix = format!("git@{}:", host);
-
-        let remainder = url
-            .strip_prefix(&https_prefix)
-            .or_else(|| url.strip_prefix(&http_prefix))
-            .or_else(|| url.strip_prefix(&ssh_prefix));
-
-        let Some(remainder) = remainder else {
-            continue;
-        };
-
-        let path = remainder.trim_end_matches(".git").trim_end_matches('/');
-        let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
-        if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-            // `host` came from `all_url_hosts()`, which is derived from the same
-            // registry, so `canonical_host` is guaranteed to resolve.
-            let canonical = host_registry
-                .canonical_host(host)
-                .expect("host from all_url_hosts is always resolvable");
-            return Ok((canonical, parts[0].to_string(), parts[1].to_string()));
-        }
+    let path = parts
+        .rest
+        .trim_start_matches('/')
+        .trim_end_matches(".git")
+        .trim_end_matches('/');
+    let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    if segs.len() < 2 || segs[0].is_empty() || segs[1].is_empty() {
+        anyhow::bail!("Could not parse GitHub URL: {}", url);
     }
-
-    anyhow::bail!("Could not parse GitHub URL: {}", url);
+    // The host matched a known API or web_url host, so canonicalization cannot fail.
+    let canonical = host_registry
+        .canonical_host(parts.host)
+        .expect("matched host is always resolvable");
+    Ok((canonical, segs[0].to_string(), segs[1].to_string()))
 }
 
 /// Represents a single entry from `git worktree list --porcelain` output.
@@ -1378,6 +1433,108 @@ mod tests {
         assert_eq!(result.0, "git.netflix.net");
         assert_eq!(result.1, "corp");
         assert_eq!(result.2, "service");
+    }
+
+    #[test]
+    fn test_parse_github_remote_https_with_explicit_port() {
+        // Self-hosted GHE behind a non-standard port must still resolve.
+        let result = parse_github_remote(
+            "https://ghe.example.com:8443/netflix/service.git",
+            &hosts_with_ghe(),
+        )
+        .unwrap();
+        assert_eq!(result.0, "ghe.example.com");
+        assert_eq!(result.1, "netflix");
+        assert_eq!(result.2, "service");
+    }
+
+    #[test]
+    fn test_parse_github_remote_http_scheme() {
+        let result = parse_github_remote(
+            "http://ghe.example.com/netflix/service.git",
+            &hosts_with_ghe(),
+        )
+        .unwrap();
+        assert_eq!(result.0, "ghe.example.com");
+        assert_eq!(result.1, "netflix");
+        assert_eq!(result.2, "service");
+    }
+
+    #[test]
+    fn test_is_github_url_accepts_explicit_port() {
+        let hosts = hosts_with_ghe();
+        assert!(is_github_url(
+            "https://ghe.example.com:8443/owner/repo.git",
+            &hosts
+        ));
+    }
+
+    #[test]
+    fn test_is_github_url_rejects_userinfo() {
+        // URLs with HTTP userinfo (user@host) are out of scope.
+        let hosts = default_hosts();
+        assert!(!is_github_url(
+            "https://user@github.com/owner/repo.git",
+            &hosts
+        ));
+    }
+
+    // --- split_github_url unit tests ---
+
+    #[test]
+    fn test_split_github_url_https_no_port() {
+        let parts = split_github_url("https://github.com/owner/repo.git").unwrap();
+        assert_eq!(parts.scheme, GitUrlScheme::Https);
+        assert_eq!(parts.host, "github.com");
+        assert_eq!(parts.rest, "/owner/repo.git");
+    }
+
+    #[test]
+    fn test_split_github_url_https_with_port() {
+        let parts = split_github_url("https://ghe.example.com:8443/owner/repo").unwrap();
+        assert_eq!(parts.scheme, GitUrlScheme::Https);
+        assert_eq!(parts.host, "ghe.example.com");
+        assert_eq!(parts.rest, "/owner/repo");
+    }
+
+    #[test]
+    fn test_split_github_url_http_scheme() {
+        let parts = split_github_url("http://github.com/owner/repo").unwrap();
+        assert_eq!(parts.scheme, GitUrlScheme::Http);
+        assert_eq!(parts.host, "github.com");
+    }
+
+    #[test]
+    fn test_split_github_url_ssh() {
+        let parts = split_github_url("git@github.com:owner/repo.git").unwrap();
+        assert_eq!(parts.scheme, GitUrlScheme::Ssh);
+        assert_eq!(parts.host, "github.com");
+        assert_eq!(parts.rest, "owner/repo.git");
+    }
+
+    #[test]
+    fn test_split_github_url_host_only() {
+        let parts = split_github_url("https://github.com").unwrap();
+        assert_eq!(parts.host, "github.com");
+        assert_eq!(parts.rest, "");
+    }
+
+    #[test]
+    fn test_split_github_url_rejects_userinfo() {
+        assert!(split_github_url("https://user@github.com/owner/repo").is_none());
+        assert!(split_github_url("https://user:pw@github.com/owner/repo").is_none());
+    }
+
+    #[test]
+    fn test_split_github_url_rejects_unsupported_scheme() {
+        assert!(split_github_url("ftp://github.com/x").is_none());
+        assert!(split_github_url("github.com/x").is_none());
+    }
+
+    #[test]
+    fn test_split_github_url_rejects_empty_host() {
+        assert!(split_github_url("https:///owner/repo").is_none());
+        assert!(split_github_url("git@:owner/repo").is_none());
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -182,18 +182,12 @@ pub(crate) async fn get_github_remote(host_registry: &HostRegistry) -> Result<St
     })
 }
 
-/// Checks if a URL is a GitHub URL (including configured GHE hosts and
-/// their web UI hostnames).
+/// Checks if `url` is a GitHub URL whose hostname matches any entry in
+/// `hosts`, using the three supported URL shapes (https, http, SSH).
 ///
-/// Matches against every API host and every configured `web_url` host in
-/// `host_registry`.
-fn is_github_url(url: &str, host_registry: &HostRegistry) -> bool {
-    url_matches_any_host(url, &host_registry.all_url_hosts())
-}
-
-/// Tests `url` against a pre-computed list of hostnames using the three
-/// supported URL shapes (https, http, SSH). Factored out so callers that check
-/// many URLs in a row can compute the host list once.
+/// Takes a pre-computed slice so callers that check many URLs in a row can
+/// build the host list once via [`HostRegistry::all_url_hosts`]. Recognises
+/// every API host and every configured `web_url` host in the registry.
 fn url_matches_any_host(url: &str, hosts: &[String]) -> bool {
     for host in hosts {
         if url.starts_with(&format!("https://{}/", host))
@@ -219,11 +213,14 @@ pub(crate) fn parse_github_remote(
     url: &str,
     host_registry: &HostRegistry,
 ) -> Result<(String, String, String)> {
-    if !is_github_url(url, host_registry) {
+    // Compute the host list once and use it for both the membership check and
+    // the per-host prefix strip below.
+    let url_hosts = host_registry.all_url_hosts();
+    if !url_matches_any_host(url, &url_hosts) {
         anyhow::bail!("Not a GitHub URL: {}", url);
     }
 
-    for host in host_registry.all_url_hosts() {
+    for host in &url_hosts {
         let https_prefix = format!("https://{}/", host);
         let http_prefix = format!("http://{}/", host);
         let ssh_prefix = format!("git@{}:", host);
@@ -243,7 +240,7 @@ pub(crate) fn parse_github_remote(
             // `host` came from `all_url_hosts()`, which is derived from the same
             // registry, so `canonical_host` is guaranteed to resolve.
             let canonical = host_registry
-                .canonical_host(&host)
+                .canonical_host(host)
                 .expect("host from all_url_hosts is always resolvable");
             return Ok((canonical, parts[0].to_string(), parts[1].to_string()));
         }
@@ -1282,6 +1279,12 @@ mod tests {
     fn test_parse_github_remote_rejects_invalid_format() {
         let result = parse_github_remote("https://github.com/incomplete", &default_hosts());
         assert!(result.is_err());
+    }
+
+    /// Convenience wrapper around `url_matches_any_host` so tests can pass a
+    /// `HostRegistry` directly rather than building the URL-host slice.
+    fn is_github_url(url: &str, registry: &HostRegistry) -> bool {
+        url_matches_any_host(url, &registry.all_url_hosts())
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -218,40 +218,24 @@ pub(crate) fn parse_github_remote(
         let http_prefix = format!("http://{}/", host);
         let ssh_prefix = format!("git@{}:", host);
 
-        let matched = if url.starts_with(&https_prefix) || url.starts_with(&http_prefix) {
-            let path = url
-                .trim_start_matches(&https_prefix)
-                .trim_start_matches(&http_prefix)
-                .trim_end_matches(".git")
-                .trim_end_matches('/');
+        let remainder = url
+            .strip_prefix(&https_prefix)
+            .or_else(|| url.strip_prefix(&http_prefix))
+            .or_else(|| url.strip_prefix(&ssh_prefix));
 
-            let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
-            if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-                Some((parts[0].to_string(), parts[1].to_string()))
-            } else {
-                None
-            }
-        } else if url.starts_with(&ssh_prefix) {
-            let path = url
-                .trim_start_matches(&ssh_prefix)
-                .trim_end_matches(".git")
-                .trim_end_matches('/');
-
-            let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
-            if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-                Some((parts[0].to_string(), parts[1].to_string()))
-            } else {
-                None
-            }
-        } else {
-            None
+        let Some(remainder) = remainder else {
+            continue;
         };
 
-        if let Some((owner, repo)) = matched {
+        let path = remainder.trim_end_matches(".git").trim_end_matches('/');
+        let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+        if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            // `host` came from `all_url_hosts()`, which is derived from the same
+            // registry, so `canonical_host` is guaranteed to resolve.
             let canonical = host_registry
                 .canonical_host(&host)
-                .with_context(|| format!("Unknown host '{}' in URL: {}", host, url))?;
-            return Ok((canonical, owner, repo));
+                .expect("host from all_url_hosts is always resolvable");
+            return Ok((canonical, parts[0].to_string(), parts[1].to_string()));
         }
     }
 

--- a/src/merge_readiness.rs
+++ b/src/merge_readiness.rs
@@ -460,10 +460,8 @@ fn evaluate_reviews(reviews: &[ReviewApiResponse], pr_author: &str) -> bool {
                     author_commented = false;
                 }
             }
-            "COMMENTED" => {
-                if review.user.login == pr_author {
-                    author_commented = true;
-                }
+            "COMMENTED" if review.user.login == pr_author => {
+                author_commented = true;
             }
             _ => {
                 // PENDING — don't change approval state

--- a/src/minion_registry.rs
+++ b/src/minion_registry.rs
@@ -743,16 +743,17 @@ pub(crate) fn is_process_alive_with_start_time(pid: u32, recorded_start_time: Op
     // If we have a recorded start time, verify the PID still belongs to the same process.
     if let Some(recorded) = recorded_start_time {
         match get_process_start_time(pid) {
-            Some(actual) => {
-                if actual != recorded {
-                    log::debug!(
-                        "PID {} recycled: recorded start_time={}, actual={}",
-                        pid,
-                        recorded,
-                        actual
-                    );
-                    return false;
-                }
+            Some(actual) if actual != recorded => {
+                log::debug!(
+                    "PID {} recycled: recorded start_time={}, actual={}",
+                    pid,
+                    recorded,
+                    actual
+                );
+                return false;
+            }
+            Some(_) => {
+                // PID still belongs to the same process.
             }
             None => {
                 // Couldn't query start time (process may have just exited between

--- a/src/minion_resolver.rs
+++ b/src/minion_resolver.rs
@@ -356,11 +356,11 @@ async fn resolve_issue_from_pr(pr_num: u64) -> Result<u64> {
     git::detect_git_repo()
         .await
         .context("Failed to detect git repository")?;
-    let github_hosts = crate::config::load_host_registry().all_hosts();
-    let remote_url = git::get_github_remote(&github_hosts)
+    let host_registry = crate::config::load_host_registry();
+    let remote_url = git::get_github_remote(&host_registry)
         .await
         .context("Failed to get GitHub remote")?;
-    let (host, det_owner, det_repo) = git::parse_github_remote(&remote_url, &github_hosts)
+    let (host, det_owner, det_repo) = git::parse_github_remote(&remote_url, &host_registry)
         .context("Failed to parse GitHub remote URL")?;
     let repo_full = github::repo_slug(&det_owner, &det_repo);
     // Use gh CLI to get linked issue from PR body

--- a/src/url_utils.rs
+++ b/src/url_utils.rs
@@ -600,4 +600,23 @@ mod tests {
         assert_eq!(num, "2612");
         assert_eq!(host, "git.netflix.net");
     }
+
+    #[tokio::test]
+    async fn test_parse_pr_info_rejects_issue_url_on_web_url_host() {
+        // Issue URL via web UI hostname is recognized (rejected for being a PR
+        // parser, not for being unrecognized). The error message references the
+        // issue URL type — confirming parsing succeeded before type validation.
+        let err = parse_pr_info(
+            "https://github.netflix.net/corp/service/issues/42",
+            &hosts_with_web_url(),
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("issue URL"),
+            "Expected specific error for issue URL given to PR parser, got: {}",
+            msg
+        );
+    }
 }

--- a/src/url_utils.rs
+++ b/src/url_utils.rs
@@ -43,59 +43,55 @@ fn clean_url(url: &str) -> &str {
 /// Handles URLs like:
 /// - `https://github.com/owner/repo/issues/42`
 /// - `https://github.com/owner/repo/pull/42`
-/// - `https://<configured-ghe-host>/owner/repo/issues/42`
+/// - `http://<configured-host>/owner/repo/issues/42`
+/// - `https://<configured-host>:8443/owner/repo/issues/42` (explicit port)
 /// - `https://<configured-web-url-host>/owner/repo/issues/42`
 /// - URLs with query params, fragments, and trailing slashes
+///
+/// Both `http://` and `https://` schemes are accepted, matching
+/// [`crate::config::GhHostConfig::web_url`] validation. SSH-style URLs
+/// (`git@host:...`) are rejected since they're remote URLs, not web URLs.
 ///
 /// Returns `None` if the URL is not a valid GitHub issue/PR URL.
 pub(crate) fn parse_github_url(url: &str, host_registry: &HostRegistry) -> Option<GitHubUrl> {
     let cleaned = clean_url(url);
+    let parts = git::split_github_url(cleaned)?;
 
-    for host in host_registry.all_url_hosts() {
-        let prefix = format!("https://{}/", host);
-        if let Some(path) = cleaned.strip_prefix(&prefix) {
-            let parts: Vec<&str> = path.split('/').collect();
-
-            if parts.len() != 4 {
-                continue;
-            }
-
-            let owner = parts[0];
-            let repo = parts[1];
-            let resource_type_str = parts[2];
-            let number_str = parts[3];
-
-            if owner.is_empty() || repo.is_empty() {
-                continue;
-            }
-
-            let resource_type = match resource_type_str {
-                "issues" => GitHubResourceType::Issue,
-                "pull" => GitHubResourceType::Pull,
-                _ => continue,
-            };
-
-            let number = match number_str.parse::<u32>() {
-                Ok(n) => n,
-                Err(_) => continue,
-            };
-
-            // `host` came from `all_url_hosts()`, so `canonical_host` always resolves.
-            let canonical = host_registry
-                .canonical_host(&host)
-                .expect("host from all_url_hosts is always resolvable");
-
-            return Some(GitHubUrl {
-                host: canonical,
-                owner: owner.to_string(),
-                repo: repo.to_string(),
-                resource_type,
-                number,
-            });
-        }
+    // parse_github_url is for web URLs — SSH remote URLs are not valid here.
+    if !matches!(
+        parts.scheme,
+        git::GitUrlScheme::Https | git::GitUrlScheme::Http
+    ) {
+        return None;
     }
 
-    None
+    let canonical = host_registry.canonical_host(parts.host)?;
+
+    // Expect exactly `/owner/repo/(issues|pull)/<num>`
+    let path = parts.rest.strip_prefix('/')?;
+    let segments: Vec<&str> = path.split('/').collect();
+    if segments.len() != 4 {
+        return None;
+    }
+    let (owner, repo, resource_type_str, number_str) =
+        (segments[0], segments[1], segments[2], segments[3]);
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    let resource_type = match resource_type_str {
+        "issues" => GitHubResourceType::Issue,
+        "pull" => GitHubResourceType::Pull,
+        _ => return None,
+    };
+    let number = number_str.parse::<u32>().ok()?;
+
+    Some(GitHubUrl {
+        host: canonical,
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        resource_type,
+        number,
+    })
 }
 
 /// Extracts owner, repo, host, and issue number from an issue argument.
@@ -388,11 +384,37 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_github_url_rejects_http() {
-        // parse_github_url only accepts https:// web URLs;
-        // use git::parse_github_remote for git remote URLs (which accept http:// and SSH)
+    fn test_parse_github_url_accepts_http_scheme() {
+        // parse_github_url accepts both http:// and https:// to match
+        // what validate_web_url allows for GhHostConfig::web_url.
+        let result =
+            parse_github_url("http://github.com/owner/repo/issues/42", &default_hosts()).unwrap();
+        assert_eq!(result.host, "github.com");
+        assert_eq!(result.owner, "owner");
+        assert_eq!(result.repo, "repo");
+        assert_eq!(result.resource_type, GitHubResourceType::Issue);
+        assert_eq!(result.number, 42);
+    }
+
+    #[test]
+    fn test_parse_github_url_accepts_explicit_port() {
+        // Users on self-hosted GHE sometimes have a custom port on the URL.
+        let result = parse_github_url(
+            "https://ghe.netflix.net:8443/netflix/some-service/issues/99",
+            &hosts_with_ghe(),
+        )
+        .unwrap();
+        assert_eq!(result.host, "ghe.netflix.net");
+        assert_eq!(result.owner, "netflix");
+        assert_eq!(result.repo, "some-service");
+        assert_eq!(result.number, 99);
+    }
+
+    #[test]
+    fn test_parse_github_url_rejects_ssh() {
+        // SSH-style URLs are git remote URLs, not web URLs — not accepted.
         assert!(
-            parse_github_url("http://github.com/owner/repo/issues/42", &default_hosts()).is_none()
+            parse_github_url("git@github.com:owner/repo/issues/42", &default_hosts()).is_none()
         );
     }
 

--- a/src/url_utils.rs
+++ b/src/url_utils.rs
@@ -1,3 +1,4 @@
+use crate::config::HostRegistry;
 use crate::git;
 use crate::github;
 use anyhow::{Context, Result};
@@ -33,19 +34,24 @@ fn clean_url(url: &str) -> &str {
 
 /// Parses a GitHub issue or PR URL into its components.
 ///
-/// `github_hosts` should contain all recognized hosts (e.g., `["github.com", "ghe.example.com"]`).
+/// Matches against every API host and every configured web UI host in
+/// `host_registry`. When the URL uses a web UI host (e.g. the Netflix pattern
+/// where `git.netflix.net` is the API host and `github.netflix.net` is the web
+/// UI host), the returned `GitHubUrl::host` is the canonical API host so
+/// subsequent `gh` CLI calls target the correct endpoint.
 ///
 /// Handles URLs like:
 /// - `https://github.com/owner/repo/issues/42`
 /// - `https://github.com/owner/repo/pull/42`
 /// - `https://<configured-ghe-host>/owner/repo/issues/42`
+/// - `https://<configured-web-url-host>/owner/repo/issues/42`
 /// - URLs with query params, fragments, and trailing slashes
 ///
 /// Returns `None` if the URL is not a valid GitHub issue/PR URL.
-pub(crate) fn parse_github_url(url: &str, github_hosts: &[String]) -> Option<GitHubUrl> {
+pub(crate) fn parse_github_url(url: &str, host_registry: &HostRegistry) -> Option<GitHubUrl> {
     let cleaned = clean_url(url);
 
-    for host in github_hosts {
+    for host in host_registry.all_url_hosts() {
         let prefix = format!("https://{}/", host);
         if let Some(path) = cleaned.strip_prefix(&prefix) {
             let parts: Vec<&str> = path.split('/').collect();
@@ -74,8 +80,10 @@ pub(crate) fn parse_github_url(url: &str, github_hosts: &[String]) -> Option<Git
                 Err(_) => continue,
             };
 
+            let canonical = host_registry.canonical_host(&host)?;
+
             return Some(GitHubUrl {
-                host: host.clone(),
+                host: canonical,
                 owner: owner.to_string(),
                 repo: repo.to_string(),
                 resource_type,
@@ -90,11 +98,12 @@ pub(crate) fn parse_github_url(url: &str, github_hosts: &[String]) -> Option<Git
 /// Extracts owner, repo, host, and issue number from an issue argument.
 ///
 /// Supports both plain issue numbers (auto-detects from current directory) and GitHub URLs.
-/// `github_hosts` should contain all recognized hosts (e.g., `["github.com", "ghe.example.com"]`).
+/// `host_registry` defines all recognized hosts. The returned `host` is always
+/// the canonical API host, even when a URL used a configured web UI host.
 /// Returns `(owner, repo, issue_number, host)`.
 pub(crate) async fn parse_issue_info(
     issue: &str,
-    github_hosts: &[String],
+    host_registry: &HostRegistry,
 ) -> Result<(String, String, String, String)> {
     // Check if it's a plain number
     if let Ok(num) = issue.parse::<u32>() {
@@ -103,18 +112,18 @@ pub(crate) async fn parse_issue_info(
             .await
             .context("Failed to detect git repository")?;
 
-        let remote_url = git::get_github_remote(github_hosts)
+        let remote_url = git::get_github_remote(host_registry)
             .await
             .context("Failed to get GitHub remote")?;
 
-        let (host, owner, repo) = git::parse_github_remote(&remote_url, github_hosts)
+        let (host, owner, repo) = git::parse_github_remote(&remote_url, host_registry)
             .context("Failed to parse GitHub remote URL")?;
 
         return Ok((owner, repo, num.to_string(), host));
     }
 
     // Try parsing as a GitHub URL
-    if let Some(parsed) = parse_github_url(issue, github_hosts) {
+    if let Some(parsed) = parse_github_url(issue, host_registry) {
         if parsed.resource_type == GitHubResourceType::Issue {
             return Ok((
                 parsed.owner,
@@ -160,12 +169,13 @@ fn build_pr_view_args(pr_num: &str, repo: Option<&str>) -> Vec<String> {
 /// Extracts owner, repo, PR number, and branch name from a PR argument.
 ///
 /// Supports both plain PR numbers and GitHub URLs.
-/// `github_hosts` should contain all recognized hosts (e.g., `["github.com", "ghe.example.com"]`).
+/// `host_registry` defines all recognized hosts. The returned `host` is always
+/// the canonical API host, even when a URL used a configured web UI host.
 /// For plain numbers, fetches metadata from GitHub to get branch info.
 /// Returns `(owner, repo, pr_number, branch, host)`.
 pub(crate) async fn parse_pr_info(
     pr: &str,
-    github_hosts: &[String],
+    host_registry: &HostRegistry,
 ) -> Result<(String, String, String, String, String)> {
     // Extract PR number, gh command, and optional repo qualifier
     let (pr_num, detected_host, repo_flag) = if pr.parse::<u32>().is_ok() {
@@ -173,13 +183,13 @@ pub(crate) async fn parse_pr_info(
         git::detect_git_repo()
             .await
             .context("Failed to detect git repository")?;
-        let remote_url = git::get_github_remote(github_hosts)
+        let remote_url = git::get_github_remote(host_registry)
             .await
             .context("Failed to get GitHub remote")?;
-        let (host, _det_owner, _det_repo) = git::parse_github_remote(&remote_url, github_hosts)
+        let (host, _det_owner, _det_repo) = git::parse_github_remote(&remote_url, host_registry)
             .context("Failed to parse GitHub remote URL")?;
         (pr.to_string(), host, None)
-    } else if let Some(parsed) = parse_github_url(pr, github_hosts) {
+    } else if let Some(parsed) = parse_github_url(pr, host_registry) {
         if parsed.resource_type != GitHubResourceType::Pull {
             // Parsed successfully but wrong resource type (e.g., issue URL given for review command)
             anyhow::bail!(
@@ -233,13 +243,34 @@ pub(crate) async fn parse_pr_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{GhHostConfig, LabConfig};
 
-    fn default_hosts() -> Vec<String> {
-        vec!["github.com".to_string()]
+    fn default_hosts() -> HostRegistry {
+        HostRegistry::from_config(&LabConfig::default())
     }
 
-    fn hosts_with_ghe() -> Vec<String> {
-        vec!["github.com".to_string(), "ghe.netflix.net".to_string()]
+    fn hosts_with_ghe() -> HostRegistry {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "ghe".to_string(),
+            GhHostConfig {
+                host: "ghe.netflix.net".to_string(),
+                web_url: None,
+            },
+        );
+        HostRegistry::from_config(&config)
+    }
+
+    fn hosts_with_web_url() -> HostRegistry {
+        let mut config = LabConfig::default();
+        config.github_hosts.insert(
+            "netflix".to_string(),
+            GhHostConfig {
+                host: "git.netflix.net".to_string(),
+                web_url: Some("https://github.netflix.net".to_string()),
+            },
+        );
+        HostRegistry::from_config(&config)
     }
 
     // --- parse_github_url tests ---
@@ -511,5 +542,62 @@ mod tests {
             "Expected specific error for issue URL given to PR parser, got: {}",
             msg
         );
+    }
+
+    // --- web_url → API host mapping tests ---
+
+    #[test]
+    fn test_parse_github_url_web_url_issue_maps_to_api_host() {
+        // URL using the configured web UI hostname is accepted, and the
+        // returned host is the canonical API host.
+        let result = parse_github_url(
+            "https://github.netflix.net/corp/service/issues/42",
+            &hosts_with_web_url(),
+        )
+        .unwrap();
+        assert_eq!(result.host, "git.netflix.net");
+        assert_eq!(result.owner, "corp");
+        assert_eq!(result.repo, "service");
+        assert_eq!(result.resource_type, GitHubResourceType::Issue);
+        assert_eq!(result.number, 42);
+    }
+
+    #[test]
+    fn test_parse_github_url_web_url_pull_maps_to_api_host() {
+        let result = parse_github_url(
+            "https://github.netflix.net/corp/service/pull/99",
+            &hosts_with_web_url(),
+        )
+        .unwrap();
+        assert_eq!(result.host, "git.netflix.net");
+        assert_eq!(result.resource_type, GitHubResourceType::Pull);
+        assert_eq!(result.number, 99);
+    }
+
+    #[test]
+    fn test_parse_github_url_api_host_still_works_with_web_url_config() {
+        // The API host continues to parse correctly when web_url is also configured.
+        let result = parse_github_url(
+            "https://git.netflix.net/corp/service/issues/7",
+            &hosts_with_web_url(),
+        )
+        .unwrap();
+        assert_eq!(result.host, "git.netflix.net");
+        assert_eq!(result.number, 7);
+    }
+
+    #[tokio::test]
+    async fn test_parse_issue_info_web_url_returns_api_host() {
+        // End-to-end: web UI URL resolves to API host for subsequent gh CLI calls.
+        let (owner, repo, num, host) = parse_issue_info(
+            "https://github.netflix.net/corp/service/issues/2612",
+            &hosts_with_web_url(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(owner, "corp");
+        assert_eq!(repo, "service");
+        assert_eq!(num, "2612");
+        assert_eq!(host, "git.netflix.net");
     }
 }

--- a/src/url_utils.rs
+++ b/src/url_utils.rs
@@ -80,7 +80,10 @@ pub(crate) fn parse_github_url(url: &str, host_registry: &HostRegistry) -> Optio
                 Err(_) => continue,
             };
 
-            let canonical = host_registry.canonical_host(&host)?;
+            // `host` came from `all_url_hosts()`, so `canonical_host` always resolves.
+            let canonical = host_registry
+                .canonical_host(&host)
+                .expect("host from all_url_hosts is always resolvable");
 
             return Some(GitHubUrl {
                 host: canonical,

--- a/src/worktree_scanner.rs
+++ b/src/worktree_scanner.rs
@@ -314,7 +314,7 @@ pub(crate) async fn discover_worktrees(repos_dir: &Path) -> Result<Vec<Worktree>
     }
 
     // Load configured hosts once for all repos
-    let github_hosts = crate::config::load_host_registry().all_hosts();
+    let host_registry = crate::config::load_host_registry();
 
     // Find all bare repositories recursively
     let bare_repos = find_bare_repos(repos_dir).await?;
@@ -322,7 +322,7 @@ pub(crate) async fn discover_worktrees(repos_dir: &Path) -> Result<Vec<Worktree>
     for bare_repo_path in bare_repos {
         // Extract repo name and host from git config
         let (host, repo_name) =
-            match extract_repo_from_git_config(&bare_repo_path, &github_hosts).await {
+            match extract_repo_from_git_config(&bare_repo_path, &host_registry).await {
                 Ok(result) => result,
                 Err(e) => {
                     log::warn!(
@@ -453,7 +453,7 @@ async fn find_bare_repos(dir: &Path) -> Result<Vec<PathBuf>> {
 /// Returns `(host, "owner/repo")`.
 async fn extract_repo_from_git_config(
     path: &Path,
-    github_hosts: &[String],
+    host_registry: &crate::config::HostRegistry,
 ) -> Result<(String, String)> {
     // Get remote.origin.url from git config
     let output = Command::new("git")
@@ -471,7 +471,7 @@ async fn extract_repo_from_git_config(
 
     let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
-    let (host, owner, repo) = git::parse_github_remote(&url, github_hosts)
+    let (host, owner, repo) = git::parse_github_remote(&url, host_registry)
         .context("Failed to parse repo from remote URL")?;
     Ok((host, github::repo_slug(&owner, &repo)))
 }


### PR DESCRIPTION
## Summary
- Teach `HostRegistry` about `web_url` hosts: `all_url_hosts()` returns API + web UI hosts for URL matching, and `canonical_host()` maps either form back to the API host.
- URL parsing helpers (`parse_github_url`, `parse_issue_info`, `parse_pr_info`, `is_github_url`, `parse_github_remote`, `get_github_remote`) now take `&HostRegistry` and always return the canonical API host, so subsequent `gh` CLI calls target the right endpoint even when the user pasted a web UI URL like `https://github.netflix.net/corp/repo/issues/42`.
- Updated all call sites (fix/resolve, review, rebase, chat, prompt, init, resume, minion_resolver, worktree_scanner) to pass the registry directly instead of the pre-derived host slice.

## Test plan
- `cargo test` — 1205 passing, 10 ignored (pre-existing).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- New unit tests:
  - `config::tests::test_canonical_host_resolves_web_url_to_api_host`
  - `config::tests::test_canonical_host_without_web_url`
  - `config::tests::test_all_url_hosts_without_web_url`
  - `config::tests::test_all_url_hosts_web_url_with_port_and_path`
  - `url_utils::tests::test_parse_github_url_web_url_issue_maps_to_api_host`
  - `url_utils::tests::test_parse_github_url_web_url_pull_maps_to_api_host`
  - `url_utils::tests::test_parse_github_url_api_host_still_works_with_web_url_config`
  - `url_utils::tests::test_parse_issue_info_web_url_returns_api_host`
  - `url_utils::tests::test_parse_pr_info_rejects_issue_url_on_web_url_host`
  - `git::tests::test_is_github_url_recognizes_web_url_host`
  - `git::tests::test_parse_github_remote_web_url_maps_to_api_host`
  - `git::tests::test_parse_github_remote_api_host_still_works_with_web_url_config`
  - `git::tests::test_parse_github_remote_ssh_web_url_maps_to_api_host`

## Notes
- The previously-public `HostRegistry::all_hosts()` (API hosts only) was removed — no caller needed it after the refactor, and `all_url_hosts()` is the semantically meaningful one now. If a caller ever needs API-only hosts, they can filter `all_url_hosts()` through `canonical_host()` or we can reintroduce the method.
- While touching `parse_github_remote`, consolidated the three scheme prefixes behind a single `strip_prefix` chain. This also fixes a latent bug where `trim_start_matches` would repeatedly strip the prefix (non-observable at the time, but no longer a foot-gun).
- The `web_url` string parser accepts both `https://` and `http://` for resilience against slightly malformed configs; the normal config validation path only documents `https://`.

Fixes #839

<sub>🤖 M1ge</sub>