### PR TITLE
Fixes #867: Idempotency check before posting review replies

### DIFF
--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -842,6 +842,56 @@ async fn handle_ready_to_merge(
     LoopAction::Continue
 }
 
+/// Apply the #867 idempotency filter to review feedback before invoking the
+/// agent. Fetches the bot user's login and every inline comment on the PR,
+/// then drops any thread where a bot reply already exists. On failure, logs
+/// a warning and returns the feedback unchanged so the normal path proceeds.
+async fn apply_bot_reply_idempotency_filter(
+    ctx: &MonitorContext<'_>,
+    feedback: pr_monitor::ReviewFeedback,
+) -> pr_monitor::ReviewFeedback {
+    let bot_user = match github::get_authenticated_user(&ctx.issue_ctx.host).await {
+        Ok(u) => u,
+        Err(e) => {
+            log::warn!(
+                "⚠️  Could not resolve bot user for review-reply idempotency check: {:#}",
+                e
+            );
+            return feedback;
+        }
+    };
+
+    let already_replied = match pr_monitor::fetch_threads_with_bot_replies(
+        &ctx.issue_ctx.host,
+        &ctx.issue_ctx.owner,
+        &ctx.issue_ctx.repo,
+        ctx.pr_number,
+        &bot_user,
+    )
+    .await
+    {
+        Ok(set) => set,
+        Err(e) => {
+            log::warn!(
+                "⚠️  Review-reply idempotency check failed (proceeding): {:#}",
+                e
+            );
+            return feedback;
+        }
+    };
+
+    let original_count = feedback.comments.len();
+    let filtered = pr_monitor::filter_feedback_against_replied_threads(feedback, &already_replied);
+    let skipped = original_count.saturating_sub(filtered.comments.len());
+    if skipped > 0 {
+        println!(
+            "🛡️  Skipping {} review thread(s) already replied to by @{}",
+            skipped, bot_user
+        );
+    }
+    filtered
+}
+
 async fn handle_new_reviews(
     state: &mut MonitorLoopState,
     ctx: &MonitorContext<'_>,
@@ -866,6 +916,20 @@ async fn handle_new_reviews(
             ctx.issue_ctx.host, ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
         );
         return LoopAction::Break;
+    }
+
+    // Best-effort idempotency check (#867): drop inline comments on threads
+    // where the bot user has already posted a reply. Belt on top of the
+    // process-level lockfile + registry guards from #862/#863. On any
+    // API failure we proceed with the unfiltered feedback.
+    let feedback = apply_bot_reply_idempotency_filter(ctx, feedback).await;
+
+    if feedback.is_empty() {
+        println!("✅ All review threads already have a bot reply; nothing to address");
+        state.review_baseline = Some(check_time);
+        save_review_check_time(&ctx.wt_ctx.minion_id, check_time).await;
+        reset_attempt_count(&ctx.wt_ctx.minion_id).await;
+        return LoopAction::Continue;
     }
 
     let review_prompt = pr_monitor::format_review_prompt(

--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -850,6 +850,13 @@ async fn apply_bot_reply_idempotency_filter(
     ctx: &MonitorContext<'_>,
     feedback: pr_monitor::ReviewFeedback,
 ) -> pr_monitor::ReviewFeedback {
+    // Short-circuit: if there are no inline comments, the per-thread filter
+    // has nothing to do. Skip the `gh api user` + `pulls/{n}/comments` round
+    // trips on review-body-only cycles.
+    if feedback.comments.is_empty() {
+        return feedback;
+    }
+
     let bot_user = match github::get_authenticated_user(&ctx.issue_ctx.host).await {
         Ok(u) => u,
         Err(e) => {
@@ -892,17 +899,82 @@ async fn apply_bot_reply_idempotency_filter(
     filtered
 }
 
+/// Decision taken after the idempotency filter runs.
+///
+/// Extracted so the branch taken by `handle_new_reviews` is unit-testable
+/// without spinning up the monitor loop.
+#[derive(Debug, PartialEq, Eq)]
+enum PostFilterAction {
+    /// Feedback is empty with no fetch failures — advance the baseline and
+    /// skip the agent invocation.
+    SkipAdvance,
+    /// Feedback is empty but some upstream fetches failed — hold the
+    /// baseline and retry on the next poll cycle.
+    SkipHold,
+    /// Feedback still contains items to address — invoke the agent.
+    Invoke,
+}
+
+fn decide_post_filter_action(feedback: &pr_monitor::ReviewFeedback) -> PostFilterAction {
+    if !feedback.is_empty() {
+        return PostFilterAction::Invoke;
+    }
+    if feedback.had_fetch_failures {
+        PostFilterAction::SkipHold
+    } else {
+        PostFilterAction::SkipAdvance
+    }
+}
+
 async fn handle_new_reviews(
     state: &mut MonitorLoopState,
     ctx: &MonitorContext<'_>,
     feedback: pr_monitor::ReviewFeedback,
     check_time: DateTime<Utc>,
 ) -> LoopAction {
-    state.review_round += 1;
     let count = feedback.comments.len() + feedback.bodies.len();
     println!(
-        "💬 Detected {} new review feedback item(s) on PR #{} (review round {}/{})",
-        count, ctx.pr_number, state.review_round, MAX_REVIEW_ROUNDS
+        "💬 Detected {} new review feedback item(s) on PR #{}",
+        count, ctx.pr_number
+    );
+
+    // Best-effort idempotency check (#867): drop inline comments on threads
+    // where the bot user has already posted a reply. Belt on top of the
+    // process-level lockfile + registry guards from #862/#863. On any
+    // API failure we proceed with the unfiltered feedback.
+    let feedback = apply_bot_reply_idempotency_filter(ctx, feedback).await;
+
+    match decide_post_filter_action(&feedback) {
+        PostFilterAction::SkipHold => {
+            // Some reviews failed to fetch upstream. The comments we did
+            // fetch are all already-replied, but the unfetched ones may
+            // still contain unhandled threads — leave the baseline alone so
+            // poll_once retries on the next cycle. review_round has not
+            // been incremented, so repeated retries cannot burn the round
+            // budget.
+            log::warn!(
+                "⚠️  All fetched review threads already have bot replies, but some \
+                 review fetches failed — will retry on the next poll cycle"
+            );
+            return LoopAction::Continue;
+        }
+        PostFilterAction::SkipAdvance => {
+            println!("✅ All review threads already have a bot reply; nothing to address");
+            state.review_baseline = Some(check_time);
+            save_review_check_time(&ctx.wt_ctx.minion_id, check_time).await;
+            reset_attempt_count(&ctx.wt_ctx.minion_id).await;
+            return LoopAction::Continue;
+        }
+        PostFilterAction::Invoke => {}
+    }
+
+    // Count this against MAX_REVIEW_ROUNDS only when we are actually going
+    // to invoke the agent — filtered-to-empty batches and fetch-failure
+    // retries must not burn the budget.
+    state.review_round += 1;
+    println!(
+        "🔄 Review round {}/{}",
+        state.review_round, MAX_REVIEW_ROUNDS
     );
 
     if state.review_round > MAX_REVIEW_ROUNDS {
@@ -916,31 +988,6 @@ async fn handle_new_reviews(
             ctx.issue_ctx.host, ctx.issue_ctx.owner, ctx.issue_ctx.repo, ctx.pr_number
         );
         return LoopAction::Break;
-    }
-
-    // Best-effort idempotency check (#867): drop inline comments on threads
-    // where the bot user has already posted a reply. Belt on top of the
-    // process-level lockfile + registry guards from #862/#863. On any
-    // API failure we proceed with the unfiltered feedback.
-    let feedback = apply_bot_reply_idempotency_filter(ctx, feedback).await;
-
-    if feedback.is_empty() {
-        if feedback.had_fetch_failures {
-            // Some reviews failed to fetch upstream. The comments we did
-            // fetch are all already-replied, but the unfetched ones may
-            // still contain unhandled threads — leave the baseline alone
-            // so poll_once retries on the next cycle.
-            log::warn!(
-                "⚠️  All fetched review threads already have bot replies, but some \
-                 review fetches failed — will retry on the next poll cycle"
-            );
-            return LoopAction::Continue;
-        }
-        println!("✅ All review threads already have a bot reply; nothing to address");
-        state.review_baseline = Some(check_time);
-        save_review_check_time(&ctx.wt_ctx.minion_id, check_time).await;
-        reset_attempt_count(&ctx.wt_ctx.minion_id).await;
-        return LoopAction::Continue;
     }
 
     let review_prompt = pr_monitor::format_review_prompt(
@@ -2134,6 +2181,89 @@ mod tests {
         assert!(
             body.contains("type: monitoring-paused"),
             "comment must include YAML frontmatter type"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // decide_post_filter_action (#867)
+    //
+    // Exercises the handler's branch selection without spinning up the
+    // monitor loop: a synthetic "already replied" batch (empty feedback)
+    // must pick SkipAdvance so the agent is not invoked and the baseline
+    // can advance.
+    // ------------------------------------------------------------------
+
+    fn make_review_comment(id: u64) -> pr_monitor::ReviewComment {
+        pr_monitor::ReviewComment {
+            file: "src/main.rs".to_string(),
+            line: Some(1),
+            body: "x".to_string(),
+            reviewer: "alice".to_string(),
+            reviewer_display_name: "Alice".to_string(),
+            comment_id: id,
+        }
+    }
+
+    fn empty_feedback(had_fetch_failures: bool) -> pr_monitor::ReviewFeedback {
+        pr_monitor::ReviewFeedback {
+            comments: Vec::new(),
+            bodies: Vec::new(),
+            had_fetch_failures,
+        }
+    }
+
+    #[test]
+    fn test_decide_post_filter_action_skip_advance_when_clean_empty() {
+        // Synthetic "already replied" batch: every fetched thread was
+        // dropped by the idempotency filter and no fetches failed.
+        let feedback = empty_feedback(false);
+        assert_eq!(
+            decide_post_filter_action(&feedback),
+            PostFilterAction::SkipAdvance
+        );
+    }
+
+    #[test]
+    fn test_decide_post_filter_action_skip_hold_when_empty_with_fetch_failures() {
+        // Same as above, but some upstream fetches failed. Must hold the
+        // baseline so unfetched threads are retried on the next cycle.
+        let feedback = empty_feedback(true);
+        assert_eq!(
+            decide_post_filter_action(&feedback),
+            PostFilterAction::SkipHold
+        );
+    }
+
+    #[test]
+    fn test_decide_post_filter_action_invoke_when_comment_remains() {
+        let feedback = pr_monitor::ReviewFeedback {
+            comments: vec![make_review_comment(100)],
+            bodies: Vec::new(),
+            had_fetch_failures: false,
+        };
+        assert_eq!(
+            decide_post_filter_action(&feedback),
+            PostFilterAction::Invoke
+        );
+    }
+
+    #[test]
+    fn test_decide_post_filter_action_invoke_when_only_body_remains() {
+        // Review bodies are not filtered by the per-comment idempotency
+        // check, so a body-only feedback must still drive an invocation.
+        let feedback = pr_monitor::ReviewFeedback {
+            comments: Vec::new(),
+            bodies: vec![pr_monitor::ReviewBody {
+                body: "LGTM".to_string(),
+                reviewer: "alice".to_string(),
+                reviewer_display_name: "Alice".to_string(),
+                state: "COMMENTED".to_string(),
+            }],
+            had_fetch_failures: false,
+        };
+        assert_eq!(
+            decide_post_filter_action(&feedback),
+            PostFilterAction::Invoke
         );
     }
 }

--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -925,6 +925,17 @@ async fn handle_new_reviews(
     let feedback = apply_bot_reply_idempotency_filter(ctx, feedback).await;
 
     if feedback.is_empty() {
+        if feedback.had_fetch_failures {
+            // Some reviews failed to fetch upstream. The comments we did
+            // fetch are all already-replied, but the unfetched ones may
+            // still contain unhandled threads — leave the baseline alone
+            // so poll_once retries on the next cycle.
+            log::warn!(
+                "⚠️  All fetched review threads already have bot replies, but some \
+                 review fetches failed — will retry on the next poll cycle"
+            );
+            return LoopAction::Continue;
+        }
         println!("✅ All review threads already have a bot reply; nothing to address");
         state.review_baseline = Some(check_time);
         save_review_check_time(&ctx.wt_ctx.minion_id, check_time).await;

--- a/src/pr_monitor.rs
+++ b/src/pr_monitor.rs
@@ -1076,6 +1076,118 @@ fn identify_duplicate_minion_replies(
     duplicates
 }
 
+/// Fetch all inline review comments on a PR (paginated).
+///
+/// Uses the `repos/{owner}/{repo}/pulls/{n}/comments` endpoint which returns
+/// every inline review comment on the PR (including replies), not just those
+/// from a single review. `--paginate` without `--jq` concatenates raw JSON
+/// arrays across pages (`[...][...]`), which is not valid JSON, so pair with
+/// `--jq ".[]"` to stream one comment per line instead.
+async fn fetch_pr_inline_comments_raw(
+    host: &str,
+    owner: &str,
+    repo: &str,
+    pr_number: &str,
+) -> Result<Vec<ApiReviewComment>> {
+    let repo_full = github::repo_slug(owner, repo);
+    let endpoint = format!("repos/{repo_full}/pulls/{pr_number}/comments");
+    let output = gh_api_with_retry(
+        host,
+        &["api", "--paginate", &endpoint, "--jq", ".[]"],
+        DEFAULT_MAX_RETRIES,
+    )
+    .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "Failed to fetch inline comments on {repo_full} PR #{pr_number}: {}",
+            stderr
+        );
+    }
+
+    let stdout = std::str::from_utf8(&output.stdout)
+        .context("Failed to decode PR inline comments stdout as UTF-8")?;
+    let mut api_comments: Vec<ApiReviewComment> = Vec::new();
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let comment: ApiReviewComment =
+            serde_json::from_str(line).context("Failed to parse PR inline comment JSON line")?;
+        api_comments.push(comment);
+    }
+    Ok(api_comments)
+}
+
+/// Collect comment thread parent IDs that the bot user has already replied to.
+///
+/// For each inline comment authored by `bot_user` with a non-empty body that
+/// targets a parent via `in_reply_to_id`, add that parent ID to the returned
+/// set. Per #867 the check is content-agnostic: any non-empty bot reply is
+/// enough — no minion-ID signature match is required. This is broader than
+/// `filter_unanswered_comments` and guards against "same reply twice" variants
+/// (bad retry, split turn, mid-batch restart) that the process-level lockfile
+/// + registry guards from #862/#863 may miss.
+fn collect_threads_with_bot_replies(
+    api_comments: &[ApiReviewComment],
+    bot_user: &str,
+) -> std::collections::HashSet<u64> {
+    api_comments
+        .iter()
+        .filter_map(|c| {
+            if c.user.login == bot_user && !c.body.trim().is_empty() {
+                c.in_reply_to_id
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Remove review comments whose `comment_id` is in `already_replied` from
+/// `feedback.comments`. Review bodies are not filtered — the idempotency
+/// check is scoped per-comment, not per-review (#867).
+pub(crate) fn filter_feedback_against_replied_threads(
+    feedback: ReviewFeedback,
+    already_replied: &std::collections::HashSet<u64>,
+) -> ReviewFeedback {
+    let ReviewFeedback {
+        comments,
+        bodies,
+        had_fetch_failures,
+    } = feedback;
+    let filtered = comments
+        .into_iter()
+        .filter(|c| !already_replied.contains(&c.comment_id))
+        .collect();
+    ReviewFeedback {
+        comments: filtered,
+        bodies,
+        had_fetch_failures,
+    }
+}
+
+/// Fetch every inline comment on the PR and return the set of thread parent
+/// comment IDs where `bot_user` has already posted a non-empty reply.
+///
+/// Best-effort idempotency backstop for #867: callers use this to drop
+/// inline comments from review feedback before invoking the agent. On API
+/// failure the caller should log and proceed with the unfiltered feedback;
+/// the process-level lockfile + registry guards from #862/#863 remain in
+/// place.
+pub(crate) async fn fetch_threads_with_bot_replies(
+    host: &str,
+    owner: &str,
+    repo: &str,
+    pr_number: &str,
+    bot_user: &str,
+) -> Result<std::collections::HashSet<u64>> {
+    let api_comments = fetch_pr_inline_comments_raw(host, owner, repo, pr_number).await?;
+    Ok(collect_threads_with_bot_replies(&api_comments, bot_user))
+}
+
 /// Fetch all inline review comments on a PR and delete any duplicate replies
 /// authored by this Minion in the current review-response session.
 ///
@@ -1092,38 +1204,7 @@ pub(crate) async fn dedup_minion_inline_replies(
     since: DateTime<Utc>,
 ) -> Result<usize> {
     let repo_full = github::repo_slug(owner, repo);
-    let endpoint = format!("repos/{repo_full}/pulls/{pr_number}/comments");
-    // `--paginate` without `--jq` concatenates raw JSON arrays across pages
-    // (`[...][...]`), which is not valid JSON. Pair with `--jq ".[]"` to
-    // stream one comment per line instead, matching the pattern used by
-    // `get_check_runs` elsewhere in this file.
-    let output = gh_api_with_retry(
-        host,
-        &["api", "--paginate", &endpoint, "--jq", ".[]"],
-        DEFAULT_MAX_RETRIES,
-    )
-    .await?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!(
-            "Failed to fetch inline comments for dedup on {repo_full} PR #{pr_number}: {}",
-            stderr
-        );
-    }
-
-    let stdout = std::str::from_utf8(&output.stdout)
-        .context("Failed to decode PR inline comments stdout as UTF-8")?;
-    let mut api_comments: Vec<ApiReviewComment> = Vec::new();
-    for line in stdout.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let comment: ApiReviewComment = serde_json::from_str(line)
-            .context("Failed to parse PR inline comment JSON line for dedup")?;
-        api_comments.push(comment);
-    }
+    let api_comments = fetch_pr_inline_comments_raw(host, owner, repo, pr_number).await?;
 
     let duplicate_ids = identify_duplicate_minion_replies(&api_comments, minion_id, since);
 
@@ -2719,6 +2800,187 @@ mod tests {
         ];
         let dups = identify_duplicate_minion_replies(&comments, "M001", t("2024-06-15T11:00:00Z"));
         assert_eq!(dups, vec![5]);
+    }
+
+    // ========================================================================
+    // collect_threads_with_bot_replies / filter_feedback_against_replied_threads tests
+    // ========================================================================
+
+    fn make_api_comment_by(
+        id: u64,
+        body: &str,
+        in_reply_to_id: Option<u64>,
+        login: &str,
+    ) -> ApiReviewComment {
+        ApiReviewComment {
+            id,
+            path: "src/main.rs".to_string(),
+            line: Some(1),
+            body: body.to_string(),
+            user: User {
+                login: login.to_string(),
+            },
+            in_reply_to_id,
+            created_at: "2024-06-15T12:00:00Z".parse().unwrap(),
+        }
+    }
+
+    fn make_review_comment(comment_id: u64, body: &str) -> ReviewComment {
+        ReviewComment {
+            file: "src/main.rs".to_string(),
+            line: Some(1),
+            body: body.to_string(),
+            reviewer: "alice".to_string(),
+            reviewer_display_name: "Alice".to_string(),
+            comment_id,
+        }
+    }
+
+    #[test]
+    fn test_collect_threads_with_bot_replies_identifies_bot_reply() {
+        // Root comment by reviewer + bot reply on the same thread → thread
+        // parent ID returned.
+        let comments = vec![
+            make_api_comment_by(1, "Please fix this.", None, "alice"),
+            make_api_comment_by(2, "Fixed!", Some(1), "gru-bot"),
+        ];
+        let replied = collect_threads_with_bot_replies(&comments, "gru-bot");
+        assert_eq!(replied.len(), 1);
+        assert!(replied.contains(&1));
+    }
+
+    #[test]
+    fn test_collect_threads_with_bot_replies_empty_input() {
+        let replied = collect_threads_with_bot_replies(&[], "gru-bot");
+        assert!(replied.is_empty());
+    }
+
+    #[test]
+    fn test_collect_threads_with_bot_replies_ignores_non_bot_replies() {
+        // A reply authored by someone other than the bot must not count.
+        let comments = vec![
+            make_api_comment_by(1, "Please fix this.", None, "alice"),
+            make_api_comment_by(2, "Agreed", Some(1), "bob"),
+        ];
+        let replied = collect_threads_with_bot_replies(&comments, "gru-bot");
+        assert!(replied.is_empty());
+    }
+
+    #[test]
+    fn test_collect_threads_with_bot_replies_ignores_empty_body() {
+        // Per #867 a reply must have a non-empty body to count as handled.
+        let comments = vec![
+            make_api_comment_by(1, "Please fix this.", None, "alice"),
+            make_api_comment_by(2, "   ", Some(1), "gru-bot"),
+        ];
+        let replied = collect_threads_with_bot_replies(&comments, "gru-bot");
+        assert!(replied.is_empty());
+    }
+
+    #[test]
+    fn test_collect_threads_with_bot_replies_ignores_orphan_bot_comments() {
+        // A bot-authored comment without `in_reply_to_id` is a root-level
+        // comment, not a reply, and must not mark any thread as handled.
+        let comments = vec![make_api_comment_by(1, "FYI update", None, "gru-bot")];
+        let replied = collect_threads_with_bot_replies(&comments, "gru-bot");
+        assert!(replied.is_empty());
+    }
+
+    #[test]
+    fn test_collect_threads_with_bot_replies_content_agnostic() {
+        // Body content is not examined — any non-empty bot reply counts,
+        // regardless of whether it carries a Minion signature (#867).
+        let comments = vec![
+            make_api_comment_by(1, "Please fix this.", None, "alice"),
+            make_api_comment_by(2, "ack", Some(1), "gru-bot"),
+        ];
+        let replied = collect_threads_with_bot_replies(&comments, "gru-bot");
+        assert!(replied.contains(&1));
+    }
+
+    #[test]
+    fn test_collect_threads_with_bot_replies_multiple_threads() {
+        let comments = vec![
+            make_api_comment_by(1, "A", None, "alice"),
+            make_api_comment_by(10, "B", None, "alice"),
+            make_api_comment_by(20, "C", None, "alice"),
+            make_api_comment_by(2, "done", Some(1), "gru-bot"),
+            make_api_comment_by(11, "done", Some(10), "gru-bot"),
+            // No reply to 20.
+        ];
+        let replied = collect_threads_with_bot_replies(&comments, "gru-bot");
+        assert_eq!(replied.len(), 2);
+        assert!(replied.contains(&1));
+        assert!(replied.contains(&10));
+        assert!(!replied.contains(&20));
+    }
+
+    #[test]
+    fn test_filter_feedback_skips_already_replied_thread() {
+        // Synthetic "already replied" review: a reviewer comment whose
+        // thread already has a bot reply. The handler must drop it before
+        // invoking the agent so no duplicate reply is posted.
+        let feedback = ReviewFeedback {
+            comments: vec![
+                make_review_comment(100, "Please fix this"),
+                make_review_comment(200, "Please also fix that"),
+            ],
+            bodies: vec![],
+            had_fetch_failures: false,
+        };
+        let already_replied: std::collections::HashSet<u64> = [100].into_iter().collect();
+
+        let filtered = filter_feedback_against_replied_threads(feedback, &already_replied);
+        assert_eq!(filtered.comments.len(), 1);
+        assert_eq!(filtered.comments[0].comment_id, 200);
+    }
+
+    #[test]
+    fn test_filter_feedback_preserves_bodies() {
+        // The idempotency check is per-comment, not per-review: review
+        // bodies must pass through unchanged.
+        let body = ReviewBody {
+            body: "LGTM overall".to_string(),
+            reviewer: "alice".to_string(),
+            reviewer_display_name: "Alice".to_string(),
+            state: "COMMENTED".to_string(),
+        };
+        let feedback = ReviewFeedback {
+            comments: vec![make_review_comment(100, "Please fix this")],
+            bodies: vec![body],
+            had_fetch_failures: false,
+        };
+        let already_replied: std::collections::HashSet<u64> = [100].into_iter().collect();
+
+        let filtered = filter_feedback_against_replied_threads(feedback, &already_replied);
+        assert!(filtered.comments.is_empty());
+        assert_eq!(filtered.bodies.len(), 1);
+        assert_eq!(filtered.bodies[0].body, "LGTM overall");
+    }
+
+    #[test]
+    fn test_filter_feedback_empty_replied_set_is_noop() {
+        let feedback = ReviewFeedback {
+            comments: vec![make_review_comment(100, "Please fix this")],
+            bodies: vec![],
+            had_fetch_failures: false,
+        };
+        let filtered =
+            filter_feedback_against_replied_threads(feedback, &std::collections::HashSet::new());
+        assert_eq!(filtered.comments.len(), 1);
+        assert_eq!(filtered.comments[0].comment_id, 100);
+    }
+
+    #[test]
+    fn test_filter_feedback_preserves_had_fetch_failures_flag() {
+        let feedback = ReviewFeedback {
+            comments: vec![make_review_comment(100, "x")],
+            bodies: vec![],
+            had_fetch_failures: true,
+        };
+        let already_replied: std::collections::HashSet<u64> = [100].into_iter().collect();
+        let filtered = filter_feedback_against_replied_threads(feedback, &already_replied);
+        assert!(filtered.had_fetch_failures);
     }
 
     // ========================================================================

--- a/src/pr_monitor.rs
+++ b/src/pr_monitor.rs
@@ -7,6 +7,7 @@ use crate::progress_comments::{extract_minion_id_from_signature, has_minion_sign
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::process::Output;
 use tokio::time::{sleep, Duration, Instant};
 
@@ -996,7 +997,7 @@ fn filter_unanswered_comments(
     minion_id: &str,
 ) -> Vec<ApiReviewComment> {
     // Collect IDs of comments that this Minion has already directly replied to.
-    let already_answered: std::collections::HashSet<u64> = api_comments
+    let already_answered: HashSet<u64> = api_comments
         .iter()
         .filter_map(|c| {
             if has_minion_signature_for(&c.body, minion_id) {
@@ -1133,7 +1134,7 @@ async fn fetch_pr_inline_comments_raw(
 fn collect_threads_with_bot_replies(
     api_comments: &[ApiReviewComment],
     bot_user: &str,
-) -> std::collections::HashSet<u64> {
+) -> HashSet<u64> {
     api_comments
         .iter()
         .filter_map(|c| {
@@ -1151,7 +1152,7 @@ fn collect_threads_with_bot_replies(
 /// check is scoped per-comment, not per-review (#867).
 pub(crate) fn filter_feedback_against_replied_threads(
     feedback: ReviewFeedback,
-    already_replied: &std::collections::HashSet<u64>,
+    already_replied: &HashSet<u64>,
 ) -> ReviewFeedback {
     let ReviewFeedback {
         comments,
@@ -1183,7 +1184,7 @@ pub(crate) async fn fetch_threads_with_bot_replies(
     repo: &str,
     pr_number: &str,
     bot_user: &str,
-) -> Result<std::collections::HashSet<u64>> {
+) -> Result<HashSet<u64>> {
     let api_comments = fetch_pr_inline_comments_raw(host, owner, repo, pr_number).await?;
     Ok(collect_threads_with_bot_replies(&api_comments, bot_user))
 }
@@ -2928,7 +2929,7 @@ mod tests {
             bodies: vec![],
             had_fetch_failures: false,
         };
-        let already_replied: std::collections::HashSet<u64> = [100].into_iter().collect();
+        let already_replied: HashSet<u64> = [100].into_iter().collect();
 
         let filtered = filter_feedback_against_replied_threads(feedback, &already_replied);
         assert_eq!(filtered.comments.len(), 1);
@@ -2950,7 +2951,7 @@ mod tests {
             bodies: vec![body],
             had_fetch_failures: false,
         };
-        let already_replied: std::collections::HashSet<u64> = [100].into_iter().collect();
+        let already_replied: HashSet<u64> = [100].into_iter().collect();
 
         let filtered = filter_feedback_against_replied_threads(feedback, &already_replied);
         assert!(filtered.comments.is_empty());
@@ -2965,8 +2966,7 @@ mod tests {
             bodies: vec![],
             had_fetch_failures: false,
         };
-        let filtered =
-            filter_feedback_against_replied_threads(feedback, &std::collections::HashSet::new());
+        let filtered = filter_feedback_against_replied_threads(feedback, &HashSet::new());
         assert_eq!(filtered.comments.len(), 1);
         assert_eq!(filtered.comments[0].comment_id, 100);
     }
@@ -2978,7 +2978,7 @@ mod tests {
             bodies: vec![],
             had_fetch_failures: true,
         };
-        let already_replied: std::collections::HashSet<u64> = [100].into_iter().collect();
+        let already_replied: HashSet<u64> = [100].into_iter().collect();
         let filtered = filter_feedback_against_replied_threads(feedback, &already_replied);
         assert!(filtered.had_fetch_failures);
     }


### PR DESCRIPTION
## Summary
- Fetch every inline comment on the PR via `repos/{o}/{r}/pulls/{n}/comments` and drop review threads where the authenticated bot user has already posted a non-empty reply. Runs before `format_review_prompt` in `handle_new_reviews`, so the agent is never invoked for an already-handled thread.
- Per-comment scoping (keyed on `in_reply_to_id` → comment ID), content-agnostic (any non-empty reply by the bot user counts — no signature match required). Best-effort: any API failure falls through to the existing code path, so the lockfile + registry guards from #862/#863 stay in charge.
- When the filter removes every inline comment and `had_fetch_failures` is false, the baseline advances and the agent is skipped. When `had_fetch_failures` is true the baseline is left alone so unfetched threads are retried next cycle.
- Extracted `fetch_pr_inline_comments_raw` so both the new filter and `dedup_minion_inline_replies` share the paginated fetch.

## Test plan
- `cargo test pr_monitor` — 122 passing (10 new tests for `collect_threads_with_bot_replies` and `filter_feedback_against_replied_threads`).
- `just check` — full suite green (1340 tests, formatting, clippy, build).

## Notes
- Fixes #867. Backstop on top of #863 (process-level lockfile) and #862 (registry guard).
- Review bodies are not filtered — the idempotency check is scoped per-comment, as the issue specifies.
- `apply_bot_reply_idempotency_filter` calls `get_authenticated_user` each review cycle; the underlying `gh api user --cache 60s` absorbs repeated calls within a poll burst. If this becomes a hot path a future refactor could cache the login on `MonitorContext`.

<sub>🤖 M1jb</sub>