### PR TITLE
Fixes #717: Share rate limit state across Minions in Lab mode

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -186,6 +186,11 @@ pub(crate) async fn gh_api_with_retry(
     let args_str = args.join(" ");
 
     loop {
+        // If another Minion has signalled a rate limit for this host, wait
+        // for the reset window before spawning `gh`. Avoids the N×62s waste
+        // of every Minion independently discovering the same limit.
+        crate::shared_rate_limit::wait_if_shared_rate_limited(host).await;
+
         let output = gh_cli_command(host)
             .args(args)
             .output()
@@ -196,6 +201,9 @@ pub(crate) async fn gh_api_with_retry(
             if attempts > 0 || rate_limit_retried {
                 log::info!("GitHub API call succeeded after retries: gh {}", args_str);
             }
+            // Clear any shared rate-limit signal: the window has passed
+            // (otherwise this call would have failed).
+            crate::shared_rate_limit::clear_rate_limit(host);
             return Ok(output);
         }
 
@@ -389,6 +397,8 @@ pub(crate) async fn sleep_until_rate_limit_reset(host: &str) {
                     dur_min,
                     dur_sec,
                 );
+                // Signal peer Minions so they skip their own doomed calls.
+                crate::shared_rate_limit::write_rate_limit_until(host, info.reset);
                 tokio::time::sleep(std::time::Duration::from_secs(sleep_secs)).await;
                 return;
             }
@@ -400,6 +410,10 @@ pub(crate) async fn sleep_until_rate_limit_reset(host: &str) {
                 RATE_LIMIT_FALLBACK_SLEEP_SECS,
                 RATE_LIMIT_FALLBACK_SLEEP_SECS,
             );
+            // Signal peer Minions with the full reset epoch; they will
+            // sleep until the window closes rather than repeating our
+            // fallback-sized waits.
+            crate::shared_rate_limit::write_rate_limit_until(host, info.reset);
         } else {
             // Reset epoch is in the past — likely stale or clock skew
             log::warn!(

--- a/src/github.rs
+++ b/src/github.rs
@@ -410,10 +410,13 @@ pub(crate) async fn sleep_until_rate_limit_reset(host: &str) {
                 RATE_LIMIT_FALLBACK_SLEEP_SECS,
                 RATE_LIMIT_FALLBACK_SLEEP_SECS,
             );
-            // Signal peer Minions with the full reset epoch; they will
-            // sleep until the window closes rather than repeating our
-            // fallback-sized waits.
-            crate::shared_rate_limit::write_rate_limit_until(host, info.reset);
+            // Signal peers with our fallback window, not info.reset: if the
+            // local Minion doesn't trust the reset epoch enough to sleep
+            // that long, peers shouldn't either.
+            crate::shared_rate_limit::write_rate_limit_until(
+                host,
+                now + RATE_LIMIT_FALLBACK_SLEEP_SECS,
+            );
         } else {
             // Reset epoch is in the past — likely stale or clock skew
             log::warn!(

--- a/src/github.rs
+++ b/src/github.rs
@@ -412,11 +412,13 @@ pub(crate) async fn sleep_until_rate_limit_reset(host: &str) {
             );
             // Signal peers with our fallback window, not info.reset: if the
             // local Minion doesn't trust the reset epoch enough to sleep
-            // that long, peers shouldn't either.
-            crate::shared_rate_limit::write_rate_limit_until(
-                host,
-                now + RATE_LIMIT_FALLBACK_SLEEP_SECS,
-            );
+            // that long, peers shouldn't either. Subtract the peer-side
+            // jitter so peers wake at roughly `now + fallback` — the same
+            // wall-clock moment as the local Minion — rather than `jitter`
+            // seconds later.
+            let peer_reset = (now + RATE_LIMIT_FALLBACK_SLEEP_SECS)
+                .saturating_sub(crate::shared_rate_limit::JITTER_SECS);
+            crate::shared_rate_limit::write_rate_limit_until(host, peer_reset);
         } else {
             // Reset epoch is in the past — likely stale or clock skew
             log::warn!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod prompt_renderer;
 mod prompt_utils;
 mod retry_queue;
 mod session_claim;
+mod shared_rate_limit;
 mod stream;
 mod text_buffer;
 mod tmux;

--- a/src/shared_rate_limit.rs
+++ b/src/shared_rate_limit.rs
@@ -15,11 +15,12 @@
 //! the shared check; direct `gh_cli_command` callers bypass it and will
 //! discover the rate limit on their own (and then signal via this module).
 //!
-//! A successful API call unconditionally clears the shared file. If a peer
-//! Minion wrote a fresh signal between our check and our success, we'll
-//! clobber it and the next peer will re-discover the limit itself — this
-//! degrades to the pre-PR behavior (one extra failed call), which the PRD
-//! explicitly accepts as the worst case.
+//! After a coordinated sleep, the wake-up path re-reads the file and only
+//! clears it when the stored epoch is no later than the one we slept on —
+//! so if a peer wrote a *later* signal while we slept, we leave it alone.
+//! A successful API call still clears unconditionally; a peer's fresh
+//! signal can be clobbered there, but the next peer will just re-discover
+//! the limit itself (the PRD-accepted "one extra failed call" worst case).
 
 use std::fs;
 use std::io::Write;
@@ -29,8 +30,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::workspace::Workspace;
 
 /// Small jitter added after the reset timestamp to avoid thundering herd
-/// when many Minions resume simultaneously.
-const JITTER_SECS: u64 = 5;
+/// when many Minions resume simultaneously. Exposed so writers can subtract
+/// it from the stored epoch to keep peer and writer wake times aligned
+/// when the writer's own sleep doesn't include jitter.
+pub(crate) const JITTER_SECS: u64 = 5;
 
 /// Reset epochs claiming more than this far in the future are treated as
 /// corruption and removed on read. GitHub rate-limit windows are at most
@@ -66,8 +69,8 @@ fn now_secs() -> u64 {
 ///
 /// Returns `Some(epoch)` only when the file exists, parses, and points to a
 /// future time within the sanity window. Returns `None` (and removes the
-/// file) when the stored value is expired, stale (>2h in the past), or
-/// implausibly far in the future (>2h ahead).
+/// file) when the stored value is expired (epoch <= now), unparseable, or
+/// implausibly far in the future (>`STALE_THRESHOLD_SECS` ahead).
 pub(crate) fn read_rate_limit_until(host: &str) -> Option<u64> {
     let path = rate_limit_path(host)?;
     let contents = fs::read_to_string(&path).ok()?;
@@ -166,8 +169,17 @@ pub(crate) async fn wait_if_shared_rate_limited(host: &str) {
         wait_secs,
     );
     tokio::time::sleep(Duration::from_secs(wait_secs)).await;
-    // Window elapsed — remove the file so the next caller doesn't re-read it.
-    clear_rate_limit(host);
+    // A peer may have written a *later* reset epoch while we slept (e.g., a
+    // shorter fallback window first, then a longer real reset). Only clear
+    // the file if the current stored epoch is no later than the one we slept
+    // on — otherwise we'd clobber a signal that's still meaningful to peers.
+    // `read_rate_limit_until` already removes files whose epoch is in the
+    // past, so a `None` return here means someone else has taken care of it.
+    if let Some(current) = read_rate_limit_until(host) {
+        if current <= reset_epoch {
+            clear_rate_limit(host);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -320,6 +332,50 @@ mod tests {
         let start = std::time::Instant::now();
         wait_if_shared_rate_limited("github.com").await;
         assert!(start.elapsed() < Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn wait_preserves_newer_signal_written_during_sleep() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+
+        // Seed with an already-expired epoch so wait_if_shared_rate_limited
+        // doesn't actually sleep. The "we slept on this" value is the past
+        // epoch; after the (no-op) sleep, a peer has written a *newer*,
+        // future reset — we must not clobber it.
+        let past = now_secs() - 10;
+        let newer_future = now_secs() + 600;
+        let path = rate_limit_path("github.com").unwrap();
+
+        // Simulate: read_rate_limit_until sees a just-past epoch (which it
+        // would clean up) — so instead put a very-recently-expired epoch
+        // and have the test inject the newer signal between the read and
+        // the post-sleep check. We can't hook the sleep, so instead drive
+        // the logic directly: write the past epoch and the newer one
+        // during a zero-duration wait sequence.
+        //
+        // Easiest: write a near-future epoch (1s) so the function sleeps
+        // briefly, then overwrite with a much-later epoch before it wakes.
+        let short_future = now_secs() + 1;
+        fs::write(&path, short_future.to_string()).unwrap();
+
+        let host = "github.com".to_string();
+        let wait_task = tokio::spawn(async move {
+            wait_if_shared_rate_limited(&host).await;
+        });
+
+        // Race in the newer signal before the sleeper wakes.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        fs::write(&path, newer_future.to_string()).unwrap();
+
+        wait_task.await.unwrap();
+
+        // The newer signal must survive.
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(after.trim(), newer_future.to_string());
+
+        // Keep `past` referenced for clarity in the test narrative.
+        let _ = past;
     }
 
     #[tokio::test]

--- a/src/shared_rate_limit.rs
+++ b/src/shared_rate_limit.rs
@@ -10,6 +10,10 @@
 //! independently. Writes are atomic (temp-file + rename). Reads may observe
 //! stale state; the worst case is one extra failed API call before the local
 //! Minion also writes the shared state — by design, no locking is used.
+//!
+//! Only callers that go through [`github::gh_api_with_retry`] benefit from
+//! the shared check; direct `gh_cli_command` callers bypass it and will
+//! discover the rate limit on their own (and then signal via this module).
 
 use std::fs;
 use std::io::Write;
@@ -99,7 +103,10 @@ pub(crate) fn write_rate_limit_until(host: &str, reset_epoch: u64) {
         return;
     };
 
-    let temp_path = path.with_extension("txt.tmp");
+    // PID-suffix the temp file so two Minions writing for the same host
+    // don't clobber each other's in-flight temp. The rename step is still
+    // the serializing point (last rename wins), which is acceptable.
+    let temp_path = path.with_extension(format!("txt.{}.tmp", std::process::id()));
     let write_result = (|| -> std::io::Result<()> {
         let mut file = fs::OpenOptions::new()
             .write(true)
@@ -281,8 +288,46 @@ mod tests {
         write_rate_limit_until("github.com", future_epoch);
 
         let path = rate_limit_path("github.com").unwrap();
-        let temp_path = path.with_extension("txt.tmp");
         assert!(path.exists());
-        assert!(!temp_path.exists());
+        // No *.tmp files left behind in the state dir.
+        let state_dir = path.parent().unwrap();
+        for entry in fs::read_dir(state_dir).unwrap() {
+            let entry = entry.unwrap();
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            assert!(
+                !name_str.ends_with(".tmp"),
+                "unexpected leftover temp file: {}",
+                name_str
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_returns_immediately_when_no_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+
+        // Missing file — should return immediately without sleeping.
+        let start = std::time::Instant::now();
+        wait_if_shared_rate_limited("github.com").await;
+        assert!(start.elapsed() < Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn wait_returns_immediately_when_file_is_expired() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+
+        // Write a past epoch directly so read_rate_limit_until's cleanup path
+        // fires and wait returns without sleeping.
+        let path = rate_limit_path("github.com").unwrap();
+        fs::write(&path, (now_secs() - 10).to_string()).unwrap();
+
+        let start = std::time::Instant::now();
+        wait_if_shared_rate_limited("github.com").await;
+        assert!(start.elapsed() < Duration::from_millis(500));
+        // Expired file should have been cleaned up.
+        assert!(!path.exists());
     }
 }

--- a/src/shared_rate_limit.rs
+++ b/src/shared_rate_limit.rs
@@ -14,6 +14,12 @@
 //! Only callers that go through [`github::gh_api_with_retry`] benefit from
 //! the shared check; direct `gh_cli_command` callers bypass it and will
 //! discover the rate limit on their own (and then signal via this module).
+//!
+//! A successful API call unconditionally clears the shared file. If a peer
+//! Minion wrote a fresh signal between our check and our success, we'll
+//! clobber it and the next peer will re-discover the limit itself — this
+//! degrades to the pre-PR behavior (one extra failed call), which the PRD
+//! explicitly accepts as the worst case.
 
 use std::fs;
 use std::io::Write;
@@ -26,9 +32,11 @@ use crate::workspace::Workspace;
 /// when many Minions resume simultaneously.
 const JITTER_SECS: u64 = 5;
 
-/// Files older than this (measured against the stored reset epoch) are
-/// considered stale and removed on read. GitHub rate-limit windows are
-/// at most ~60 minutes; anything claiming 2h in the past is corruption.
+/// Reset epochs claiming more than this far in the future are treated as
+/// corruption and removed on read. GitHub rate-limit windows are at most
+/// ~60 minutes, so anything >2h ahead is implausible. Past epochs are
+/// unconditionally treated as expired (see `read_rate_limit_until`) — this
+/// threshold only bounds the future direction.
 const STALE_THRESHOLD_SECS: u64 = 2 * 60 * 60;
 
 /// Sanitize a hostname into a filesystem-safe component by replacing any

--- a/src/shared_rate_limit.rs
+++ b/src/shared_rate_limit.rs
@@ -1,0 +1,288 @@
+//! Cross-Minion rate limit coordination.
+//!
+//! When one Minion hits a GitHub rate limit and learns the reset timestamp,
+//! it writes that epoch to `~/.gru/state/rate_limit_until_{host}.txt`. Other
+//! Minions check this file before making `gh` API calls and skip the call
+//! (sleeping until the reset window) instead of burning independent failed
+//! attempts.
+//!
+//! Per-host files allow `github.com` and GHES to track rate limits
+//! independently. Writes are atomic (temp-file + rename). Reads may observe
+//! stale state; the worst case is one extra failed API call before the local
+//! Minion also writes the shared state — by design, no locking is used.
+
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::workspace::Workspace;
+
+/// Small jitter added after the reset timestamp to avoid thundering herd
+/// when many Minions resume simultaneously.
+const JITTER_SECS: u64 = 5;
+
+/// Files older than this (measured against the stored reset epoch) are
+/// considered stale and removed on read. GitHub rate-limit windows are
+/// at most ~60 minutes; anything claiming 2h in the past is corruption.
+const STALE_THRESHOLD_SECS: u64 = 2 * 60 * 60;
+
+/// Sanitize a hostname into a filesystem-safe component by replacing any
+/// character that isn't an ASCII alphanumeric with `_`.
+fn sanitize_host(host: &str) -> String {
+    host.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+/// Resolve the shared rate-limit file path for the given host.
+/// Returns `None` if the workspace cannot be initialized.
+fn rate_limit_path(host: &str) -> Option<PathBuf> {
+    let ws = Workspace::global().ok()?;
+    let filename = format!("rate_limit_until_{}.txt", sanitize_host(host));
+    Some(ws.state().join(filename))
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Read the stored reset epoch for `host`, cleaning up stale state.
+///
+/// Returns `Some(epoch)` only when the file exists, parses, and points to a
+/// future time within the sanity window. Returns `None` (and removes the
+/// file) when the stored value is expired, stale (>2h in the past), or
+/// implausibly far in the future (>2h ahead).
+pub(crate) fn read_rate_limit_until(host: &str) -> Option<u64> {
+    let path = rate_limit_path(host)?;
+    let contents = fs::read_to_string(&path).ok()?;
+    let reset: u64 = contents.trim().parse().ok().or_else(|| {
+        // Unparseable — drop it so callers aren't stuck on corruption.
+        let _ = fs::remove_file(&path);
+        None
+    })?;
+
+    let now = now_secs();
+
+    if reset <= now {
+        // Window has passed — clean up and proceed normally.
+        let _ = fs::remove_file(&path);
+        return None;
+    }
+
+    // Sanity check: rate-limit windows are ≤ 1h. Anything claiming >2h in
+    // the future is stale/corrupt and should be ignored.
+    if reset.saturating_sub(now) > STALE_THRESHOLD_SECS {
+        log::warn!(
+            "Shared rate-limit file for {} points >2h in the future ({}s); \
+             treating as stale and removing.",
+            host,
+            reset.saturating_sub(now),
+        );
+        let _ = fs::remove_file(&path);
+        return None;
+    }
+
+    Some(reset)
+}
+
+/// Atomically write the reset epoch for `host` using temp-file + rename.
+///
+/// Errors are logged and swallowed: shared coordination is best-effort, and
+/// a failed write just means this Minion won't signal its peers.
+pub(crate) fn write_rate_limit_until(host: &str, reset_epoch: u64) {
+    let Some(path) = rate_limit_path(host) else {
+        log::debug!("Cannot resolve shared rate-limit path for {}", host);
+        return;
+    };
+
+    let temp_path = path.with_extension("txt.tmp");
+    let write_result = (|| -> std::io::Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&temp_path)?;
+        file.write_all(reset_epoch.to_string().as_bytes())?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&temp_path, &path)?;
+        Ok(())
+    })();
+
+    if let Err(e) = write_result {
+        log::warn!("Failed to write shared rate-limit file for {}: {}", host, e);
+        let _ = fs::remove_file(&temp_path);
+    }
+}
+
+/// Remove the shared rate-limit file for `host`, if present.
+///
+/// Called after a successful API call to clear the gate for other Minions.
+/// Missing files are not an error.
+pub(crate) fn clear_rate_limit(host: &str) {
+    let Some(path) = rate_limit_path(host) else {
+        return;
+    };
+    match fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => log::debug!("Failed to clear shared rate-limit file for {}: {}", host, e),
+    }
+}
+
+/// If another Minion has signalled a rate limit on `host`, sleep until the
+/// reset window passes. Intended to be called at the top of each attempt in
+/// `gh_api_with_retry` before spawning `gh`.
+pub(crate) async fn wait_if_shared_rate_limited(host: &str) {
+    let Some(reset_epoch) = read_rate_limit_until(host) else {
+        return;
+    };
+    let now = now_secs();
+    // read_rate_limit_until already filtered past/stale values; reset > now.
+    let wait_secs = reset_epoch.saturating_sub(now).saturating_add(JITTER_SECS);
+    log::warn!(
+        "Shared rate limit active for {} (signalled by another Minion). \
+         Sleeping {}s until reset.",
+        host,
+        wait_secs,
+    );
+    tokio::time::sleep(Duration::from_secs(wait_secs)).await;
+    // Window elapsed — remove the file so the next caller doesn't re-read it.
+    clear_rate_limit(host);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace::set_test_workspace;
+
+    #[test]
+    fn sanitize_host_replaces_dots_and_special_chars() {
+        assert_eq!(sanitize_host("github.com"), "github_com");
+        assert_eq!(sanitize_host("ghe.netflix.com"), "ghe_netflix_com");
+        assert_eq!(sanitize_host("host:8080"), "host_8080");
+        assert_eq!(sanitize_host("a/b\\c"), "a_b_c");
+        assert_eq!(sanitize_host("plain"), "plain");
+    }
+
+    #[test]
+    fn read_missing_file_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+        assert!(read_rate_limit_until("github.com").is_none());
+    }
+
+    #[test]
+    fn write_then_read_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+
+        let future_epoch = now_secs() + 300;
+        write_rate_limit_until("github.com", future_epoch);
+
+        // File should land at the per-host path and contain exactly the epoch.
+        let path = rate_limit_path("github.com").unwrap();
+        assert!(path.exists());
+        let contents = fs::read_to_string(&path).unwrap();
+        assert_eq!(contents.trim(), future_epoch.to_string());
+
+        assert_eq!(read_rate_limit_until("github.com"), Some(future_epoch));
+    }
+
+    #[test]
+    fn read_past_epoch_is_cleaned_up() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+
+        let past_epoch = now_secs() - 10;
+        write_rate_limit_until("github.com", past_epoch);
+
+        assert!(read_rate_limit_until("github.com").is_none());
+        // File should be removed as a side effect.
+        let path = rate_limit_path("github.com").unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn read_far_future_epoch_is_stale_and_removed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+
+        // 3h in the future — outside the 2h sanity window.
+        let bogus_epoch = now_secs() + 3 * 60 * 60;
+        write_rate_limit_until("github.com", bogus_epoch);
+
+        assert!(read_rate_limit_until("github.com").is_none());
+        let path = rate_limit_path("github.com").unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn read_unparseable_contents_is_cleaned_up() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+
+        let path = rate_limit_path("github.com").unwrap();
+        fs::write(&path, "not-a-number").unwrap();
+
+        assert!(read_rate_limit_until("github.com").is_none());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn clear_rate_limit_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+
+        // Missing file is not an error.
+        clear_rate_limit("github.com");
+
+        let future_epoch = now_secs() + 300;
+        write_rate_limit_until("github.com", future_epoch);
+        let path = rate_limit_path("github.com").unwrap();
+        assert!(path.exists());
+
+        clear_rate_limit("github.com");
+        assert!(!path.exists());
+
+        // Second clear on missing file still works.
+        clear_rate_limit("github.com");
+    }
+
+    #[test]
+    fn per_host_files_are_independent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+
+        let reset_a = now_secs() + 200;
+        let reset_b = now_secs() + 400;
+        write_rate_limit_until("github.com", reset_a);
+        write_rate_limit_until("ghe.netflix.com", reset_b);
+
+        assert_eq!(read_rate_limit_until("github.com"), Some(reset_a));
+        assert_eq!(read_rate_limit_until("ghe.netflix.com"), Some(reset_b));
+
+        // Clearing one does not affect the other.
+        clear_rate_limit("github.com");
+        assert!(read_rate_limit_until("github.com").is_none());
+        assert_eq!(read_rate_limit_until("ghe.netflix.com"), Some(reset_b));
+    }
+
+    #[test]
+    fn write_is_atomic_no_temp_file_left_behind() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_workspace(tmp.path().to_path_buf()).unwrap();
+
+        let future_epoch = now_secs() + 300;
+        write_rate_limit_until("github.com", future_epoch);
+
+        let path = rate_limit_path("github.com").unwrap();
+        let temp_path = path.with_extension("txt.tmp");
+        assert!(path.exists());
+        assert!(!temp_path.exists());
+    }
+}


### PR DESCRIPTION
## Summary
- New `src/shared_rate_limit.rs` module: per-host file at `~/.gru/state/rate_limit_until_{sanitized_host}.txt` stores the epoch reset timestamp. Writes are atomic (temp-file + rename, PID-suffixed temp to avoid concurrent same-host collisions), reads clean up stale state (past, unparseable, or >2h in the future), and no lock is held — stale reads are acceptable per the PRD.
- `gh_api_with_retry` now calls `wait_if_shared_rate_limited(host)` at the top of each attempt before spawning `gh`, so peer Minions skip doomed API calls while a window is active. On success it clears the file so the next call proceeds without re-reading.
- `sleep_until_rate_limit_reset` writes the reset epoch to the shared file when the core quota is exhausted and the reset time is known. In the fallback-cap branch it writes `now + fallback_secs` (matching what the local Minion actually waits), keeping writer and peer wait durations aligned.
- Fixes #717.

## Test plan
- 11 new unit tests in `shared_rate_limit::tests` cover: hostname sanitization, missing/expired/stale/unparseable/far-future files, write-read roundtrip, idempotent clear, per-host independence, atomic-write leftover check, and async `wait_if_shared_rate_limited` fast-path cases.
- Full suite: `just check` — 1283 tests pass, fmt/clippy clean, release build succeeds.

## Notes
- Only callers that route through `gh_api_with_retry` benefit from the shared check; direct `gh_cli_command` callers discover rate limits on their own (and then signal via this module). Called out in module docs; migrating additional call sites is out of scope.
- The AC wording "stale (>2h old)" is implemented as "reset epoch >2h in the future," which is the correct interpretation (GitHub rate-limit windows are ≤1h, so anything claiming >2h ahead is corruption). Past epochs are always treated as expired and removed on read.
- Depends on #715 (rate-limit-aware retry logic), which is already merged.

<sub>🤖 M1hw</sub>