### PR TITLE
Fixes #859: Minion pushes to invented branch name instead of gru-assigned branch

### DIFF
--- a/src/prompt_loader.rs
+++ b/src/prompt_loader.rs
@@ -99,7 +99,7 @@ Note: if the repo uses squash merges, the pre-merge SHA may become unreachable a
 When your implementation is complete and ready for human review:
 
 1. **Commit your implementation changes** with a descriptive commit message prefixed with your Minion ID, e.g. `[{{ minion_id }}] Fix null pointer in parser`
-2. **Push the branch** to the remote repository
+2. **Push the current branch** — run `git push -u origin HEAD`. Do NOT rename, create, or switch branches; Gru set up the branch for you and tracks it by name.
 3. Write `PR_DESCRIPTION.md` to `{{ minion_dir }}/PR_DESCRIPTION.md` with this format:
    ```markdown
    ## Summary


### PR DESCRIPTION
## Summary
- Replaced the ambiguous "Push the branch" step in the built-in `do` prompt with explicit `git push -u origin HEAD` instruction and a prohibition on renaming, creating, or switching branches
- Prevents agents from inventing their own branch names (e.g. based on a Jira key) and pushing to a branch Gru doesn't track, which currently breaks `gru resume` with "Branch was not pushed"

## Test plan
- `just fmt-check` — passed
- `just lint` — passed
- `just test` — 1322 passed, 10 skipped

## Notes
- Only the built-in prompt in `src/prompt_loader.rs` was changed; the `.claude/commands/do.md` slash command carries the same text but is intended to be edited separately if desired
- Optional follow-up (out of scope): detect HEAD on a non-gru branch with commits in `handle_pr_creation` and either open the PR from the agent's branch or print an error naming both branches

Fixes #859

<sub>🤖 M1is</sub>