### PR TITLE
Fixes #838: Orchestration failure after agent phase leaves gru:in-progress label orphaned

### DIFF
--- a/src/commands/fix/helpers.rs
+++ b/src/commands/fix/helpers.rs
@@ -77,16 +77,20 @@ pub(crate) async fn try_mark_issue_failed(host: &str, owner: &str, repo: &str, i
     }
 }
 
-/// Cleans up orchestration state after a post-agent failure (PR creation or
-/// PR lifecycle monitoring). Without this, a failure between the agent exiting
-/// and the worker exiting leaves the issue with `gru:in-progress` and no live
-/// process — an "orphaned label" recoverable only by the multi-hour auto-recovery
-/// scan.
+/// Cleans up orchestration state after a post-agent failure. Without this,
+/// a failure between the agent exiting and the worker exiting leaves the
+/// issue with `gru:in-progress` and no live process — an "orphaned label"
+/// recoverable only by the multi-hour auto-recovery scan.
 ///
 /// This helper:
 /// 1. Posts an explanatory comment on the issue
 /// 2. Transitions the issue label `gru:in-progress` → `gru:failed`
 /// 3. Clears the PID and marks the minion as `Stopped` in the registry
+///
+/// Currently wired only to PR creation failures in `run_worker`. The PR
+/// lifecycle monitoring phase (`monitor_pr_phase`) handles its own label
+/// transitions (to `gru:blocked`), so invoking this helper there would
+/// double-label the issue.
 ///
 /// Fire-and-forget: logs on failure but does not propagate errors, since the
 /// caller is already returning an error of its own.

--- a/src/commands/fix/helpers.rs
+++ b/src/commands/fix/helpers.rs
@@ -262,9 +262,11 @@ mod tests {
              Use `gru resume {}` to retry.",
             minion_id, reason, minion_id
         );
-        assert!(comment.contains("Minion `M1gt` failed after the agent phase"));
-        assert!(comment.contains("PR creation failed"));
-        assert!(comment.contains("gru resume M1gt"));
+        assert_eq!(
+            comment,
+            "⚠️  Minion `M1gt` failed after the agent phase: PR creation failed: no PR was created\n\n\
+             Use `gru resume M1gt` to retry."
+        );
     }
 
     #[test]

--- a/src/commands/fix/helpers.rs
+++ b/src/commands/fix/helpers.rs
@@ -1,4 +1,4 @@
-use crate::minion_registry::{with_registry, OrchestrationPhase};
+use crate::minion_registry::{with_registry, MinionMode, OrchestrationPhase};
 
 /// Updates the orchestration phase for a minion in the registry.
 /// Logs a warning if the update fails, since phase tracking is important for resume correctness.
@@ -74,6 +74,54 @@ pub(crate) async fn try_mark_issue_failed(host: &str, owner: &str, repo: &str, i
         Err(e) => {
             log::warn!("⚠️  Failed to update issue label: {:#}", e);
         }
+    }
+}
+
+/// Cleans up orchestration state after a post-agent failure (PR creation or
+/// PR lifecycle monitoring). Without this, a failure between the agent exiting
+/// and the worker exiting leaves the issue with `gru:in-progress` and no live
+/// process — an "orphaned label" recoverable only by the multi-hour auto-recovery
+/// scan.
+///
+/// This helper:
+/// 1. Posts an explanatory comment on the issue
+/// 2. Transitions the issue label `gru:in-progress` → `gru:failed`
+/// 3. Clears the PID and marks the minion as `Stopped` in the registry
+///
+/// Fire-and-forget: logs on failure but does not propagate errors, since the
+/// caller is already returning an error of its own.
+pub(crate) async fn cleanup_post_agent_failure(
+    host: &str,
+    owner: &str,
+    repo: &str,
+    issue_num: Option<u64>,
+    minion_id: &str,
+    reason: &str,
+) {
+    if let Some(num) = issue_num {
+        let comment = format!(
+            "⚠️  Minion `{}` failed after the agent phase: {}\n\n\
+             Use `gru resume {}` to retry.",
+            minion_id, reason, minion_id
+        );
+        try_post_issue_comment(host, owner, repo, num, &comment).await;
+        try_mark_issue_failed(host, owner, repo, num).await;
+    }
+
+    let mid = minion_id.to_string();
+    if let Err(e) = with_registry(move |reg| {
+        reg.update(&mid, |info| {
+            info.clear_pid();
+            info.mode = MinionMode::Stopped;
+        })
+    })
+    .await
+    {
+        log::warn!(
+            "⚠️  Failed to clear registry state for {}: {:#}",
+            minion_id,
+            e
+        );
     }
 }
 
@@ -199,6 +247,20 @@ mod tests {
                 crate::ci::MAX_CI_FIX_ATTEMPTS
             )
         );
+    }
+
+    #[test]
+    fn test_post_agent_failure_comment_format() {
+        let minion_id = "M1gt";
+        let reason = "PR creation failed: no PR was created";
+        let comment = format!(
+            "⚠️  Minion `{}` failed after the agent phase: {}\n\n\
+             Use `gru resume {}` to retry.",
+            minion_id, reason, minion_id
+        );
+        assert!(comment.contains("Minion `M1gt` failed after the agent phase"));
+        assert!(comment.contains("PR creation failed"));
+        assert!(comment.contains("gru resume M1gt"));
     }
 
     #[test]

--- a/src/commands/fix/mod.rs
+++ b/src/commands/fix/mod.rs
@@ -218,7 +218,22 @@ async fn run_worker(minion_id: &str, issue: &str, opts: FixOptions) -> Result<i3
     }
 
     // Phase 4: Create PR
-    let pr_number = worker::create_pr_phase(&issue_ctx, &wt_ctx, &start_phase, auto_merge).await?;
+    let pr_number =
+        match worker::create_pr_phase(&issue_ctx, &wt_ctx, &start_phase, auto_merge).await {
+            Ok(pr) => pr,
+            Err(e) => {
+                helpers::cleanup_post_agent_failure(
+                    &issue_ctx.host,
+                    &issue_ctx.owner,
+                    &issue_ctx.repo,
+                    issue_ctx.issue_num,
+                    &wt_ctx.minion_id,
+                    &format!("{:#}", e),
+                )
+                .await;
+                return Err(e);
+            }
+        };
 
     if no_watch {
         if let Some(ref pr_num) = pr_number {
@@ -244,6 +259,8 @@ async fn run_worker(minion_id: &str, issue: &str, opts: FixOptions) -> Result<i3
     .await;
 
     if monitor_result.is_err() {
+        // monitor_pr_phase already marks the issue as blocked on its known
+        // failure paths; no label cleanup needed here.
         return Ok(1);
     }
 


### PR DESCRIPTION
## Summary
- Adds `cleanup_post_agent_failure` helper in `src/commands/fix/helpers.rs` that posts an explanatory comment, transitions the issue label `gru:in-progress` → `gru:failed`, and clears the minion's PID/mode in the registry.
- Wires it into `run_worker` so that when `create_pr_phase` returns `Err` after the agent has already succeeded, the issue no longer sits with an orphaned `gru:in-progress` label waiting on the multi-hour auto-recovery scan.
- Leaves `monitor_pr_phase` error handling unchanged — its known failure paths already mark the issue as blocked; touching them would risk double-labeling with both `gru:blocked` and `gru:failed`.

## Test plan
- `just check` — fmt, clippy, 1238 tests, build — all pass
- Added a format-string snapshot test (`test_post_agent_failure_comment_format`) matching the style of the existing `test_blocked_reason_*` tests in this file.

## Notes
- Fixes #838. This does not touch the upstream `Ok(None)` bug (#837) that triggers this code path — the fix ensures that whenever PR creation fails for any reason, the label/registry state is cleaned up.
- The explanatory comment directs users to `gru resume <minion_id>` for retry. `create_pr_phase` still sets the orchestration phase appropriately (e.g., keeps it at `CreatingPr` on the `Ok(None)` path) so resume continues to work; only the label and pid/mode are cleaned up.

<sub>🤖 M1gt</sub>