### PR TITLE
Fixes #862: Duplicate review replies from concurrent gru do + gru resume on same Minion

### DIFF
--- a/src/commands/fix/agent.rs
+++ b/src/commands/fix/agent.rs
@@ -2,7 +2,7 @@ use super::helpers::try_post_progress_comment;
 use super::types::{AgentResult, IssueContext, WorktreeContext};
 use crate::agent::{AgentBackend, AgentEvent};
 use crate::agent_runner::{run_agent_with_stream_monitoring, EXIT_CODE_SIGNAL_TERMINATED};
-use crate::minion_registry::{with_registry, MinionMode, MinionRegistry};
+use crate::minion_registry::{get_process_start_time, with_registry, MinionMode, MinionRegistry};
 use crate::progress::{ProgressConfig, ProgressDisplay};
 use crate::progress_comments::{MinionPhase, ProgressCommentTracker};
 use crate::prompt_loader;
@@ -250,16 +250,29 @@ async fn run_agent_session_inner(
     )
     .await;
 
-    // Best-effort cleanup: clear PID, set mode to Stopped, and save token usage.
-    // Token usage is persisted regardless of exit status (Ok with non-zero exit) because
-    // cost data is valuable even for failed tasks. Only stream-level errors (timeout, stuck)
-    // result in Err, in which case partial usage is not saved.
+    // The agent child process has exited, but the parent worker process
+    // continues into PR creation and monitoring. Transfer ownership back to
+    // the current (parent) process PID and keep mode=Autonomous so that
+    // concurrent `gru resume`/`gru attach` attempts are rejected by
+    // `check_and_claim_session` (see issue #862: without this, the registry
+    // reports the minion as Stopped while the worker is still alive, and a
+    // second process can claim it and spawn a duplicate agent against the
+    // same session, producing duplicate review replies).
+    //
+    // Token usage is persisted regardless of exit status (Ok with non-zero
+    // exit) because cost data is valuable even for failed tasks. Only
+    // stream-level errors (timeout, stuck) result in Err, in which case
+    // partial usage is not saved.
     let token_usage = run_result.as_ref().ok().map(|r| r.token_usage.clone());
     let exit_minion_id = wt_ctx.minion_id.clone();
+    let parent_pid = std::process::id();
+    let parent_start_time = get_process_start_time(parent_pid);
     let _ = with_registry(move |registry| {
         registry.update(&exit_minion_id, |info| {
-            info.clear_pid();
-            info.mode = MinionMode::Stopped;
+            info.pid = Some(parent_pid);
+            info.pid_start_time = parent_start_time;
+            info.mode = MinionMode::Autonomous;
+            info.last_activity = chrono::Utc::now();
             if let Some(usage) = token_usage {
                 info.token_usage = Some(usage);
             }

--- a/src/commands/fix/agent.rs
+++ b/src/commands/fix/agent.rs
@@ -271,7 +271,8 @@ async fn run_agent_session_inner(
     // PR creation and monitoring after the agent child exits.
     let parent_pid = std::process::id();
     let parent_start_time = get_process_start_time(parent_pid);
-    let _ = with_registry(move |registry| {
+    let log_minion_id = wt_ctx.minion_id.clone();
+    if let Err(e) = with_registry(move |registry| {
         registry.update(&exit_minion_id, |info| {
             info.pid = Some(parent_pid);
             info.pid_start_time = parent_start_time;
@@ -282,7 +283,21 @@ async fn run_agent_session_inner(
             }
         })
     })
-    .await;
+    .await
+    {
+        // A failure here leaves the registry pointing at the now-dead agent
+        // child PID. `session_claim` would treat that as a stale entry and
+        // allow a concurrent `gru resume`/`gru attach` to claim the minion —
+        // the exact failure mode this block exists to prevent (issue #862).
+        // Log loudly so operators can correlate a duplicate-agent incident
+        // with the registry write that failed.
+        log::warn!(
+            "Failed to transfer registry ownership to worker PID for {}: {:#}. \
+             Registry may briefly allow concurrent claim.",
+            log_minion_id,
+            e
+        );
+    }
 
     let agent_run = run_result?;
 

--- a/src/commands/fix/agent.rs
+++ b/src/commands/fix/agent.rs
@@ -265,6 +265,10 @@ async fn run_agent_session_inner(
     // partial usage is not saved.
     let token_usage = run_result.as_ref().ok().map(|r| r.token_usage.clone());
     let exit_minion_id = wt_ctx.minion_id.clone();
+    // `run_agent_session_inner` is only invoked from within a worker process
+    // (via `run_agent_phase` in worker.rs / resume.rs), so `process::id()`
+    // here is always the worker PID — the process that owns the minion for
+    // PR creation and monitoring after the agent child exits.
     let parent_pid = std::process::id();
     let parent_start_time = get_process_start_time(parent_pid);
     let _ = with_registry(move |registry| {

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -93,6 +93,31 @@ async fn check_resumption_preconditions(
         }
     };
 
+    // Record our own PID as the live owner of this minion so concurrent
+    // `gru resume`/`gru attach` attempts are rejected as AlreadyRunning.
+    // Without this, `check_and_claim_session` only sets mode=Autonomous but
+    // leaves pid=None; a second process checking the registry would treat
+    // the entry as stale (non-Stopped mode with no PID) and reset + claim
+    // it, producing two live resumes against the same session (issue #862).
+    let parent_pid = std::process::id();
+    let parent_start_time = crate::minion_registry::get_process_start_time(parent_pid);
+    let mid = minion.minion_id.clone();
+    if let Err(e) = with_registry(move |reg| {
+        reg.update(&mid, |i| {
+            i.pid = Some(parent_pid);
+            i.pid_start_time = parent_start_time;
+            i.last_activity = Utc::now();
+        })
+    })
+    .await
+    {
+        log::warn!(
+            "Failed to record resume process PID for {}: {:#}",
+            minion.minion_id,
+            e
+        );
+    }
+
     // Parse owner/repo from "owner/repo" format
     let (owner, repo_name) = info
         .repo


### PR DESCRIPTION
## Summary

Fixes #862. When a `gru do` worker finished the fix-phase agent and entered PR monitoring, the registry was incorrectly set to `pid=None, mode=Stopped` even though the worker process was still alive. A concurrent `gru resume` then passed `check_and_claim_session`, spawned a second agent against the same session, and both workers independently posted replies to the same Copilot review comments (verso#292 saw three threads each receive two near-identical replies).

- `src/commands/fix/agent.rs`: after the agent child exits in `run_agent_session_inner`, record the parent worker's own PID and keep `mode=Autonomous` (instead of clearing to `Stopped`). Token usage is still persisted regardless of exit status.
- `src/commands/resume.rs`: right after `check_and_claim_session` sets `mode=Autonomous`, record the resume process's own PID. Without this, the registry briefly has `mode=Autonomous` with `pid=None`, which `session_claim` would treat as a stale entry and allow another process to claim.

With these changes, concurrent `gru resume`/`gru attach` attempts against a live worker are correctly rejected by `check_and_claim_session` with `SessionClaimError::AlreadyRunning` through the entire PR-monitoring lifetime.

## Test plan

- `just check` — 1322 tests pass, clippy clean, formatter clean.
- Existing `session_claim` tests already cover the invariant that a minion with `mode=Autonomous` and a live PID rejects concurrent claims; the fix relies on that invariant by keeping the registry in that state instead of resetting it.

## Notes

- Scope was kept to the primary fix described in the issue. The issue also suggested two defence-in-depth measures (per-minion advisory lockfile, and idempotency check before posting review replies). Those are not included here — they can be layered on in follow-up issues once the registry-level race is closed.
- Three duplicate review replies on verso#292 still need manual cleanup per the issue body (`gh api -X DELETE .../pulls/comments/{3125030692,3125031419,3125032472}`).
- `run_agent_session_inner` is only invoked from worker processes today (`fix/worker.rs` and `resume.rs`), so `std::process::id()` reliably refers to the worker PID. A comment was added to make that invariant explicit for future refactors.

<sub>🤖 M1iy</sub>