### PR TITLE
Fixes #727: Migrate merge-readiness check to single GraphQL query

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -32,6 +32,7 @@ const QUERY: &str = r#"query($owner: String!, $repo: String!, $number: Int!) {
         nodes {
           commit {
             statusCheckRollup {
+              state
               contexts(first: 100) {
                 nodes {
                   __typename
@@ -86,6 +87,10 @@ pub(crate) struct MergeReadinessData {
     pub reviews: Vec<ReviewInfo>,
     pub check_runs: Vec<CheckRunInfo>,
     pub status_contexts: Vec<StatusContextInfo>,
+    /// Top-level rollup state aggregating all contexts (`success`, `pending`,
+    /// `failure`, `error`, `expected`). `None` when no commits / no checks
+    /// exist on the head commit. Lower-cased to match REST conventions.
+    pub rollup_state: Option<String>,
     #[allow(dead_code)]
     pub labels: Vec<String>,
     /// `true` if any of the paginated sub-connections (reviews, rollup
@@ -181,6 +186,7 @@ fn is_graphql_unavailable(stderr: &str) -> bool {
     // 404/403 on the /graphql endpoint itself, or "not supported" messaging.
     (lower.contains("404") && lower.contains("not found"))
         || (lower.contains("403") && lower.contains("forbidden"))
+        || (lower.contains("401") && lower.contains("unauthorized"))
         || lower.contains("graphql is not supported")
         || lower.contains("graphql not enabled")
 }
@@ -209,6 +215,10 @@ fn parse_response(resp: GqlResponse) -> Result<MergeReadinessData> {
 
     let mut has_more_pages = pr.reviews.page_info.has_next_page;
 
+    // Review states are intentionally left in SCREAMING_SNAKE_CASE to match
+    // the REST `ReviewApiResponse.state` format that `evaluate_reviews`
+    // already compares against (e.g. `"APPROVED"`, `"CHANGES_REQUESTED"`).
+    // Normalizing would require updating the shared evaluator.
     let reviews: Vec<ReviewInfo> = pr
         .reviews
         .nodes
@@ -223,8 +233,10 @@ fn parse_response(resp: GqlResponse) -> Result<MergeReadinessData> {
 
     let mut check_runs: Vec<CheckRunInfo> = Vec::new();
     let mut status_contexts: Vec<StatusContextInfo> = Vec::new();
+    let mut rollup_state: Option<String> = None;
     if let Some(commit_node) = pr.commits.nodes.into_iter().next() {
         if let Some(rollup) = commit_node.commit.status_check_rollup {
+            rollup_state = rollup.state.as_deref().map(normalize_enum);
             if rollup.contexts.page_info.has_next_page {
                 has_more_pages = true;
             }
@@ -258,6 +270,7 @@ fn parse_response(resp: GqlResponse) -> Result<MergeReadinessData> {
         reviews,
         check_runs,
         status_contexts,
+        rollup_state,
         labels,
         has_more_pages,
     })
@@ -364,6 +377,11 @@ struct GqlCommit {
 
 #[derive(Debug, Deserialize)]
 struct GqlRollup {
+    /// Top-level aggregate state (`SUCCESS` | `PENDING` | `FAILURE` | `ERROR`
+    /// | `EXPECTED`). Not paginated, so it remains accurate even when
+    /// `contexts` exceeds our page size.
+    #[serde(default)]
+    state: Option<String>,
     contexts: GqlContextConnection,
 }
 
@@ -419,6 +437,7 @@ mod tests {
                   "nodes": [{
                     "commit": {
                       "statusCheckRollup": {
+                        "state": "SUCCESS",
                         "contexts": {
                           "nodes": [
                             {"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"SUCCESS"},
@@ -449,6 +468,7 @@ mod tests {
         assert_eq!(data.check_runs[0].conclusion.as_deref(), Some("success"));
         assert_eq!(data.status_contexts.len(), 1);
         assert_eq!(data.status_contexts[0].state, "success");
+        assert_eq!(data.rollup_state.as_deref(), Some("success"));
         assert!(!data.has_more_pages);
     }
 
@@ -601,6 +621,9 @@ mod tests {
         ));
         assert!(is_graphql_unavailable(
             "HTTP 403: Forbidden (graphql disabled)"
+        ));
+        assert!(is_graphql_unavailable(
+            "HTTP 401: Unauthorized (auth proxy blocked graphql)"
         ));
         assert!(is_graphql_unavailable(
             "GraphQL is not supported on this server"

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -20,7 +20,14 @@ const QUERY: &str = r#"query($owner: String!, $repo: String!, $number: Int!) {
       mergeable
       headRefOid
       author { login }
-      labels(first: 50) { nodes { name } }
+      labels(first: 50) {
+        nodes { name }
+        pageInfo { hasNextPage }
+      }
+      # Reviews are returned in ascending creation order (GitHub's default for
+      # this connection — there is no orderBy argument on PullRequest.reviews).
+      # `evaluate_reviews` depends on this chronological ordering so that
+      # DISMISSED can correctly clear a reviewer's prior state.
       reviews(first: 100) {
         nodes {
           state
@@ -138,6 +145,8 @@ pub(crate) async fn fetch_pr_merge_data(
         &[
             "api",
             "graphql",
+            "--cache",
+            "20s",
             "-f",
             &query_arg,
             "-F",
@@ -213,7 +222,8 @@ fn parse_response(resp: GqlResponse) -> Result<MergeReadinessData> {
 
     let author_login = pr.author.map(|a| a.login).unwrap_or_default();
 
-    let mut has_more_pages = pr.reviews.page_info.has_next_page;
+    let mut has_more_pages =
+        pr.reviews.page_info.has_next_page || pr.labels.page_info.has_next_page;
 
     // Review states are intentionally left in SCREAMING_SNAKE_CASE to match
     // the REST `ReviewApiResponse.state` format that `evaluate_reviews`
@@ -331,6 +341,8 @@ struct GqlAuthor {
 struct GqlLabelConnection {
     #[serde(default)]
     nodes: Vec<GqlLabel>,
+    #[serde(rename = "pageInfo", default)]
+    page_info: GqlPageInfo,
 }
 
 #[derive(Debug, Deserialize)]
@@ -557,6 +569,20 @@ mod tests {
             "author": {"login":"a"},
             "labels": {"nodes": []},
             "reviews": {"nodes": [], "pageInfo":{"hasNextPage":true}},
+            "commits": {"nodes": []}
+        }}}}"#;
+        assert!(parse(json).unwrap().has_more_pages);
+    }
+
+    #[test]
+    fn flags_pagination_overflow_on_labels() {
+        let json = r#"{"data":{"repository":{"pullRequest":{
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "headRefOid": "abc",
+            "author": {"login":"a"},
+            "labels": {"nodes": [], "pageInfo": {"hasNextPage": true}},
+            "reviews": {"nodes": [], "pageInfo":{"hasNextPage":false}},
             "commits": {"nodes": []}
         }}}}"#;
         assert!(parse(json).unwrap().has_more_pages);

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1,0 +1,611 @@
+//! GraphQL-based merge-readiness data fetching.
+//!
+//! Replaces 5+ REST calls with a single GraphQL query per merge-readiness
+//! check. The `repository.pullRequest` query returns PR metadata, reviews,
+//! check runs, legacy status contexts, and labels in one round-trip.
+//!
+//! GraphQL may be disabled or misconfigured on GHES installations; callers
+//! are expected to fall back to REST when [`fetch_pr_merge_data`] returns
+//! [`FetchOutcome::Unavailable`].
+
+use crate::github;
+use crate::github::DEFAULT_MAX_RETRIES;
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+const QUERY: &str = r#"query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      isDraft
+      mergeable
+      headRefOid
+      author { login }
+      labels(first: 50) { nodes { name } }
+      reviews(first: 100) {
+        nodes {
+          state
+          author { login }
+        }
+        pageInfo { hasNextPage }
+      }
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              contexts(first: 100) {
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    status
+                    conclusion
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                  }
+                }
+                pageInfo { hasNextPage }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"#;
+
+/// Outcome of attempting to fetch merge-readiness data via GraphQL.
+#[derive(Debug)]
+pub(crate) enum FetchOutcome {
+    /// GraphQL query succeeded and returned usable data.
+    Available(MergeReadinessData),
+    /// GraphQL endpoint is unavailable (e.g., disabled on GHES, 404/403).
+    /// Callers should fall back to REST.
+    Unavailable,
+}
+
+/// Merge-readiness data returned by the GraphQL query.
+///
+/// All enum-valued fields (states, conclusions, statuses) are lower-cased
+/// here so downstream evaluation logic can share behavior with the REST path,
+/// which returns already-lowercase strings.
+#[derive(Debug)]
+pub(crate) struct MergeReadinessData {
+    // head_sha and labels are fetched by the query (per #727 acceptance
+    // criteria) but not yet consumed by merge-readiness evaluation. Kept on
+    // the struct so a follow-up can use the same query to avoid the separate
+    // PR-details and labels REST calls elsewhere in pr_monitor.
+    #[allow(dead_code)]
+    pub head_sha: String,
+    pub draft: bool,
+    /// `Some(true)` when GitHub reports `MERGEABLE`, `Some(false)` for
+    /// `CONFLICTING`, `None` for `UNKNOWN` (still computing).
+    pub mergeable: Option<bool>,
+    pub author_login: String,
+    pub reviews: Vec<ReviewInfo>,
+    pub check_runs: Vec<CheckRunInfo>,
+    pub status_contexts: Vec<StatusContextInfo>,
+    #[allow(dead_code)]
+    pub labels: Vec<String>,
+    /// `true` if any of the paginated sub-connections (reviews, rollup
+    /// contexts) reported `hasNextPage`. The caller should treat this as a
+    /// signal to fall back to REST so no data is silently dropped.
+    pub has_more_pages: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReviewInfo {
+    pub state: String,
+    pub author_login: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CheckRunInfo {
+    pub status: Option<String>,
+    pub conclusion: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct StatusContextInfo {
+    pub state: String,
+}
+
+/// Fetch merge-readiness data for a PR via a single GraphQL query.
+///
+/// Returns [`FetchOutcome::Unavailable`] when the GraphQL endpoint cannot be
+/// reached (404/403) or reports a transport-level error indicating GraphQL
+/// is disabled. Query-level "not found" errors (e.g., PR doesn't exist) are
+/// returned as `Err`.
+pub(crate) async fn fetch_pr_merge_data(
+    host: &str,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+) -> Result<FetchOutcome> {
+    let number_arg = format!("number={pr_number}");
+    let owner_arg = format!("owner={owner}");
+    let repo_arg = format!("repo={repo}");
+    let query_arg = format!("query={QUERY}");
+
+    let output = github::gh_api_with_retry(
+        host,
+        &[
+            "api",
+            "graphql",
+            "-f",
+            &query_arg,
+            "-F",
+            &owner_arg,
+            "-F",
+            &repo_arg,
+            "-F",
+            &number_arg,
+        ],
+        DEFAULT_MAX_RETRIES,
+    )
+    .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_graphql_unavailable(&stderr) {
+            log::info!(
+                "GraphQL unavailable for {}/{} PR #{}: {}. Falling back to REST.",
+                owner,
+                repo,
+                pr_number,
+                stderr.trim()
+            );
+            return Ok(FetchOutcome::Unavailable);
+        }
+        anyhow::bail!(
+            "GraphQL merge-readiness query failed for {}/{} PR #{}: {}",
+            owner,
+            repo,
+            pr_number,
+            stderr.trim()
+        );
+    }
+
+    let parsed: GqlResponse = serde_json::from_slice(&output.stdout)
+        .context("Failed to parse GraphQL merge-readiness response")?;
+
+    parse_response(parsed).map(FetchOutcome::Available)
+}
+
+/// Returns `true` when `stderr` suggests the GraphQL endpoint itself is not
+/// available (as opposed to a per-query error). This is how GHES installs
+/// without GraphQL typically present themselves.
+fn is_graphql_unavailable(stderr: &str) -> bool {
+    let lower = stderr.to_lowercase();
+    // 404/403 on the /graphql endpoint itself, or "not supported" messaging.
+    (lower.contains("404") && lower.contains("not found"))
+        || (lower.contains("403") && lower.contains("forbidden"))
+        || lower.contains("graphql is not supported")
+        || lower.contains("graphql not enabled")
+}
+
+fn parse_response(resp: GqlResponse) -> Result<MergeReadinessData> {
+    if !resp.errors.is_empty() {
+        let messages: Vec<String> = resp.errors.iter().map(|e| e.message.clone()).collect();
+        anyhow::bail!("GraphQL query returned errors: {}", messages.join("; "));
+    }
+
+    let repository = resp
+        .data
+        .and_then(|d| d.repository)
+        .context("GraphQL response missing repository")?;
+    let pr = repository
+        .pull_request
+        .context("GraphQL response missing pullRequest")?;
+
+    let mergeable = match pr.mergeable.as_str() {
+        "MERGEABLE" => Some(true),
+        "CONFLICTING" => Some(false),
+        _ => None, // UNKNOWN or anything unexpected
+    };
+
+    let author_login = pr.author.map(|a| a.login).unwrap_or_default();
+
+    let mut has_more_pages = pr.reviews.page_info.has_next_page;
+
+    let reviews: Vec<ReviewInfo> = pr
+        .reviews
+        .nodes
+        .into_iter()
+        .map(|r| ReviewInfo {
+            state: r.state,
+            author_login: r.author.map(|a| a.login).unwrap_or_default(),
+        })
+        .collect();
+
+    let labels: Vec<String> = pr.labels.nodes.into_iter().map(|l| l.name).collect();
+
+    let mut check_runs: Vec<CheckRunInfo> = Vec::new();
+    let mut status_contexts: Vec<StatusContextInfo> = Vec::new();
+    if let Some(commit_node) = pr.commits.nodes.into_iter().next() {
+        if let Some(rollup) = commit_node.commit.status_check_rollup {
+            if rollup.contexts.page_info.has_next_page {
+                has_more_pages = true;
+            }
+            for ctx in rollup.contexts.nodes {
+                match ctx.typename.as_str() {
+                    "CheckRun" => check_runs.push(CheckRunInfo {
+                        status: ctx.status.map(|s| normalize_enum(&s)),
+                        conclusion: ctx.conclusion.map(|c| normalize_enum(&c)),
+                    }),
+                    "StatusContext" => {
+                        if let Some(state) = ctx.state {
+                            status_contexts.push(StatusContextInfo {
+                                state: normalize_enum(&state),
+                            });
+                        }
+                    }
+                    // Unknown context type — ignore. Unknown types contribute
+                    // no signal, and silently including them would risk
+                    // misclassifying CI state.
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Ok(MergeReadinessData {
+        head_sha: pr.head_ref_oid,
+        draft: pr.is_draft,
+        mergeable,
+        author_login,
+        reviews,
+        check_runs,
+        status_contexts,
+        labels,
+        has_more_pages,
+    })
+}
+
+/// GraphQL enum values are SCREAMING_SNAKE_CASE. Lower-case them to match the
+/// REST representation used by the existing evaluation logic.
+fn normalize_enum(s: &str) -> String {
+    s.to_ascii_lowercase()
+}
+
+// --- GraphQL response types ---
+
+#[derive(Debug, Deserialize)]
+struct GqlResponse {
+    #[serde(default)]
+    data: Option<GqlData>,
+    #[serde(default)]
+    errors: Vec<GqlError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlError {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlData {
+    repository: Option<GqlRepository>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlRepository {
+    #[serde(rename = "pullRequest")]
+    pull_request: Option<GqlPullRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlPullRequest {
+    #[serde(rename = "isDraft")]
+    is_draft: bool,
+    mergeable: String,
+    #[serde(rename = "headRefOid")]
+    head_ref_oid: String,
+    author: Option<GqlAuthor>,
+    labels: GqlLabelConnection,
+    reviews: GqlReviewConnection,
+    commits: GqlCommitConnection,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlAuthor {
+    #[serde(default)]
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlLabelConnection {
+    #[serde(default)]
+    nodes: Vec<GqlLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlLabel {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlReviewConnection {
+    #[serde(default)]
+    nodes: Vec<GqlReview>,
+    #[serde(rename = "pageInfo", default)]
+    page_info: GqlPageInfo,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GqlPageInfo {
+    #[serde(rename = "hasNextPage", default)]
+    has_next_page: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlReview {
+    state: String,
+    author: Option<GqlAuthor>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlCommitConnection {
+    #[serde(default)]
+    nodes: Vec<GqlCommitNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlCommitNode {
+    commit: GqlCommit,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlCommit {
+    #[serde(rename = "statusCheckRollup", default)]
+    status_check_rollup: Option<GqlRollup>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlRollup {
+    contexts: GqlContextConnection,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlContextConnection {
+    #[serde(default)]
+    nodes: Vec<GqlContext>,
+    #[serde(rename = "pageInfo", default)]
+    page_info: GqlPageInfo,
+}
+
+/// Flattened context node. Accepts both `CheckRun` and `StatusContext`
+/// variants from the `StatusCheckRollupContext` union.
+#[derive(Debug, Deserialize)]
+struct GqlContext {
+    #[serde(rename = "__typename")]
+    typename: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    conclusion: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> Result<MergeReadinessData> {
+        let resp: GqlResponse = serde_json::from_str(json).expect("valid json");
+        parse_response(resp)
+    }
+
+    #[test]
+    fn parses_typical_successful_response() {
+        let json = r#"{
+          "data": {
+            "repository": {
+              "pullRequest": {
+                "isDraft": false,
+                "mergeable": "MERGEABLE",
+                "headRefOid": "deadbeef",
+                "author": { "login": "alice" },
+                "labels": { "nodes": [{"name":"enhancement"},{"name":"gru:in-progress"}] },
+                "reviews": {
+                  "nodes": [
+                    {"state":"APPROVED","author":{"login":"bob"}}
+                  ],
+                  "pageInfo": {"hasNextPage": false}
+                },
+                "commits": {
+                  "nodes": [{
+                    "commit": {
+                      "statusCheckRollup": {
+                        "contexts": {
+                          "nodes": [
+                            {"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"SUCCESS"},
+                            {"__typename":"StatusContext","context":"ci/legacy","state":"SUCCESS"}
+                          ],
+                          "pageInfo": {"hasNextPage": false}
+                        }
+                      }
+                    }
+                  }]
+                }
+              }
+            }
+          }
+        }"#;
+
+        let data = parse(json).unwrap();
+        assert_eq!(data.head_sha, "deadbeef");
+        assert!(!data.draft);
+        assert_eq!(data.mergeable, Some(true));
+        assert_eq!(data.author_login, "alice");
+        assert_eq!(data.labels, vec!["enhancement", "gru:in-progress"]);
+        assert_eq!(data.reviews.len(), 1);
+        assert_eq!(data.reviews[0].state, "APPROVED");
+        assert_eq!(data.reviews[0].author_login, "bob");
+        assert_eq!(data.check_runs.len(), 1);
+        assert_eq!(data.check_runs[0].status.as_deref(), Some("completed"));
+        assert_eq!(data.check_runs[0].conclusion.as_deref(), Some("success"));
+        assert_eq!(data.status_contexts.len(), 1);
+        assert_eq!(data.status_contexts[0].state, "success");
+        assert!(!data.has_more_pages);
+    }
+
+    #[test]
+    fn parses_conflicting_and_unknown_mergeable() {
+        let conflicting = r#"{"data":{"repository":{"pullRequest":{
+            "isDraft": false,
+            "mergeable": "CONFLICTING",
+            "headRefOid": "abc",
+            "author": {"login":"a"},
+            "labels": {"nodes": []},
+            "reviews": {"nodes": [], "pageInfo":{"hasNextPage":false}},
+            "commits": {"nodes": []}
+        }}}}"#;
+        assert_eq!(parse(conflicting).unwrap().mergeable, Some(false));
+
+        let unknown = r#"{"data":{"repository":{"pullRequest":{
+            "isDraft": false,
+            "mergeable": "UNKNOWN",
+            "headRefOid": "abc",
+            "author": {"login":"a"},
+            "labels": {"nodes": []},
+            "reviews": {"nodes": [], "pageInfo":{"hasNextPage":false}},
+            "commits": {"nodes": []}
+        }}}}"#;
+        assert_eq!(parse(unknown).unwrap().mergeable, None);
+    }
+
+    #[test]
+    fn parses_draft_pr() {
+        let json = r#"{"data":{"repository":{"pullRequest":{
+            "isDraft": true,
+            "mergeable": "UNKNOWN",
+            "headRefOid": "abc",
+            "author": {"login":"a"},
+            "labels": {"nodes": []},
+            "reviews": {"nodes": [], "pageInfo":{"hasNextPage":false}},
+            "commits": {"nodes": []}
+        }}}}"#;
+        let data = parse(json).unwrap();
+        assert!(data.draft);
+    }
+
+    #[test]
+    fn parses_null_rollup() {
+        // A brand-new PR with no commits yet or no CI wired up — statusCheckRollup is null.
+        let json = r#"{"data":{"repository":{"pullRequest":{
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "headRefOid": "abc",
+            "author": {"login":"a"},
+            "labels": {"nodes": []},
+            "reviews": {"nodes": [], "pageInfo":{"hasNextPage":false}},
+            "commits": {"nodes": [{"commit": {"statusCheckRollup": null}}]}
+        }}}}"#;
+        let data = parse(json).unwrap();
+        assert!(data.check_runs.is_empty());
+        assert!(data.status_contexts.is_empty());
+    }
+
+    #[test]
+    fn parses_null_author_login() {
+        // Ghost/deleted users yield null author. Should not crash.
+        let json = r#"{"data":{"repository":{"pullRequest":{
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "headRefOid": "abc",
+            "author": null,
+            "labels": {"nodes": []},
+            "reviews": {"nodes": [
+              {"state":"APPROVED","author": null}
+            ], "pageInfo":{"hasNextPage":false}},
+            "commits": {"nodes": []}
+        }}}}"#;
+        let data = parse(json).unwrap();
+        assert_eq!(data.author_login, "");
+        assert_eq!(data.reviews[0].author_login, "");
+    }
+
+    #[test]
+    fn flags_pagination_overflow() {
+        let json = r#"{"data":{"repository":{"pullRequest":{
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "headRefOid": "abc",
+            "author": {"login":"a"},
+            "labels": {"nodes": []},
+            "reviews": {"nodes": [], "pageInfo":{"hasNextPage":true}},
+            "commits": {"nodes": []}
+        }}}}"#;
+        assert!(parse(json).unwrap().has_more_pages);
+    }
+
+    #[test]
+    fn flags_pagination_overflow_on_rollup() {
+        let json = r#"{"data":{"repository":{"pullRequest":{
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "headRefOid": "abc",
+            "author": {"login":"a"},
+            "labels": {"nodes": []},
+            "reviews": {"nodes": [], "pageInfo":{"hasNextPage":false}},
+            "commits": {"nodes": [{"commit": {"statusCheckRollup": {
+              "contexts": {
+                "nodes": [],
+                "pageInfo": {"hasNextPage": true}
+              }
+            }}}]}
+        }}}}"#;
+        assert!(parse(json).unwrap().has_more_pages);
+    }
+
+    #[test]
+    fn ignores_unknown_context_types() {
+        let json = r#"{"data":{"repository":{"pullRequest":{
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "headRefOid": "abc",
+            "author": {"login":"a"},
+            "labels": {"nodes": []},
+            "reviews": {"nodes": [], "pageInfo":{"hasNextPage":false}},
+            "commits": {"nodes": [{"commit": {"statusCheckRollup": {
+              "contexts": {
+                "nodes": [
+                  {"__typename":"SomeFutureType"},
+                  {"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}
+                ],
+                "pageInfo": {"hasNextPage": false}
+              }
+            }}}]}
+        }}}}"#;
+        let data = parse(json).unwrap();
+        assert_eq!(data.check_runs.len(), 1);
+    }
+
+    #[test]
+    fn surfaces_graphql_errors() {
+        let json = r#"{
+          "errors": [{"message": "Could not resolve to a PullRequest"}],
+          "data": null
+        }"#;
+        let err = parse(json).unwrap_err();
+        assert!(err.to_string().contains("Could not resolve"));
+    }
+
+    #[test]
+    fn unavailable_detection_matches_ghes_responses() {
+        assert!(is_graphql_unavailable(
+            "HTTP 404: Not Found (https://ghes.example.com/api/graphql)"
+        ));
+        assert!(is_graphql_unavailable(
+            "HTTP 403: Forbidden (graphql disabled)"
+        ));
+        assert!(is_graphql_unavailable(
+            "GraphQL is not supported on this server"
+        ));
+        assert!(!is_graphql_unavailable("500 Internal Server Error"));
+        assert!(!is_graphql_unavailable("rate limit exceeded"));
+    }
+}

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -13,6 +13,13 @@ use crate::github::DEFAULT_MAX_RETRIES;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+/// Sentinels substituted for null author logins. They contain `<`, which is
+/// invalid in a GitHub login, so they can never collide with a real user —
+/// and the per-review suffix ensures two ghost reviewers never match each
+/// other or a ghost PR author.
+const GHOST_PR_AUTHOR: &str = "<ghost-pr-author>";
+const GHOST_REVIEW_AUTHOR_PREFIX: &str = "<ghost-review-author-";
+
 const QUERY: &str = r#"query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
@@ -75,9 +82,12 @@ pub(crate) enum FetchOutcome {
 
 /// Merge-readiness data returned by the GraphQL query.
 ///
-/// All enum-valued fields (states, conclusions, statuses) are lower-cased
-/// here so downstream evaluation logic can share behavior with the REST path,
-/// which returns already-lowercase strings.
+/// Enum-valued fields are normalized to lowercase where appropriate so
+/// downstream evaluation logic can share behavior with the REST path, which
+/// returns already-lowercase strings. Review `state` is the exception — it
+/// intentionally preserves GitHub's SCREAMING_SNAKE_CASE to match the REST
+/// `ReviewApiResponse.state` format that the shared `evaluate_reviews`
+/// function compares against.
 #[derive(Debug)]
 pub(crate) struct MergeReadinessData {
     // head_sha and labels are fetched by the query (per #727 acceptance
@@ -220,7 +230,16 @@ fn parse_response(resp: GqlResponse) -> Result<MergeReadinessData> {
         _ => None, // UNKNOWN or anything unexpected
     };
 
-    let author_login = pr.author.map(|a| a.login).unwrap_or_default();
+    // Null authors (ghost/deleted users) must never match each other via
+    // empty-string equality, or the self-review exception in
+    // `evaluate_reviews` would fire for a ghost-authored PR with a
+    // ghost-authored review. Use distinct sentinels containing `<`, which is
+    // invalid in a GitHub login, so collisions with real users or between
+    // sentinels are impossible.
+    let author_login = pr
+        .author
+        .map(|a| a.login)
+        .unwrap_or_else(|| GHOST_PR_AUTHOR.to_string());
 
     let mut has_more_pages =
         pr.reviews.page_info.has_next_page || pr.labels.page_info.has_next_page;
@@ -233,9 +252,13 @@ fn parse_response(resp: GqlResponse) -> Result<MergeReadinessData> {
         .reviews
         .nodes
         .into_iter()
-        .map(|r| ReviewInfo {
+        .enumerate()
+        .map(|(idx, r)| ReviewInfo {
             state: r.state,
-            author_login: r.author.map(|a| a.login).unwrap_or_default(),
+            author_login: r
+                .author
+                .map(|a| a.login)
+                .unwrap_or_else(|| format!("{GHOST_REVIEW_AUTHOR_PREFIX}{idx}>")),
         })
         .collect();
 
@@ -556,8 +579,33 @@ mod tests {
             "commits": {"nodes": []}
         }}}}"#;
         let data = parse(json).unwrap();
-        assert_eq!(data.author_login, "");
-        assert_eq!(data.reviews[0].author_login, "");
+        // Ghost authors get distinct sentinels, so the self-review exception
+        // can't accidentally fire for ghost-authored PR + ghost reviewer.
+        assert_eq!(data.author_login, GHOST_PR_AUTHOR);
+        assert_eq!(data.reviews[0].author_login, "<ghost-review-author-0>");
+        assert_ne!(data.author_login, data.reviews[0].author_login);
+    }
+
+    #[test]
+    fn ghost_pr_author_does_not_match_ghost_reviewer() {
+        // Regression test for #855 inline comment: null author logins must
+        // never allow the self-review exception to pass.
+        let json = r#"{"data":{"repository":{"pullRequest":{
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "headRefOid": "abc",
+            "author": null,
+            "labels": {"nodes": []},
+            "reviews": {"nodes": [
+              {"state":"COMMENTED","author": null},
+              {"state":"COMMENTED","author": null}
+            ], "pageInfo":{"hasNextPage":false}},
+            "commits": {"nodes": []}
+        }}}}"#;
+        let data = parse(json).unwrap();
+        assert_ne!(data.author_login, data.reviews[0].author_login);
+        assert_ne!(data.author_login, data.reviews[1].author_login);
+        assert_ne!(data.reviews[0].author_login, data.reviews[1].author_login);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod display_utils;
 mod file_lock;
 mod git;
 mod github;
+mod graphql;
 mod labels;
 mod log_viewer;
 mod mcp;

--- a/src/merge_readiness.rs
+++ b/src/merge_readiness.rs
@@ -475,7 +475,15 @@ fn evaluate_graphql_data(data: &graphql::MergeReadinessData) -> MergeReadiness {
         })
         .collect();
 
-    let legacy_statuses_ok = data.status_contexts.iter().all(|sc| sc.state == "success");
+    // Prefer the rollup's top-level aggregate state when available: it is not
+    // paginated, so it remains accurate even when `contexts` exceeds our page
+    // size. Fall back to per-StatusContext aggregation (matching the REST
+    // `evaluate_combined_status` behavior of treating zero legacy statuses as
+    // passing) when the rollup is null (no CI wired up on the head commit).
+    let legacy_statuses_ok = match data.rollup_state.as_deref() {
+        Some(state) => state == "success",
+        None => data.status_contexts.iter().all(|sc| sc.state == "success"),
+    };
 
     let ci_passing = evaluate_ci(&check_runs) && legacy_statuses_ok;
     let review_approved = evaluate_reviews(&reviews, &data.author_login);
@@ -1379,6 +1387,7 @@ mod tests {
                     state: state.into(),
                 })
                 .collect(),
+            rollup_state: None,
             labels: vec![],
             has_more_pages: false,
         }
@@ -1462,6 +1471,55 @@ mod tests {
         );
         let mr = evaluate_graphql_data(&data);
         assert!(mr.is_ready());
+    }
+
+    #[test]
+    fn test_graphql_evaluate_rollup_state_success_takes_precedence() {
+        // Rollup state is authoritative when present (not paginated), so a
+        // missing StatusContext (e.g. >100 contexts) can't cause a false pass.
+        let mut data = gql_data(
+            false,
+            Some(true),
+            "bot",
+            vec![("APPROVED", "alice")],
+            vec![(Some("completed"), Some("success"))],
+            vec![], // no per-context statuses visible
+        );
+        data.rollup_state = Some("success".into());
+        let mr = evaluate_graphql_data(&data);
+        assert!(mr.is_ready());
+    }
+
+    #[test]
+    fn test_graphql_evaluate_rollup_state_failure_blocks() {
+        // Rollup state reports failure even though visible contexts all pass
+        // (simulates a failing context not returned in the current page).
+        let mut data = gql_data(
+            false,
+            Some(true),
+            "bot",
+            vec![("APPROVED", "alice")],
+            vec![(Some("completed"), Some("success"))],
+            vec!["success"],
+        );
+        data.rollup_state = Some("failure".into());
+        let mr = evaluate_graphql_data(&data);
+        assert!(!mr.ci_passing);
+    }
+
+    #[test]
+    fn test_graphql_evaluate_rollup_state_pending_blocks() {
+        let mut data = gql_data(
+            false,
+            Some(true),
+            "bot",
+            vec![("APPROVED", "alice")],
+            vec![(Some("completed"), Some("success"))],
+            vec![],
+        );
+        data.rollup_state = Some("pending".into());
+        let mr = evaluate_graphql_data(&data);
+        assert!(!mr.ci_passing);
     }
 
     #[test]

--- a/src/merge_readiness.rs
+++ b/src/merge_readiness.rs
@@ -12,6 +12,7 @@
 use crate::github;
 use crate::github::ReviewUser;
 use crate::github::DEFAULT_MAX_RETRIES;
+use crate::graphql;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::fmt;
@@ -111,7 +112,49 @@ pub(crate) struct PreFetchedCheckRun {
 ///
 /// This is a pure query function — it reads GitHub state and returns a
 /// deterministic result. Same API state always produces the same output.
+///
+/// Prefers a single GraphQL query that bundles PR metadata, reviews, check
+/// runs, legacy status contexts, and labels into one round-trip. Falls back
+/// to the multi-call REST path when GraphQL is unavailable (e.g., disabled
+/// on GHES) or when paginated sub-collections overflow the query limits.
 pub(crate) async fn check_merge_readiness(
+    host: &str,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+) -> Result<MergeReadiness> {
+    match graphql::fetch_pr_merge_data(host, owner, repo, pr_number).await {
+        Ok(graphql::FetchOutcome::Available(data)) if !data.has_more_pages => {
+            return Ok(evaluate_graphql_data(&data));
+        }
+        Ok(graphql::FetchOutcome::Available(_)) => {
+            log::info!(
+                "GraphQL result for {}/{} PR #{} has additional pages; falling back to REST for completeness",
+                owner,
+                repo,
+                pr_number
+            );
+        }
+        Ok(graphql::FetchOutcome::Unavailable) => {
+            // is_graphql_unavailable already logged at info level
+        }
+        Err(e) => {
+            log::warn!(
+                "GraphQL merge-readiness fetch failed for {}/{} PR #{}: {:#}. Falling back to REST.",
+                owner,
+                repo,
+                pr_number,
+                e
+            );
+        }
+    }
+
+    check_merge_readiness_rest(host, owner, repo, pr_number).await
+}
+
+/// REST-based merge readiness check. Used as a fallback when GraphQL is
+/// unavailable.
+async fn check_merge_readiness_rest(
     host: &str,
     owner: &str,
     repo: &str,
@@ -394,6 +437,56 @@ async fn get_combined_status(
         serde_json::from_slice(&output.stdout).context("Failed to parse combined status JSON")?;
 
     Ok(status)
+}
+
+/// Evaluate merge readiness from a fully-populated GraphQL response.
+///
+/// Mirrors the REST path's logic so results are identical for the same
+/// underlying GitHub state. Legacy status contexts from the rollup are
+/// treated like the combined-status API: the gate passes when every context
+/// is in the `success` state, or when there are no contexts at all.
+fn evaluate_graphql_data(data: &graphql::MergeReadinessData) -> MergeReadiness {
+    if data.draft {
+        return MergeReadiness {
+            not_draft: false,
+            ci_passing: false,
+            review_approved: false,
+            no_conflicts: false,
+        };
+    }
+
+    let check_runs: Vec<CheckRun> = data
+        .check_runs
+        .iter()
+        .map(|cr| CheckRun {
+            conclusion: cr.conclusion.clone(),
+            status: cr.status.clone(),
+        })
+        .collect();
+
+    let reviews: Vec<ReviewApiResponse> = data
+        .reviews
+        .iter()
+        .map(|r| ReviewApiResponse {
+            state: r.state.clone(),
+            user: ReviewUser {
+                login: r.author_login.clone(),
+            },
+        })
+        .collect();
+
+    let legacy_statuses_ok = data.status_contexts.iter().all(|sc| sc.state == "success");
+
+    let ci_passing = evaluate_ci(&check_runs) && legacy_statuses_ok;
+    let review_approved = evaluate_reviews(&reviews, &data.author_login);
+    let no_conflicts = data.mergeable == Some(true);
+
+    MergeReadiness {
+        not_draft: true,
+        ci_passing,
+        review_approved,
+        no_conflicts,
+    }
 }
 
 // --- Evaluation logic (pure functions, easy to test) ---
@@ -1249,6 +1342,140 @@ mod tests {
 
         let readiness = evaluate_from_prefetched(&data);
         assert!(!readiness.no_conflicts);
+    }
+
+    // --- GraphQL evaluation tests ---
+
+    fn gql_data(
+        draft: bool,
+        mergeable: Option<bool>,
+        author: &str,
+        reviews: Vec<(&str, &str)>,
+        check_runs: Vec<(Option<&str>, Option<&str>)>,
+        status_contexts: Vec<&str>,
+    ) -> graphql::MergeReadinessData {
+        graphql::MergeReadinessData {
+            head_sha: "sha".into(),
+            draft,
+            mergeable,
+            author_login: author.into(),
+            reviews: reviews
+                .into_iter()
+                .map(|(state, login)| graphql::ReviewInfo {
+                    state: state.into(),
+                    author_login: login.into(),
+                })
+                .collect(),
+            check_runs: check_runs
+                .into_iter()
+                .map(|(status, conclusion)| graphql::CheckRunInfo {
+                    status: status.map(Into::into),
+                    conclusion: conclusion.map(Into::into),
+                })
+                .collect(),
+            status_contexts: status_contexts
+                .into_iter()
+                .map(|state| graphql::StatusContextInfo {
+                    state: state.into(),
+                })
+                .collect(),
+            labels: vec![],
+            has_more_pages: false,
+        }
+    }
+
+    #[test]
+    fn test_graphql_evaluate_all_passing() {
+        let data = gql_data(
+            false,
+            Some(true),
+            "bot",
+            vec![("APPROVED", "alice")],
+            vec![(Some("completed"), Some("success"))],
+            vec!["success"],
+        );
+        let mr = evaluate_graphql_data(&data);
+        assert!(mr.is_ready());
+    }
+
+    #[test]
+    fn test_graphql_evaluate_draft_bails_out() {
+        let data = gql_data(true, Some(true), "bot", vec![], vec![], vec![]);
+        let mr = evaluate_graphql_data(&data);
+        assert!(!mr.not_draft);
+        assert!(!mr.is_ready());
+    }
+
+    #[test]
+    fn test_graphql_evaluate_legacy_status_failure_blocks() {
+        let data = gql_data(
+            false,
+            Some(true),
+            "bot",
+            vec![("APPROVED", "alice")],
+            vec![], // no modern check runs
+            vec!["success", "pending"],
+        );
+        let mr = evaluate_graphql_data(&data);
+        assert!(!mr.ci_passing);
+    }
+
+    #[test]
+    fn test_graphql_evaluate_no_legacy_statuses_ok() {
+        // Repos using only Check Runs emit an empty status contexts list;
+        // that should not block readiness.
+        let data = gql_data(
+            false,
+            Some(true),
+            "bot",
+            vec![("APPROVED", "alice")],
+            vec![(Some("completed"), Some("success"))],
+            vec![],
+        );
+        let mr = evaluate_graphql_data(&data);
+        assert!(mr.is_ready());
+    }
+
+    #[test]
+    fn test_graphql_evaluate_unknown_mergeable_blocks() {
+        let data = gql_data(
+            false,
+            None,
+            "bot",
+            vec![("APPROVED", "alice")],
+            vec![(Some("completed"), Some("success"))],
+            vec![],
+        );
+        let mr = evaluate_graphql_data(&data);
+        assert!(!mr.no_conflicts);
+    }
+
+    #[test]
+    fn test_graphql_evaluate_self_review_gate() {
+        let data = gql_data(
+            false,
+            Some(true),
+            "minion-bot",
+            vec![("COMMENTED", "minion-bot")],
+            vec![(Some("completed"), Some("success"))],
+            vec![],
+        );
+        let mr = evaluate_graphql_data(&data);
+        assert!(mr.is_ready());
+    }
+
+    #[test]
+    fn test_graphql_evaluate_changes_requested_blocks() {
+        let data = gql_data(
+            false,
+            Some(true),
+            "bot",
+            vec![("CHANGES_REQUESTED", "alice")],
+            vec![(Some("completed"), Some("success"))],
+            vec!["success"],
+        );
+        let mr = evaluate_graphql_data(&data);
+        assert!(!mr.review_approved);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Added `src/graphql.rs` that fetches PR state, reviews, check runs, the status-check rollup (both top-level `state` and individual contexts), and labels in a single `gh api graphql` call.
- `check_merge_readiness` now tries GraphQL first and falls back to the existing REST path when GraphQL is unavailable (404/403/401 on GHES), when the fetch errors, or when paginated sub-connections overflow the query limits.
- Legacy-status gate uses the rollup's top-level aggregate `state` when present, which is not paginated — so a failing context beyond the first 100 can no longer cause a false pass. Falls back to per-`StatusContext` aggregation only when the rollup is null.
- REST fallback is kept intact; evaluation helpers (`evaluate_ci`, `evaluate_reviews`) are shared between paths so the two produce identical `MergeReadiness` for the same GitHub state.

## Test plan
- `just check` (format + clippy + nextest + build): 1292 tests pass, 10 skipped, no warnings.
- New unit tests exercise:
  - GraphQL response parsing: typical success, `CONFLICTING` / `UNKNOWN` mergeable, draft PRs, null rollup, null author, pagination-overflow detection on both reviews and rollup contexts, unknown context typename, surfaced GraphQL errors, and `is_graphql_unavailable` heuristics (404/403/401, "not supported" messaging, negative cases).
  - Evaluation parity in `merge_readiness`: all-passing, draft bail-out, legacy-status failure blocking, no-legacy-statuses-OK, unknown-mergeable blocking, self-review gate, `CHANGES_REQUESTED` blocking, and rollup-state precedence (success / failure / pending).

## Notes
- `MergeReadinessData.head_sha` and `MergeReadinessData.labels` are parsed from the query per the issue's acceptance criteria but not yet consumed. They are marked `#[allow(dead_code)]` with a note so a follow-up can reuse the same query to also replace the separate PR-details and labels REST calls in `pr_monitor.rs`.
- Review states are intentionally kept in GraphQL's SCREAMING_SNAKE_CASE to match the existing REST `ReviewApiResponse.state` format that the shared `evaluate_reviews` function compares against. A comment in `graphql.rs` documents the intentional mismatch.
- `check_merge_readiness_with_data` (the prefetched poll-cycle path) is unchanged — it was already the hot path for `gru lab` and only made one extra REST call (combined status). Migrating it to GraphQL would require plumbing GraphQL through `poll_once()` and is out of scope for this issue.

Fixes #727

<sub>🤖 M1hv</sub>