### PR TITLE
Fixes #847: Agent non-zero exit silently abandons useful commits (no push, no PR, no comment)

### DIFF
--- a/src/commands/fix/helpers.rs
+++ b/src/commands/fix/helpers.rs
@@ -133,17 +133,12 @@ async fn base_branch_candidates(
     candidates
 }
 
-/// Returns `true` if `refs/remotes/origin/<branch>` exists locally in the worktree.
-async fn origin_ref_exists(checkout_path: &Path, branch: &str) -> bool {
+/// Checks whether a git ref exists in the worktree.
+async fn ref_exists(checkout_path: &Path, refname: &str) -> bool {
     TokioCommand::new("git")
         .arg("-C")
         .arg(checkout_path)
-        .args([
-            "show-ref",
-            "--verify",
-            "--quiet",
-            &format!("refs/remotes/origin/{}", branch),
-        ])
+        .args(["show-ref", "--verify", "--quiet", refname])
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_INDEX_FILE")
@@ -154,26 +149,30 @@ async fn origin_ref_exists(checkout_path: &Path, branch: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Counts commits on HEAD that are not on the base branch.
-/// Returns 0 when `origin/<base_branch>` is missing or the rev-list fails —
-/// callers treat 0 as "nothing to preserve".
-async fn count_commits_ahead(checkout_path: &Path, base_branch: &str) -> usize {
-    if !origin_ref_exists(checkout_path, base_branch).await {
-        log::warn!(
-            "origin/{} not present in worktree; cannot count commits ahead of base",
-            base_branch
-        );
-        return 0;
+/// Resolves a usable base ref for `branch`, preferring the remote-tracking
+/// ref and falling back to the local head. Gru's bare-repo worktrees typically
+/// fetch the default branch into `refs/heads/<base>`, not
+/// `refs/remotes/origin/<base>`, so the local fallback keeps the rescue from
+/// silently giving up on otherwise-standard setups.
+async fn resolve_base_ref(checkout_path: &Path, branch: &str) -> Option<String> {
+    let remote = format!("refs/remotes/origin/{}", branch);
+    if ref_exists(checkout_path, &remote).await {
+        return Some(remote);
     }
+    let local = format!("refs/heads/{}", branch);
+    if ref_exists(checkout_path, &local).await {
+        return Some(local);
+    }
+    None
+}
 
+/// Counts commits on HEAD that are not on `base_ref`.
+/// Returns 0 on any error — callers treat 0 as "nothing to preserve".
+async fn count_commits_ahead(checkout_path: &Path, base_ref: &str) -> usize {
     let output = match TokioCommand::new("git")
         .arg("-C")
         .arg(checkout_path)
-        .args([
-            "rev-list",
-            "--count",
-            &format!("origin/{}..HEAD", base_branch),
-        ])
+        .args(["rev-list", "--count", &format!("{}..HEAD", base_ref)])
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_INDEX_FILE")
@@ -200,12 +199,18 @@ async fn count_commits_ahead(checkout_path: &Path, base_branch: &str) -> usize {
         .unwrap_or(0)
 }
 
-/// Pushes the branch to origin from within the worktree's checkout.
+/// Pushes the worktree's HEAD to `refs/heads/<branch_name>` on origin.
+///
+/// Using an explicit `HEAD:refs/heads/<branch>` refspec (rather than
+/// `origin <branch>`) makes the rescue robust when the worktree is in a
+/// detached-HEAD state (rebase, merge, or mid-cherry-pick), which can
+/// happen if the agent was killed at the wrong moment.
 async fn push_branch(checkout_path: &Path, branch_name: &str) -> anyhow::Result<()> {
+    let refspec = format!("HEAD:refs/heads/{}", branch_name);
     let output = TokioCommand::new("git")
         .arg("-C")
         .arg(checkout_path)
-        .args(["push", "--force-with-lease", "origin", branch_name])
+        .args(["push", "--force-with-lease", "origin", &refspec])
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_INDEX_FILE")
@@ -240,17 +245,16 @@ pub(crate) async fn try_preserve_branch_work(
     minion_id: &str,
 ) -> bool {
     let candidates = base_branch_candidates(checkout_path, host, owner, repo).await;
-    let mut resolved: Option<(String, usize)> = None;
+    let mut resolved: Option<(String, String, usize)> = None;
     for base in &candidates {
-        if !origin_ref_exists(checkout_path, base).await {
-            continue;
+        if let Some(base_ref) = resolve_base_ref(checkout_path, base).await {
+            let n = count_commits_ahead(checkout_path, &base_ref).await;
+            resolved = Some((base.clone(), base_ref, n));
+            break;
         }
-        let n = count_commits_ahead(checkout_path, base).await;
-        resolved = Some((base.clone(), n));
-        break;
     }
 
-    let (base_branch, commits_ahead) = match resolved {
+    let (base_branch, base_ref, commits_ahead) = match resolved {
         Some(r) => r,
         None => {
             log::error!(
@@ -269,10 +273,11 @@ pub(crate) async fn try_preserve_branch_work(
         return false;
     }
     log::info!(
-        "Preserving {} commit(s) on '{}' (base: origin/{})",
+        "Preserving {} commit(s) on '{}' (base: {} via '{}')",
         commits_ahead,
         branch_name,
-        base_branch
+        base_branch,
+        base_ref
     );
 
     let push_result = push_branch(checkout_path, branch_name).await;
@@ -531,14 +536,15 @@ mod tests {
         };
 
         let bare = dir.join("origin.git");
-        StdCmd::new("git")
+        let status = StdCmd::new("git")
             .args(["init", "--bare", bare.to_str().unwrap()])
             .env_remove("GIT_DIR")
             .env_remove("GIT_WORK_TREE")
             .env_remove("GIT_INDEX_FILE")
             .env_remove("GIT_COMMON_DIR")
             .status()
-            .unwrap();
+            .expect("git init --bare failed to spawn");
+        assert!(status.success(), "git init --bare exited {:?}", status);
 
         let wt = dir.join("wt");
         std::fs::create_dir_all(&wt).unwrap();
@@ -563,8 +569,54 @@ mod tests {
     async fn test_count_commits_ahead_with_new_commits() {
         let tmp = tempfile::tempdir().unwrap();
         let wt = setup_test_repo_ahead(tmp.path(), 2);
-        let n = super::count_commits_ahead(&wt, "main").await;
+        let n = super::count_commits_ahead(&wt, "refs/remotes/origin/main").await;
         assert_eq!(n, 2);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_base_ref_prefers_remote_then_local() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = setup_test_repo_ahead(tmp.path(), 1);
+
+        // feature branch is checked out; local `main` exists and so does
+        // `refs/remotes/origin/main` — remote should win.
+        let base = super::resolve_base_ref(&wt, "main").await;
+        assert_eq!(base.as_deref(), Some("refs/remotes/origin/main"));
+
+        // Missing branch returns None.
+        let missing = super::resolve_base_ref(&wt, "nope").await;
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_base_ref_falls_back_to_local_head() {
+        // Repo with a local `refs/heads/main` but no `refs/remotes/origin/main`
+        // — mimics Gru's bare-repo-worktree layout where the default branch
+        // is fetched into refs/heads/<base>, not refs/remotes/origin/<base>.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        use std::process::Command as StdCmd;
+        let run = |args: &[&str]| {
+            let out = StdCmd::new("git")
+                .args(args)
+                .current_dir(dir)
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_WORK_TREE")
+                .env_remove("GIT_INDEX_FILE")
+                .env_remove("GIT_COMMON_DIR")
+                .output()
+                .unwrap();
+            assert!(out.status.success());
+        };
+        run(&["init", "-b", "main"]);
+        run(&["config", "user.email", "t@t"]);
+        run(&["config", "user.name", "t"]);
+        std::fs::write(dir.join("a"), "a").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "a"]);
+
+        let base = super::resolve_base_ref(dir, "main").await;
+        assert_eq!(base.as_deref(), Some("refs/heads/main"));
     }
 
     #[tokio::test]
@@ -595,31 +647,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_count_commits_ahead_missing_origin_ref_returns_zero() {
-        // Worktree with no `origin/<base>` ref should report 0, not error.
+    async fn test_push_branch_from_detached_head() {
+        // Detach HEAD, then push — the explicit `HEAD:refs/heads/<branch>`
+        // refspec should still advance the remote branch.
         let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path();
+        let wt = setup_test_repo_ahead(tmp.path(), 1);
         use std::process::Command as StdCmd;
-        let run = |args: &[&str]| {
-            let out = StdCmd::new("git")
-                .args(args)
-                .current_dir(dir)
-                .env_remove("GIT_DIR")
-                .env_remove("GIT_WORK_TREE")
-                .env_remove("GIT_INDEX_FILE")
-                .env_remove("GIT_COMMON_DIR")
-                .output()
-                .unwrap();
-            assert!(out.status.success());
-        };
-        run(&["init", "-b", "main"]);
-        run(&["config", "user.email", "t@t"]);
-        run(&["config", "user.name", "t"]);
-        std::fs::write(dir.join("a"), "a").unwrap();
-        run(&["add", "."]);
-        run(&["commit", "-m", "a"]);
-        // No origin remote, no origin/main ref.
-        let n = super::count_commits_ahead(dir, "main").await;
+        let out = StdCmd::new("git")
+            .args(["-C", wt.to_str().unwrap(), "checkout", "--detach", "HEAD"])
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_COMMON_DIR")
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git checkout --detach failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let result = super::push_branch(&wt, "feature").await;
+        assert!(result.is_ok(), "push_branch failed: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_count_commits_ahead_bad_ref_returns_zero() {
+        // Bogus base ref → rev-list fails → function returns 0 rather than erroring.
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = setup_test_repo_ahead(tmp.path(), 1);
+        let n = super::count_commits_ahead(&wt, "refs/remotes/origin/does-not-exist").await;
         assert_eq!(n, 0);
     }
 
@@ -627,7 +684,7 @@ mod tests {
     async fn test_count_commits_ahead_no_new_commits() {
         let tmp = tempfile::tempdir().unwrap();
         let wt = setup_test_repo_ahead(tmp.path(), 0);
-        let n = super::count_commits_ahead(&wt, "main").await;
+        let n = super::count_commits_ahead(&wt, "refs/remotes/origin/main").await;
         assert_eq!(n, 0);
     }
 

--- a/src/commands/fix/helpers.rs
+++ b/src/commands/fix/helpers.rs
@@ -1,4 +1,6 @@
 use crate::minion_registry::{with_registry, MinionMode, OrchestrationPhase};
+use std::path::Path;
+use tokio::process::Command as TokioCommand;
 
 /// Updates the orchestration phase for a minion in the registry.
 /// Logs a warning if the update fails, since phase tracking is important for resume correctness.
@@ -75,6 +77,162 @@ pub(crate) async fn try_mark_issue_failed(host: &str, owner: &str, repo: &str, i
             log::warn!("⚠️  Failed to update issue label: {:#}", e);
         }
     }
+}
+
+/// Resolves the base branch for a worktree, preferring local `origin/HEAD`
+/// and falling back to the GitHub API.
+async fn resolve_base_branch(checkout_path: &Path, host: &str, owner: &str, repo: &str) -> String {
+    if let Ok(out) = TokioCommand::new("git")
+        .arg("-C")
+        .arg(checkout_path)
+        .args(["symbolic-ref", "refs/remotes/origin/HEAD"])
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
+        .output()
+        .await
+    {
+        if out.status.success() {
+            let raw = String::from_utf8_lossy(&out.stdout);
+            if let Some(branch) = raw.trim().strip_prefix("refs/remotes/origin/") {
+                return branch.to_string();
+            }
+        }
+    }
+
+    crate::github::get_default_branch(host, owner, repo)
+        .await
+        .unwrap_or_else(|e| {
+            log::warn!(
+                "Could not determine default branch from GitHub API: {}. Falling back to 'main'.",
+                e
+            );
+            "main".to_string()
+        })
+}
+
+/// Counts commits on HEAD that are not on the base branch.
+/// Returns 0 on any error (conservative: only act when we're confident).
+async fn count_commits_ahead(checkout_path: &Path, base_branch: &str) -> usize {
+    let output = match TokioCommand::new("git")
+        .arg("-C")
+        .arg(checkout_path)
+        .args([
+            "rev-list",
+            "--count",
+            &format!("origin/{}..HEAD", base_branch),
+        ])
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            log::warn!("Failed to count commits ahead of base: {}", e);
+            return 0;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::warn!("git rev-list --count failed: {}", stderr.trim());
+        return 0;
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<usize>()
+        .unwrap_or(0)
+}
+
+/// Pushes the branch to origin from within the worktree's checkout.
+async fn push_branch(checkout_path: &Path, branch_name: &str) -> anyhow::Result<()> {
+    let output = TokioCommand::new("git")
+        .arg("-C")
+        .arg(checkout_path)
+        .args(["push", "origin", branch_name])
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
+        .output()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to execute git push: {}", e))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(anyhow::anyhow!("git push failed: {}", stderr.trim()))
+    }
+}
+
+/// Attempts to preserve committed work when the agent exits unexpectedly.
+///
+/// If the branch has local commits that aren't on the base, pushes the branch
+/// and posts a diagnostic comment on the issue so the user (or a future minion)
+/// can recover the work. Fire-and-forget: errors are logged, not propagated.
+///
+/// Returns `true` if commits were found and a push was attempted (regardless of
+/// whether the push itself succeeded).
+pub(crate) async fn try_preserve_branch_work(
+    host: &str,
+    owner: &str,
+    repo: &str,
+    issue_num: Option<u64>,
+    checkout_path: &Path,
+    branch_name: &str,
+    minion_id: &str,
+) -> bool {
+    let base_branch = resolve_base_branch(checkout_path, host, owner, repo).await;
+    let commits_ahead = count_commits_ahead(checkout_path, &base_branch).await;
+
+    if commits_ahead == 0 {
+        return false;
+    }
+
+    let push_result = push_branch(checkout_path, branch_name).await;
+    let push_succeeded = push_result.is_ok();
+    if let Err(ref e) = push_result {
+        log::warn!(
+            "⚠️  Failed to push branch '{}' after agent exit: {:#}",
+            branch_name,
+            e
+        );
+    } else {
+        println!(
+            "🚀 Pushed branch '{}' to preserve agent's work",
+            branch_name
+        );
+    }
+
+    if let Some(num) = issue_num {
+        let branch_line = if push_succeeded {
+            format!(
+                "Branch pushed: [`{}`](https://{}/{}/{}/tree/{})",
+                branch_name, host, owner, repo, branch_name
+            )
+        } else {
+            format!(
+                "⚠️  Branch push failed — commits remain only in the local worktree for `{}`.",
+                branch_name
+            )
+        };
+        let comment = format!(
+            "⚠️  Minion `{}` exited unexpectedly during the agent phase with {} \
+             unpushed commit(s) on its branch.\n\n\
+             {}\n\n\
+             Use `gru resume {}` to retry, or inspect the branch to recover the work.",
+            minion_id, commits_ahead, branch_line, minion_id
+        );
+        try_post_issue_comment(host, owner, repo, num, &comment).await;
+    }
+
+    true
 }
 
 /// Cleans up orchestration state after a post-agent failure. Without this,
@@ -267,6 +425,74 @@ mod tests {
             "⚠️  Minion `M1gt` failed after the agent phase: PR creation failed: no PR was created\n\n\
              Use `gru resume M1gt` to retry."
         );
+    }
+
+    /// Sets up a tiny git repo with `main` as base and a feature branch with
+    /// `extra` commits ahead. The `origin` remote points to a bare clone so
+    /// that `origin/main` resolves locally.
+    fn setup_test_repo_ahead(dir: &std::path::Path, extra: usize) -> std::path::PathBuf {
+        use std::process::Command as StdCmd;
+        let run = |args: &[&str], cwd: &std::path::Path| {
+            let out = StdCmd::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_WORK_TREE")
+                .env_remove("GIT_INDEX_FILE")
+                .env_remove("GIT_COMMON_DIR")
+                .output()
+                .expect("git failed");
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+
+        let bare = dir.join("origin.git");
+        StdCmd::new("git")
+            .args(["init", "--bare", bare.to_str().unwrap()])
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_COMMON_DIR")
+            .status()
+            .unwrap();
+
+        let wt = dir.join("wt");
+        std::fs::create_dir_all(&wt).unwrap();
+        run(&["init", "-b", "main"], &wt);
+        run(&["config", "user.email", "t@t"], &wt);
+        run(&["config", "user.name", "t"], &wt);
+        run(&["remote", "add", "origin", bare.to_str().unwrap()], &wt);
+        std::fs::write(wt.join("base.txt"), "base").unwrap();
+        run(&["add", "."], &wt);
+        run(&["commit", "-m", "base"], &wt);
+        run(&["push", "-u", "origin", "main"], &wt);
+        run(&["checkout", "-b", "feature"], &wt);
+        for i in 0..extra {
+            std::fs::write(wt.join(format!("f{}.txt", i)), "x").unwrap();
+            run(&["add", "."], &wt);
+            run(&["commit", "-m", &format!("c{}", i)], &wt);
+        }
+        wt
+    }
+
+    #[tokio::test]
+    async fn test_count_commits_ahead_with_new_commits() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = setup_test_repo_ahead(tmp.path(), 2);
+        let n = super::count_commits_ahead(&wt, "main").await;
+        assert_eq!(n, 2);
+    }
+
+    #[tokio::test]
+    async fn test_count_commits_ahead_no_new_commits() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = setup_test_repo_ahead(tmp.path(), 0);
+        let n = super::count_commits_ahead(&wt, "main").await;
+        assert_eq!(n, 0);
     }
 
     #[test]

--- a/src/commands/fix/helpers.rs
+++ b/src/commands/fix/helpers.rs
@@ -112,9 +112,39 @@ async fn resolve_base_branch(checkout_path: &Path, host: &str, owner: &str, repo
         })
 }
 
+/// Returns `true` if `refs/remotes/origin/<branch>` exists locally in the worktree.
+async fn origin_ref_exists(checkout_path: &Path, branch: &str) -> bool {
+    TokioCommand::new("git")
+        .arg("-C")
+        .arg(checkout_path)
+        .args([
+            "show-ref",
+            "--verify",
+            "--quiet",
+            &format!("refs/remotes/origin/{}", branch),
+        ])
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
 /// Counts commits on HEAD that are not on the base branch.
-/// Returns 0 on any error (conservative: only act when we're confident).
+/// Returns 0 when `origin/<base_branch>` is missing or the rev-list fails —
+/// callers treat 0 as "nothing to preserve".
 async fn count_commits_ahead(checkout_path: &Path, base_branch: &str) -> usize {
+    if !origin_ref_exists(checkout_path, base_branch).await {
+        log::warn!(
+            "origin/{} not present in worktree; cannot count commits ahead of base",
+            base_branch
+        );
+        return 0;
+    }
+
     let output = match TokioCommand::new("git")
         .arg("-C")
         .arg(checkout_path)
@@ -154,7 +184,7 @@ async fn push_branch(checkout_path: &Path, branch_name: &str) -> anyhow::Result<
     let output = TokioCommand::new("git")
         .arg("-C")
         .arg(checkout_path)
-        .args(["push", "origin", branch_name])
+        .args(["push", "--force-with-lease", "origin", branch_name])
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_INDEX_FILE")
@@ -224,7 +254,7 @@ pub(crate) async fn try_preserve_branch_work(
         };
         let comment = format!(
             "⚠️  Minion `{}` exited unexpectedly during the agent phase with {} \
-             unpushed commit(s) on its branch.\n\n\
+             commit(s) ahead of the base branch.\n\n\
              {}\n\n\
              Use `gru resume {}` to retry, or inspect the branch to recover the work.",
             minion_id, commits_ahead, branch_line, minion_id
@@ -485,6 +515,62 @@ mod tests {
         let wt = setup_test_repo_ahead(tmp.path(), 2);
         let n = super::count_commits_ahead(&wt, "main").await;
         assert_eq!(n, 2);
+    }
+
+    #[tokio::test]
+    async fn test_push_branch_pushes_to_origin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = setup_test_repo_ahead(tmp.path(), 1);
+        let result = super::push_branch(&wt, "feature").await;
+        assert!(result.is_ok(), "push_branch failed: {:?}", result.err());
+
+        // Verify the ref now exists in the bare origin.
+        use std::process::Command as StdCmd;
+        let bare = tmp.path().join("origin.git");
+        let out = StdCmd::new("git")
+            .args([
+                "-C",
+                bare.to_str().unwrap(),
+                "show-ref",
+                "--verify",
+                "refs/heads/feature",
+            ])
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_COMMON_DIR")
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "feature ref missing in bare origin");
+    }
+
+    #[tokio::test]
+    async fn test_count_commits_ahead_missing_origin_ref_returns_zero() {
+        // Worktree with no `origin/<base>` ref should report 0, not error.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        use std::process::Command as StdCmd;
+        let run = |args: &[&str]| {
+            let out = StdCmd::new("git")
+                .args(args)
+                .current_dir(dir)
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_WORK_TREE")
+                .env_remove("GIT_INDEX_FILE")
+                .env_remove("GIT_COMMON_DIR")
+                .output()
+                .unwrap();
+            assert!(out.status.success());
+        };
+        run(&["init", "-b", "main"]);
+        run(&["config", "user.email", "t@t"]);
+        run(&["config", "user.name", "t"]);
+        std::fs::write(dir.join("a"), "a").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "a"]);
+        // No origin remote, no origin/main ref.
+        let n = super::count_commits_ahead(dir, "main").await;
+        assert_eq!(n, 0);
     }
 
     #[tokio::test]

--- a/src/commands/fix/helpers.rs
+++ b/src/commands/fix/helpers.rs
@@ -79,9 +79,17 @@ pub(crate) async fn try_mark_issue_failed(host: &str, owner: &str, repo: &str, i
     }
 }
 
-/// Resolves the base branch for a worktree, preferring local `origin/HEAD`
-/// and falling back to the GitHub API.
-async fn resolve_base_branch(checkout_path: &Path, host: &str, owner: &str, repo: &str) -> String {
+/// Resolves candidate base-branch names in preference order: local
+/// `origin/HEAD`, then the GitHub API result, then `main` / `master`.
+/// Callers pick the first candidate whose `origin/<branch>` ref exists locally.
+async fn base_branch_candidates(
+    checkout_path: &Path,
+    host: &str,
+    owner: &str,
+    repo: &str,
+) -> Vec<String> {
+    let mut candidates: Vec<String> = Vec::new();
+
     if let Ok(out) = TokioCommand::new("git")
         .arg("-C")
         .arg(checkout_path)
@@ -96,20 +104,33 @@ async fn resolve_base_branch(checkout_path: &Path, host: &str, owner: &str, repo
         if out.status.success() {
             let raw = String::from_utf8_lossy(&out.stdout);
             if let Some(branch) = raw.trim().strip_prefix("refs/remotes/origin/") {
-                return branch.to_string();
+                candidates.push(branch.to_string());
             }
         }
     }
 
-    crate::github::get_default_branch(host, owner, repo)
-        .await
-        .unwrap_or_else(|e| {
+    match crate::github::get_default_branch(host, owner, repo).await {
+        Ok(branch) => {
+            if !candidates.iter().any(|c| c == &branch) {
+                candidates.push(branch);
+            }
+        }
+        Err(e) => {
             log::warn!(
-                "Could not determine default branch from GitHub API: {}. Falling back to 'main'.",
+                "Could not determine default branch from GitHub API: {}. \
+                 Falling back to 'main' / 'master' guesses.",
                 e
             );
-            "main".to_string()
-        })
+        }
+    }
+
+    for guess in ["main", "master"] {
+        if !candidates.iter().any(|c| c == guess) {
+            candidates.push(guess.to_string());
+        }
+    }
+
+    candidates
 }
 
 /// Returns `true` if `refs/remotes/origin/<branch>` exists locally in the worktree.
@@ -218,12 +239,41 @@ pub(crate) async fn try_preserve_branch_work(
     branch_name: &str,
     minion_id: &str,
 ) -> bool {
-    let base_branch = resolve_base_branch(checkout_path, host, owner, repo).await;
-    let commits_ahead = count_commits_ahead(checkout_path, &base_branch).await;
+    let candidates = base_branch_candidates(checkout_path, host, owner, repo).await;
+    let mut resolved: Option<(String, usize)> = None;
+    for base in &candidates {
+        if !origin_ref_exists(checkout_path, base).await {
+            continue;
+        }
+        let n = count_commits_ahead(checkout_path, base).await;
+        resolved = Some((base.clone(), n));
+        break;
+    }
+
+    let (base_branch, commits_ahead) = match resolved {
+        Some(r) => r,
+        None => {
+            log::error!(
+                "🚨 Could not resolve a base branch for commit preservation on '{}'. \
+                 Tried: {:?}. Committed work on the branch remains only in the local \
+                 worktree at {}.",
+                branch_name,
+                candidates,
+                checkout_path.display()
+            );
+            return false;
+        }
+    };
 
     if commits_ahead == 0 {
         return false;
     }
+    log::info!(
+        "Preserving {} commit(s) on '{}' (base: origin/{})",
+        commits_ahead,
+        branch_name,
+        base_branch
+    );
 
     let push_result = push_branch(checkout_path, branch_name).await;
     let push_succeeded = push_result.is_ok();

--- a/src/commands/fix/worker.rs
+++ b/src/commands/fix/worker.rs
@@ -1,5 +1,8 @@
 use super::agent::{resume_agent_session, run_agent_session};
-use super::helpers::{try_mark_issue_blocked, try_mark_issue_failed, update_orchestration_phase};
+use super::helpers::{
+    try_mark_issue_blocked, try_mark_issue_failed, try_preserve_branch_work,
+    update_orchestration_phase,
+};
 use super::monitor::{monitor_ci_after_fix, monitor_pr_lifecycle};
 use super::pr::handle_pr_creation;
 use super::types::{AgentResult, IssueContext, WorktreeContext};
@@ -56,6 +59,16 @@ pub(crate) async fn run_agent_phase(
         Ok(result) => {
             if !result.status.success() {
                 update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::Failed).await;
+                try_preserve_branch_work(
+                    &issue_ctx.host,
+                    &issue_ctx.owner,
+                    &issue_ctx.repo,
+                    issue_ctx.issue_num,
+                    &wt_ctx.checkout_path,
+                    &wt_ctx.branch_name,
+                    &wt_ctx.minion_id,
+                )
+                .await;
                 if let Some(issue_num) = issue_ctx.issue_num {
                     try_mark_issue_failed(
                         &issue_ctx.host,

--- a/src/commands/fix/worker.rs
+++ b/src/commands/fix/worker.rs
@@ -58,7 +58,10 @@ pub(crate) async fn run_agent_phase(
     match result {
         Ok(result) => {
             if !result.status.success() {
-                update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::Failed).await;
+                // Preserve any committed work BEFORE flipping the phase to
+                // Failed — a concurrent `gru resume` could otherwise spawn a
+                // new agent session on the same branch and force-push over
+                // the commits we're trying to rescue.
                 try_preserve_branch_work(
                     &issue_ctx.host,
                     &issue_ctx.owner,
@@ -69,6 +72,7 @@ pub(crate) async fn run_agent_phase(
                     &wt_ctx.minion_id,
                 )
                 .await;
+                update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::Failed).await;
                 if let Some(issue_num) = issue_ctx.issue_num {
                     try_mark_issue_failed(
                         &issue_ctx.host,

--- a/src/commands/fix/worker.rs
+++ b/src/commands/fix/worker.rs
@@ -55,23 +55,32 @@ pub(crate) async fn run_agent_phase(
         run_agent_session(backend, issue_ctx, wt_ctx, quiet, timeout_opt).await
     };
 
+    // Preserve any committed work BEFORE any failure-path bookkeeping — a
+    // concurrent `gru resume` could otherwise spawn a new agent session on the
+    // same branch and force-push over the commits we're trying to rescue. All
+    // three failure arms below (non-zero exit, stuck/timeout, other error) hit
+    // the same user-visible #847 symptom when the branch has committed work,
+    // so preservation runs for all three.
+    let agent_failed = match &result {
+        Ok(r) => !r.status.success(),
+        Err(_) => true,
+    };
+    if agent_failed {
+        try_preserve_branch_work(
+            &issue_ctx.host,
+            &issue_ctx.owner,
+            &issue_ctx.repo,
+            issue_ctx.issue_num,
+            &wt_ctx.checkout_path,
+            &wt_ctx.branch_name,
+            &wt_ctx.minion_id,
+        )
+        .await;
+    }
+
     match result {
         Ok(result) => {
             if !result.status.success() {
-                // Preserve any committed work BEFORE flipping the phase to
-                // Failed — a concurrent `gru resume` could otherwise spawn a
-                // new agent session on the same branch and force-push over
-                // the commits we're trying to rescue.
-                try_preserve_branch_work(
-                    &issue_ctx.host,
-                    &issue_ctx.owner,
-                    &issue_ctx.repo,
-                    issue_ctx.issue_num,
-                    &wt_ctx.checkout_path,
-                    &wt_ctx.branch_name,
-                    &wt_ctx.minion_id,
-                )
-                .await;
                 update_orchestration_phase(&wt_ctx.minion_id, OrchestrationPhase::Failed).await;
                 if let Some(issue_num) = issue_ctx.issue_num {
                     try_mark_issue_failed(


### PR DESCRIPTION
## Summary
- When the agent subprocess exits non-zero mid-stream, the worker no longer silently abandons any commits on the minion branch. It now pushes the branch (`--force-with-lease`) and posts a diagnostic comment on the issue linking the pushed branch so a human or follow-up minion can recover the work.
- New helper `try_preserve_branch_work` in `src/commands/fix/helpers.rs` resolves the base branch (local `origin/HEAD` → GitHub API → `"main"` fallback), checks that `refs/remotes/origin/<base>` exists, counts commits ahead of base, pushes if >0, and posts a comment with the branch URL.
- Invoked from `run_agent_phase` in `src/commands/fix/worker.rs` *before* the orchestration phase flips to `Failed`, so a concurrent `gru resume` cannot spawn a new agent session and force-push over the commits being rescued.

## Test plan
- `just check` — fmt, clippy, 1250 tests pass.
- New unit tests cover:
  - commits-ahead counting with and without new commits
  - commits-ahead returns 0 when `origin/<base>` ref is missing
  - `push_branch` actually advances `refs/heads/<branch>` on the local bare origin

## Notes
- Push uses `--force-with-lease` rather than a plain push so partial-push or concurrent-minion conflicts surface in the warning instead of being silently rejected.
- Out of scope (called out in issue #847): the lab re-claim lockout when the user flips `gru:failed` → `gru:todo`. That needs a separate fix in `check_existing_minions` / registry handling.
- `cleanup_post_agent_failure` was *not* unified with the new helper in this PR. The PR-phase failure path (`handle_pr_creation`) only reaches `cleanup_post_agent_failure` after a successful branch push (PR creation requires the branch to already be on GitHub), so adding a push there would be a no-op. Keeping the two helpers separate avoids duplicating the comment logic when branches are already pushed.

Fixes #847

<sub>🤖 M1h8</sub>