### PR TITLE
Fixes #793: handle_new_reviews hardcodes github.com — GHES compatibility gap

### DIFF
--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -1063,16 +1063,16 @@ async fn handle_failed_checks(
             }
             println!("⚠️  CI auto-fix escalated to human after max attempts");
             println!(
-                "   Review the checks at: https://github.com/{}/{}/pull/{}/checks",
-                ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
+                "   Review the checks at: https://{}/{}/{}/pull/{}/checks",
+                ctx.issue_ctx.host, ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
             );
             println!("🔄 Continuing to monitor PR for other events...\n");
         }
         Err(e) => {
             println!("⚠️  CI auto-fix error: {}", e);
             println!(
-                "   Review the checks at: https://github.com/{}/{}/pull/{}/checks",
-                ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
+                "   Review the checks at: https://{}/{}/{}/pull/{}/checks",
+                ctx.issue_ctx.host, ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
             );
             println!("🔄 Will retry CI auto-fix on subsequent monitoring cycles...\n");
         }
@@ -1181,8 +1181,8 @@ fn handle_timeout(state: &MonitorLoopState, ctx: &MonitorContext<'_>) -> LoopAct
     let display = format_duration(state.monitor_start.elapsed().as_secs());
     println!("⏰ PR monitoring timed out after {}", display);
     println!(
-        "   PR is still open: https://github.com/{}/{}/pull/{}",
-        ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
+        "   PR is still open: https://{}/{}/{}/pull/{}",
+        ctx.issue_ctx.host, ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
     );
     LoopAction::Break
 }
@@ -1190,8 +1190,8 @@ fn handle_timeout(state: &MonitorLoopState, ctx: &MonitorContext<'_>) -> LoopAct
 fn handle_interrupted(ctx: &MonitorContext<'_>) -> LoopAction {
     println!("\n⚠️  Monitoring interrupted by user");
     println!(
-        "   PR is still open: https://github.com/{}/{}/pull/{}",
-        ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
+        "   PR is still open: https://{}/{}/{}/pull/{}",
+        ctx.issue_ctx.host, ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
     );
     LoopAction::Break
 }
@@ -1250,7 +1250,8 @@ async fn handle_monitor_error(
             error
         );
         log::warn!(
-            "   You can monitor manually at: https://github.com/{}/{}/pull/{}",
+            "   You can monitor manually at: https://{}/{}/{}/pull/{}",
+            ctx.issue_ctx.host,
             ctx.issue_ctx.owner,
             ctx.issue_ctx.repo,
             ctx.pr_number
@@ -1554,8 +1555,8 @@ pub(crate) async fn monitor_pr_lifecycle(
             let display = format_duration(state.monitor_start.elapsed().as_secs());
             println!("⏰ PR monitoring timed out after {}", display);
             println!(
-                "   PR is still open: https://github.com/{}/{}/pull/{}",
-                ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
+                "   PR is still open: https://{}/{}/{}/pull/{}",
+                ctx.issue_ctx.host, ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
             );
             break;
         }


### PR DESCRIPTION
## Summary
- Audit `src/commands/fix/monitor.rs` for hardcoded `https://github.com/...` URLs in log/print output
- Replace 5 remaining hardcodings with `https://{ctx.issue_ctx.host}/...` so URLs render correctly on GitHub Enterprise Server
- The `handle_new_reviews` site called out in the issue was already fixed; this change covers the rest

Sites updated:
- `handle_failed_checks` — both "Review the checks at" URLs
- `handle_timeout` and `handle_interrupted` — "PR is still open" URLs
- `handle_monitor_error` — "monitor manually at" URL
- `monitor_pr_loop` outer timeout guard — "PR is still open" URL

The only remaining `github.com` literal is in a test fixture (`IssueContext` default host), which is intentional.

## Test plan
- `just check` — format, clippy (`-D warnings`), tests (1323 passed), build — all green

## Notes
- `ctx.issue_ctx.host` is a plain `String` populated from the canonical host registry wherever `IssueContext` is constructed, so there's no risk of an empty host in the URL.
- Follow-up (optional, not in scope): add a test asserting the printed URL contains the configured host rather than a literal `github.com`, so a future re-hardcoding would be caught at the test layer.

Fixes #793

<sub>🤖 M1i1</sub>