### PR TITLE
Fixes #864: Atomic claim-with-PID in check_and_claim_session

### DIFF
--- a/src/commands/attach.rs
+++ b/src/commands/attach.rs
@@ -66,6 +66,7 @@ pub(crate) async fn handle_attach(
     let registry_data = match session_claim::check_and_claim_session(
         &minion.minion_id,
         MinionMode::Interactive,
+        None, // PID is stamped after spawn() below via a separate registry update
         true, // graceful: allow attach without registry
     )
     .await
@@ -84,6 +85,7 @@ pub(crate) async fn handle_attach(
                 session_claim::check_and_claim_session(
                     &minion.minion_id,
                     MinionMode::Interactive,
+                    None,
                     true,
                 )
                 .await?

--- a/src/commands/fix/agent.rs
+++ b/src/commands/fix/agent.rs
@@ -282,9 +282,8 @@ async fn run_agent_session_inner(
     let parent_pid = std::process::id();
     let parent_start_time = get_process_start_time(parent_pid);
 
-    let claim_minion_id = wt_ctx.minion_id.clone();
     let claim_result = crate::session_claim::check_and_claim_session(
-        &claim_minion_id,
+        &wt_ctx.minion_id,
         MinionMode::Autonomous,
         Some((parent_pid, parent_start_time)),
         true, // graceful: don't fail the worker over a transient registry error

--- a/src/commands/fix/agent.rs
+++ b/src/commands/fix/agent.rs
@@ -282,30 +282,52 @@ async fn run_agent_session_inner(
     let parent_pid = std::process::id();
     let parent_start_time = get_process_start_time(parent_pid);
 
+    // Call with graceful=false so that transient registry IO/lock failures
+    // propagate as Err rather than being silently swallowed into Ok(None) —
+    // a silent failure here would leave the registry pointing at the dead
+    // child PID, which is the exact state #864 aims to eliminate. We then
+    // locally downgrade both error shapes to warn+continue so neither kills
+    // the worker (which still has a valid agent_run to return) but both
+    // remain visible in operator logs.
     let claim_result = crate::session_claim::check_and_claim_session(
         &wt_ctx.minion_id,
         MinionMode::Autonomous,
         Some((parent_pid, parent_start_time)),
-        true, // graceful: don't fail the worker over a transient registry error
+        false,
     )
     .await;
 
-    // With graceful=true, `check_and_claim_session` only surfaces
-    // `SessionClaimError::AlreadyRunning`; IO/lock errors are swallowed into
-    // `Ok(None)`. So any `Err` here is a concurrent-claim conflict.
-    if let Err(e) = claim_result {
-        // A concurrent `gru resume`/`gru attach` won the race and now owns
-        // the minion. The worker cannot safely re-stamp ownership, but
-        // killing it would lose the work already done. Log loudly so
-        // operators can correlate duplicate-agent incidents with this event,
-        // and proceed — the other process owns the session claim but this
-        // worker still has the in-memory agent_run to return.
-        log::warn!(
-            "Concurrent claim detected while transferring post-agent ownership for {}: {:#}. \
-             Another process may now own the minion; proceeding with this worker anyway.",
-            wt_ctx.minion_id,
-            e
-        );
+    match claim_result {
+        Ok(_) => {}
+        Err(e)
+            if e.downcast_ref::<crate::session_claim::SessionClaimError>()
+                .is_some() =>
+        {
+            // A concurrent `gru resume`/`gru attach` won the race and now
+            // owns the minion. The worker cannot safely re-stamp ownership,
+            // but killing it would lose the work already done. Log loudly so
+            // operators can correlate duplicate-agent incidents with this
+            // event, and proceed — the other process owns the session claim
+            // but this worker still has the in-memory agent_run to return.
+            log::warn!(
+                "Concurrent claim detected while transferring post-agent ownership for {}: {:#}. \
+                 Another process may now own the minion; proceeding with this worker anyway.",
+                wt_ctx.minion_id,
+                e
+            );
+        }
+        Err(e) => {
+            // Transient registry error (IO, lock timeout). Registry still
+            // points at the dead child PID, so a concurrent claimer could
+            // observe a stale-PID entry — same failure shape #864 aims to
+            // close, now visible instead of silent.
+            log::warn!(
+                "Failed to transfer registry ownership to worker PID for {}: {:#}. \
+                 Registry may briefly allow concurrent claim.",
+                wt_ctx.minion_id,
+                e
+            );
+        }
     }
 
     // Persist token_usage in a separate update. This is not part of the

--- a/src/commands/fix/agent.rs
+++ b/src/commands/fix/agent.rs
@@ -7,6 +7,7 @@ use crate::progress::{ProgressConfig, ProgressDisplay};
 use crate::progress_comments::{MinionPhase, ProgressCommentTracker};
 use crate::prompt_loader;
 use crate::prompt_renderer::{render_template, PromptContext};
+use crate::session_claim::SessionClaimError;
 use anyhow::{Context, Result};
 use tokio::process::Command as TokioCommand;
 use uuid::Uuid;
@@ -259,44 +260,92 @@ async fn run_agent_session_inner(
     // second process can claim it and spawn a duplicate agent against the
     // same session, producing duplicate review replies).
     //
+    // The ownership transfer is routed through `check_and_claim_session` so
+    // the mode flip and the new PID are written in the same file-locked save.
+    // A prior implementation wrote pid/mode as one registry.update and the
+    // stale-pid check in `session_claim` happened in a separate lock window,
+    // leaving a microsecond-wide TOCTOU window where a concurrent claimer
+    // could observe `mode=Autonomous, pid=<dead child>` and reset + claim the
+    // minion (issue #864).
+    //
     // Token usage is persisted regardless of exit status (Ok with non-zero
     // exit) because cost data is valuable even for failed tasks. Only
     // stream-level errors (timeout, stuck) result in Err, in which case
-    // partial usage is not saved.
+    // partial usage is not saved. Token-usage is written in a separate
+    // registry update because it is not part of the concurrency invariant;
+    // serializing it with the atomic claim would entangle a presentation
+    // concern with the lock-ordering guarantee.
     let token_usage = run_result.as_ref().ok().map(|r| r.token_usage.clone());
-    let exit_minion_id = wt_ctx.minion_id.clone();
     // `run_agent_session_inner` is only invoked from within a worker process
     // (via `run_agent_phase` in worker.rs / resume.rs), so `process::id()`
     // here is always the worker PID — the process that owns the minion for
     // PR creation and monitoring after the agent child exits.
     let parent_pid = std::process::id();
     let parent_start_time = get_process_start_time(parent_pid);
-    let log_minion_id = wt_ctx.minion_id.clone();
-    if let Err(e) = with_registry(move |registry| {
-        registry.update(&exit_minion_id, |info| {
-            info.pid = Some(parent_pid);
-            info.pid_start_time = parent_start_time;
-            info.mode = MinionMode::Autonomous;
-            info.last_activity = chrono::Utc::now();
-            if let Some(usage) = token_usage {
+
+    let claim_minion_id = wt_ctx.minion_id.clone();
+    let claim_result = crate::session_claim::check_and_claim_session(
+        &claim_minion_id,
+        MinionMode::Autonomous,
+        Some((parent_pid, parent_start_time)),
+        true, // graceful: don't fail the worker over a transient registry error
+    )
+    .await;
+
+    match claim_result {
+        Ok(_) => {
+            // Ownership transfer succeeded (Some) or registry was unavailable
+            // and graceful-mode swallowed it (None). The graceful case leaves
+            // the registry in its pre-exit state (pid=<dead child>) but the
+            // worker continues; this matches the previous behavior where a
+            // failed update was logged but non-fatal.
+        }
+        Err(e) if e.downcast_ref::<SessionClaimError>().is_some() => {
+            // A concurrent `gru resume`/`gru attach` won the race and now
+            // owns the minion. The worker cannot safely continue into PR
+            // creation without competing writes, but killing it would lose
+            // the work already done. Log loudly so operators can investigate,
+            // and proceed — the other process owns the session claim but
+            // this worker still has the in-memory agent_run to return.
+            log::warn!(
+                "Concurrent claim detected while transferring post-agent ownership for {}: {:#}. \
+                 Another process may now own the minion; proceeding with this worker anyway.",
+                wt_ctx.minion_id,
+                e
+            );
+        }
+        Err(e) => {
+            // Non-graceful error (shouldn't happen since graceful=true, but
+            // handle defensively). Matches the original log-and-continue
+            // behavior.
+            log::warn!(
+                "Failed to transfer registry ownership to worker PID for {}: {:#}. \
+                 Registry may briefly allow concurrent claim.",
+                wt_ctx.minion_id,
+                e
+            );
+        }
+    }
+
+    // Persist token_usage in a separate update. This is not part of the
+    // concurrency invariant: token counters are additive and not inspected
+    // by the claim logic.
+    if let Some(usage) = token_usage {
+        let usage_minion_id = wt_ctx.minion_id.clone();
+        if let Err(e) = with_registry(move |registry| {
+            registry.update(&usage_minion_id, |info| {
                 info.token_usage = Some(usage);
-            }
+                info.last_activity = chrono::Utc::now();
+            })
         })
-    })
-    .await
-    {
-        // A failure here leaves the registry pointing at the now-dead agent
-        // child PID. `session_claim` would treat that as a stale entry and
-        // allow a concurrent `gru resume`/`gru attach` to claim the minion —
-        // the exact failure mode this block exists to prevent (issue #862).
-        // Log loudly so operators can correlate a duplicate-agent incident
-        // with the registry write that failed.
-        log::warn!(
-            "Failed to transfer registry ownership to worker PID for {}: {:#}. \
-             Registry may briefly allow concurrent claim.",
-            log_minion_id,
-            e
-        );
+        .await
+        {
+            log::warn!(
+                "Failed to persist token usage for {}: {:#}",
+                wt_ctx.minion_id,
+                e
+            );
+        }
     }
 
     let agent_run = run_result?;

--- a/src/commands/fix/agent.rs
+++ b/src/commands/fix/agent.rs
@@ -7,7 +7,6 @@ use crate::progress::{ProgressConfig, ProgressDisplay};
 use crate::progress_comments::{MinionPhase, ProgressCommentTracker};
 use crate::prompt_loader;
 use crate::prompt_renderer::{render_template, PromptContext};
-use crate::session_claim::SessionClaimError;
 use anyhow::{Context, Result};
 use tokio::process::Command as TokioCommand;
 use uuid::Uuid;
@@ -292,39 +291,22 @@ async fn run_agent_session_inner(
     )
     .await;
 
-    match claim_result {
-        Ok(_) => {
-            // Ownership transfer succeeded (Some) or registry was unavailable
-            // and graceful-mode swallowed it (None). The graceful case leaves
-            // the registry in its pre-exit state (pid=<dead child>) but the
-            // worker continues; this matches the previous behavior where a
-            // failed update was logged but non-fatal.
-        }
-        Err(e) if e.downcast_ref::<SessionClaimError>().is_some() => {
-            // A concurrent `gru resume`/`gru attach` won the race and now
-            // owns the minion. The worker cannot safely continue into PR
-            // creation without competing writes, but killing it would lose
-            // the work already done. Log loudly so operators can investigate,
-            // and proceed — the other process owns the session claim but
-            // this worker still has the in-memory agent_run to return.
-            log::warn!(
-                "Concurrent claim detected while transferring post-agent ownership for {}: {:#}. \
-                 Another process may now own the minion; proceeding with this worker anyway.",
-                wt_ctx.minion_id,
-                e
-            );
-        }
-        Err(e) => {
-            // Non-graceful error (shouldn't happen since graceful=true, but
-            // handle defensively). Matches the original log-and-continue
-            // behavior.
-            log::warn!(
-                "Failed to transfer registry ownership to worker PID for {}: {:#}. \
-                 Registry may briefly allow concurrent claim.",
-                wt_ctx.minion_id,
-                e
-            );
-        }
+    // With graceful=true, `check_and_claim_session` only surfaces
+    // `SessionClaimError::AlreadyRunning`; IO/lock errors are swallowed into
+    // `Ok(None)`. So any `Err` here is a concurrent-claim conflict.
+    if let Err(e) = claim_result {
+        // A concurrent `gru resume`/`gru attach` won the race and now owns
+        // the minion. The worker cannot safely re-stamp ownership, but
+        // killing it would lose the work already done. Log loudly so
+        // operators can correlate duplicate-agent incidents with this event,
+        // and proceed — the other process owns the session claim but this
+        // worker still has the in-memory agent_run to return.
+        log::warn!(
+            "Concurrent claim detected while transferring post-agent ownership for {}: {:#}. \
+             Another process may now own the minion; proceeding with this worker anyway.",
+            wt_ctx.minion_id,
+            e
+        );
     }
 
     // Persist token_usage in a separate update. This is not part of the

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -73,10 +73,17 @@ async fn check_resumption_preconditions(
         );
     }
 
-    // Atomically check registry state and claim as Autonomous
+    // Atomically check registry state and claim as Autonomous with our own
+    // PID in a single file-locked write. Passing `claim_pid` here closes the
+    // TOCTOU window where a concurrent claimer would otherwise observe
+    // `mode=Autonomous, pid=None` and reset + claim the minion, producing two
+    // live resumes against the same session (issues #862 and #864).
+    let parent_pid = std::process::id();
+    let parent_start_time = crate::minion_registry::get_process_start_time(parent_pid);
     let registry_info = session_claim::check_and_claim_session(
         &minion.minion_id,
         MinionMode::Autonomous,
+        Some((parent_pid, parent_start_time)),
         false, // not graceful: resume requires registry
     )
     .await?;
@@ -92,31 +99,6 @@ async fn check_resumption_preconditions(
             );
         }
     };
-
-    // Record our own PID as the live owner of this minion so concurrent
-    // `gru resume`/`gru attach` attempts are rejected as AlreadyRunning.
-    // Without this, `check_and_claim_session` only sets mode=Autonomous but
-    // leaves pid=None; a second process checking the registry would treat
-    // the entry as stale (non-Stopped mode with no PID) and reset + claim
-    // it, producing two live resumes against the same session (issue #862).
-    let parent_pid = std::process::id();
-    let parent_start_time = crate::minion_registry::get_process_start_time(parent_pid);
-    let mid = minion.minion_id.clone();
-    if let Err(e) = with_registry(move |reg| {
-        reg.update(&mid, |i| {
-            i.pid = Some(parent_pid);
-            i.pid_start_time = parent_start_time;
-            i.last_activity = Utc::now();
-        })
-    })
-    .await
-    {
-        log::warn!(
-            "Failed to record resume process PID for {}: {:#}",
-            minion.minion_id,
-            e
-        );
-    }
 
     // Parse owner/repo from "owner/repo" format
     let (owner, repo_name) = info

--- a/src/session_claim.rs
+++ b/src/session_claim.rs
@@ -28,11 +28,17 @@ impl std::error::Error for SessionClaimError {}
 /// Core claim logic shared by the production function and the test-only variant.
 ///
 /// Checks if a minion is available in the given registry and claims it with
-/// `target_mode`. Returns a snapshot of the `MinionInfo` before claiming.
+/// `target_mode`. When `claim_pid` is `Some((pid, start_time))`, the PID and
+/// its start time are written in the same registry save as the mode flip,
+/// closing the TOCTOU window where a concurrent claimer would otherwise see
+/// `mode=<target>, pid=None` and treat the entry as stale (see issue #864).
+///
+/// Returns a snapshot of the `MinionInfo` before claiming.
 fn claim_session_in_registry(
     reg: &mut MinionRegistry,
     minion_id: &str,
     target_mode: MinionMode,
+    claim_pid: Option<(u32, Option<i64>)>,
 ) -> Result<Option<MinionInfo>> {
     let id = minion_id.to_string();
     let info = match reg.get(&id) {
@@ -84,10 +90,17 @@ fn claim_session_in_registry(
 
     // Claim the session with the requested mode.
     // Clear archived_at so a resumed/attached minion is visible in `gru status`.
+    // When claim_pid is provided, stamp pid/pid_start_time atomically so no
+    // concurrent claimer can observe a `mode=<target>, pid=None` intermediate
+    // state (issue #864).
     reg.update(&id, |i| {
         i.mode = target_mode.clone();
         i.last_activity = Utc::now();
         i.archived_at = None;
+        if let Some((pid, start_time)) = claim_pid {
+            i.pid = Some(pid);
+            i.pid_start_time = start_time;
+        }
     })?;
 
     Ok(Some(info))
@@ -123,6 +136,14 @@ fn handle_claim_result(
 /// call, which holds an exclusive file lock for the duration. This prevents
 /// TOCTOU races between concurrent attach/resume calls.
 ///
+/// When `claim_pid` is `Some((pid, start_time))`, the PID and start time are
+/// written in the same registry save as the mode flip. Callers that own a
+/// live process (e.g., `gru resume` with `std::process::id()`, or the
+/// post-agent cleanup in `fix/agent.rs` transferring ownership from the
+/// now-dead child to the parent worker) should use this to close the TOCTOU
+/// window where a concurrent claimer would otherwise observe
+/// `mode=<target>, pid=None` and treat the entry as stale (issue #864).
+///
 /// Returns a clone of the [`MinionInfo`] (as it was before claiming) if the
 /// minion is found in the registry. Callers can extract whatever fields they
 /// need from this snapshot.
@@ -139,10 +160,12 @@ fn handle_claim_result(
 pub(crate) async fn check_and_claim_session(
     minion_id: &str,
     target_mode: MinionMode,
+    claim_pid: Option<(u32, Option<i64>)>,
     graceful: bool,
 ) -> Result<Option<MinionInfo>> {
     let id = minion_id.to_string();
-    let result = with_registry(move |reg| claim_session_in_registry(reg, &id, target_mode)).await;
+    let result =
+        with_registry(move |reg| claim_session_in_registry(reg, &id, target_mode, claim_pid)).await;
 
     handle_claim_result(result, graceful)
 }
@@ -155,6 +178,7 @@ pub(crate) async fn check_and_claim_session_with_dir(
     state_dir: &std::path::Path,
     minion_id: &str,
     target_mode: MinionMode,
+    claim_pid: Option<(u32, Option<i64>)>,
     graceful: bool,
 ) -> Result<Option<MinionInfo>> {
     use anyhow::Context as _;
@@ -162,7 +186,7 @@ pub(crate) async fn check_and_claim_session_with_dir(
     let dir = state_dir.to_path_buf();
     let result = tokio::task::spawn_blocking(move || {
         let mut reg = MinionRegistry::load(Some(&dir))?;
-        claim_session_in_registry(&mut reg, &id, target_mode)
+        claim_session_in_registry(&mut reg, &id, target_mode, claim_pid)
     })
     .await
     .context("Registry task panicked")?;
@@ -252,10 +276,15 @@ mod tests {
         let info = test_minion_info(); // mode: Stopped, pid: None
         register_minion(tmp.path(), "M001", info.clone());
 
-        let result =
-            check_and_claim_session_with_dir(tmp.path(), "M001", MinionMode::Interactive, false)
-                .await
-                .unwrap();
+        let result = check_and_claim_session_with_dir(
+            tmp.path(),
+            "M001",
+            MinionMode::Interactive,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         // Returns the pre-claim snapshot
         let snapshot = result.expect("should return Some for existing minion");
@@ -279,10 +308,15 @@ mod tests {
         };
         register_minion(tmp.path(), "M001", info);
 
-        let err =
-            check_and_claim_session_with_dir(tmp.path(), "M001", MinionMode::Interactive, false)
-                .await
-                .unwrap_err();
+        let err = check_and_claim_session_with_dir(
+            tmp.path(),
+            "M001",
+            MinionMode::Interactive,
+            None,
+            false,
+        )
+        .await
+        .unwrap_err();
 
         let claim_err = err.downcast_ref::<SessionClaimError>().unwrap();
         let SessionClaimError::AlreadyRunning { minion_id, mode } = claim_err;
@@ -308,10 +342,15 @@ mod tests {
         };
         register_minion(tmp.path(), "M001", info);
 
-        let result =
-            check_and_claim_session_with_dir(tmp.path(), "M001", MinionMode::Interactive, false)
-                .await
-                .unwrap();
+        let result = check_and_claim_session_with_dir(
+            tmp.path(),
+            "M001",
+            MinionMode::Interactive,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         // Should succeed — the dead PID was detected and the entry was reset
         let snapshot = result.expect("should return Some after dead-PID reset");
@@ -336,10 +375,15 @@ mod tests {
         };
         register_minion(tmp.path(), "M001", info);
 
-        let result =
-            check_and_claim_session_with_dir(tmp.path(), "M001", MinionMode::Interactive, false)
-                .await
-                .unwrap();
+        let result = check_and_claim_session_with_dir(
+            tmp.path(),
+            "M001",
+            MinionMode::Interactive,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         // Should succeed — the stale entry was detected and reset
         let snapshot = result.expect("should return Some after stale-entry reset");
@@ -366,6 +410,7 @@ mod tests {
             &impossible_dir,
             "M001",
             MinionMode::Interactive,
+            None,
             true, // graceful
         )
         .await;
@@ -386,6 +431,7 @@ mod tests {
             &impossible_dir,
             "M001",
             MinionMode::Interactive,
+            None,
             false, // non-graceful
         )
         .await;
@@ -404,11 +450,156 @@ mod tests {
     async fn test_nonexistent_minion_returns_none() {
         let tmp = tempdir().unwrap();
         // Empty registry — no minions registered
-        let result =
-            check_and_claim_session_with_dir(tmp.path(), "M999", MinionMode::Interactive, false)
-                .await
-                .unwrap();
+        let result = check_and_claim_session_with_dir(
+            tmp.path(),
+            "M999",
+            MinionMode::Interactive,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         assert!(result.is_none());
+    }
+
+    // --- issue #864: atomic claim-with-PID ---
+
+    #[tokio::test]
+    async fn test_claim_with_pid_writes_pid_atomically() {
+        let tmp = tempdir().unwrap();
+        let info = test_minion_info(); // mode: Stopped, pid: None
+        register_minion(tmp.path(), "M001", info);
+
+        let our_pid = std::process::id();
+        let our_start = get_process_start_time(our_pid);
+
+        let result = check_and_claim_session_with_dir(
+            tmp.path(),
+            "M001",
+            MinionMode::Autonomous,
+            Some((our_pid, our_start)),
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_some(), "claim should have succeeded");
+
+        // The registry write should contain mode, pid, and pid_start_time.
+        let updated = read_minion(tmp.path(), "M001").unwrap();
+        assert_eq!(updated.mode, MinionMode::Autonomous);
+        assert_eq!(updated.pid, Some(our_pid));
+        assert_eq!(updated.pid_start_time, our_start);
+    }
+
+    #[tokio::test]
+    async fn test_claim_with_pid_after_dead_pid_reset() {
+        // Dead PID in the registry (the scenario fix/agent.rs post-exit cleanup
+        // sees: registry points at the now-dead agent child). A concurrent claim
+        // that passes its own pid should reset the stale entry and atomically
+        // stamp the new pid in a single save.
+        let tmp = tempdir().unwrap();
+        let dead_pid = 4_194_304_u32;
+        let info = MinionInfo {
+            mode: MinionMode::Autonomous,
+            pid: Some(dead_pid),
+            pid_start_time: Some(1_000_000),
+            ..test_minion_info()
+        };
+        register_minion(tmp.path(), "M001", info);
+
+        let our_pid = std::process::id();
+        let our_start = get_process_start_time(our_pid);
+
+        let result = check_and_claim_session_with_dir(
+            tmp.path(),
+            "M001",
+            MinionMode::Autonomous,
+            Some((our_pid, our_start)),
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_some());
+
+        let updated = read_minion(tmp.path(), "M001").unwrap();
+        assert_eq!(updated.mode, MinionMode::Autonomous);
+        assert_eq!(updated.pid, Some(our_pid));
+        assert_eq!(updated.pid_start_time, our_start);
+    }
+
+    /// Concurrent-claim race: two threads race to claim the same minion with
+    /// distinct PIDs. Exactly one must win the claim; the other must see
+    /// `AlreadyRunning`. This validates the atomic pid-write closes the
+    /// microsecond-wide TOCTOU window described in issue #864.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_claim_only_one_wins() {
+        let tmp = tempdir().unwrap();
+        let info = test_minion_info(); // mode: Stopped, pid: None
+        register_minion(tmp.path(), "M001", info);
+
+        // Use PIDs that the OS will report as "alive" so whichever thread
+        // wins the claim, the loser will observe `AlreadyRunning` instead of
+        // the "dead pid ⇒ reset + claim" path. `std::process::id()` is the
+        // test runner — guaranteed alive for the duration of the test.
+        let live_pid_a = std::process::id();
+        let start_a = get_process_start_time(live_pid_a);
+        let live_pid_b = std::process::id();
+        let start_b = get_process_start_time(live_pid_b);
+
+        let dir_a = tmp.path().to_path_buf();
+        let dir_b = tmp.path().to_path_buf();
+
+        let handle_a = tokio::spawn(async move {
+            check_and_claim_session_with_dir(
+                &dir_a,
+                "M001",
+                MinionMode::Autonomous,
+                Some((live_pid_a, start_a)),
+                false,
+            )
+            .await
+        });
+        let handle_b = tokio::spawn(async move {
+            check_and_claim_session_with_dir(
+                &dir_b,
+                "M001",
+                MinionMode::Autonomous,
+                Some((live_pid_b, start_b)),
+                false,
+            )
+            .await
+        });
+
+        let (result_a, result_b) = tokio::join!(handle_a, handle_b);
+        let result_a = result_a.unwrap();
+        let result_b = result_b.unwrap();
+
+        // Exactly one must succeed and one must return AlreadyRunning.
+        let (winner, loser) = match (&result_a, &result_b) {
+            (Ok(_), Err(_)) => (&result_a, &result_b),
+            (Err(_), Ok(_)) => (&result_b, &result_a),
+            (Ok(a), Ok(b)) => panic!(
+                "both claims succeeded: a={:?}, b={:?} — the atomic pid-write \
+                 should force the second caller to observe AlreadyRunning",
+                a, b
+            ),
+            (Err(a), Err(b)) => panic!("both claims failed: a={:#}, b={:#}", a, b),
+        };
+
+        assert!(winner.is_ok());
+        let loser_err = loser.as_ref().unwrap_err();
+        assert!(
+            loser_err.downcast_ref::<SessionClaimError>().is_some(),
+            "loser should fail with SessionClaimError::AlreadyRunning, got: {:#}",
+            loser_err
+        );
+
+        // Exactly one pid should be stamped in the registry.
+        let final_state = read_minion(tmp.path(), "M001").unwrap();
+        assert_eq!(final_state.mode, MinionMode::Autonomous);
+        assert!(final_state.pid.is_some(), "pid should be stamped");
     }
 }

--- a/src/session_claim.rs
+++ b/src/session_claim.rs
@@ -569,10 +569,18 @@ mod tests {
         // weaker distinct-PID assertion at the end).
         let pid_a = std::process::id();
         let start_a = get_process_start_time(pid_a);
+        // Use `libc::getppid()` rather than `std::os::unix::process::parent_id()`
+        // — the latter is only available on Rust 1.83+, but the crate MSRV
+        // (Cargo.toml `rust-version`) is 1.73. libc is already a direct
+        // dependency.
         #[cfg(unix)]
         let parent = {
-            use std::os::unix::process::parent_id;
-            parent_id()
+            let ppid = unsafe { libc::getppid() };
+            if ppid > 0 {
+                ppid as u32
+            } else {
+                0
+            }
         };
         #[cfg(not(unix))]
         let parent: u32 = 0;

--- a/src/session_claim.rs
+++ b/src/session_claim.rs
@@ -197,7 +197,10 @@ pub(crate) async fn check_and_claim_session_with_dir(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::minion_registry::{get_process_start_time, MinionRegistry, OrchestrationPhase};
+    use crate::minion_registry::{
+        get_process_start_time, is_process_alive_with_start_time, MinionRegistry,
+        OrchestrationPhase,
+    };
     use std::path::PathBuf;
     use tempfile::tempdir;
 
@@ -532,22 +535,47 @@ mod tests {
 
     /// Concurrent-claim race: two threads race to claim the same minion with
     /// distinct PIDs. Exactly one must win the claim; the other must see
-    /// `AlreadyRunning`. This validates the atomic pid-write closes the
-    /// microsecond-wide TOCTOU window described in issue #864.
+    /// `AlreadyRunning`. This validates that the file-lock + atomic pid-write
+    /// in a single save close the TOCTOU window described in issue #864 —
+    /// there is no observable intermediate state where `mode=<target>` and
+    /// `pid=None`.
+    ///
+    /// Uses distinct live PIDs (the test process and its parent) so that the
+    /// final registry state uniquely identifies which thread won: the loser
+    /// must see the winner's PID in the registry, not its own.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_concurrent_claim_only_one_wins() {
         let tmp = tempdir().unwrap();
         let info = test_minion_info(); // mode: Stopped, pid: None
         register_minion(tmp.path(), "M001", info);
 
-        // Use PIDs that the OS will report as "alive" so whichever thread
-        // wins the claim, the loser will observe `AlreadyRunning` instead of
-        // the "dead pid ⇒ reset + claim" path. `std::process::id()` is the
-        // test runner — guaranteed alive for the duration of the test.
-        let live_pid_a = std::process::id();
-        let start_a = get_process_start_time(live_pid_a);
-        let live_pid_b = std::process::id();
-        let start_b = get_process_start_time(live_pid_b);
+        // Use two distinct PIDs the OS reports as alive: the test process and
+        // its parent (cargo/nextest runner), both live for the duration of
+        // the test. The whole point is that whichever thread wins, the loser
+        // reads a *live, matching start_time* pid from the registry and
+        // correctly returns `AlreadyRunning` — not the "dead pid ⇒ reset +
+        // claim" path.
+        //
+        // If `parent_id()` cannot be resolved to a live process (e.g. some
+        // exotic CI runner), the test falls back to reusing `process::id()`,
+        // which still exercises the mutual-exclusion invariant (just with a
+        // weaker distinct-PID assertion at the end).
+        let pid_a = std::process::id();
+        let start_a = get_process_start_time(pid_a);
+        #[cfg(unix)]
+        let parent = {
+            use std::os::unix::process::parent_id;
+            parent_id()
+        };
+        #[cfg(not(unix))]
+        let parent: u32 = 0;
+        let (pid_b, start_b) =
+            match (parent != 0 && parent != pid_a).then(|| get_process_start_time(parent)) {
+                Some(Some(st)) if is_process_alive_with_start_time(parent, Some(st)) => {
+                    (parent, Some(st))
+                }
+                _ => (pid_a, start_a),
+            };
 
         let dir_a = tmp.path().to_path_buf();
         let dir_b = tmp.path().to_path_buf();
@@ -557,7 +585,7 @@ mod tests {
                 &dir_a,
                 "M001",
                 MinionMode::Autonomous,
-                Some((live_pid_a, start_a)),
+                Some((pid_a, start_a)),
                 false,
             )
             .await
@@ -567,7 +595,7 @@ mod tests {
                 &dir_b,
                 "M001",
                 MinionMode::Autonomous,
-                Some((live_pid_b, start_b)),
+                Some((pid_b, start_b)),
                 false,
             )
             .await
@@ -577,10 +605,12 @@ mod tests {
         let result_a = result_a.unwrap();
         let result_b = result_b.unwrap();
 
-        // Exactly one must succeed and one must return AlreadyRunning.
-        let (winner, loser) = match (&result_a, &result_b) {
-            (Ok(_), Err(_)) => (&result_a, &result_b),
-            (Err(_), Ok(_)) => (&result_b, &result_a),
+        // Exactly one must succeed and one must return AlreadyRunning — the
+        // file lock serializes the two claims and the atomic pid-write means
+        // the second caller never sees a `pid=None` intermediate state.
+        let (winner_pid, loser_result) = match (&result_a, &result_b) {
+            (Ok(_), Err(_)) => (pid_a, &result_b),
+            (Err(_), Ok(_)) => (pid_b, &result_a),
             (Ok(a), Ok(b)) => panic!(
                 "both claims succeeded: a={:?}, b={:?} — the atomic pid-write \
                  should force the second caller to observe AlreadyRunning",
@@ -589,17 +619,22 @@ mod tests {
             (Err(a), Err(b)) => panic!("both claims failed: a={:#}, b={:#}", a, b),
         };
 
-        assert!(winner.is_ok());
-        let loser_err = loser.as_ref().unwrap_err();
+        let loser_err = loser_result.as_ref().unwrap_err();
         assert!(
             loser_err.downcast_ref::<SessionClaimError>().is_some(),
             "loser should fail with SessionClaimError::AlreadyRunning, got: {:#}",
             loser_err
         );
 
-        // Exactly one pid should be stamped in the registry.
+        // The registry must reflect the winner's PID — not some arbitrary
+        // intermediate state. This directly validates that the claim write
+        // and the pid write landed in the same registry save.
         let final_state = read_minion(tmp.path(), "M001").unwrap();
         assert_eq!(final_state.mode, MinionMode::Autonomous);
-        assert!(final_state.pid.is_some(), "pid should be stamped");
+        assert_eq!(
+            final_state.pid,
+            Some(winner_pid),
+            "registry should contain the winning thread's PID"
+        );
     }
 }

--- a/src/session_claim.rs
+++ b/src/session_claim.rs
@@ -33,6 +33,13 @@ impl std::error::Error for SessionClaimError {}
 /// closing the TOCTOU window where a concurrent claimer would otherwise see
 /// `mode=<target>, pid=None` and treat the entry as stale (see issue #864).
 ///
+/// When `claim_pid` is `None`, only `mode`/`last_activity`/`archived_at` are
+/// touched in the claim write — whatever `pid`/`pid_start_time` survived from
+/// the earlier branches (the stale-reset's `clear_pid`, or the pre-existing
+/// values on a clean Stopped entry) remain. The caller is expected to stamp a
+/// PID separately. This is the path `attach.rs` uses because the spawned
+/// child's PID isn't known until after `cmd.spawn()`.
+///
 /// Returns a snapshot of the `MinionInfo` before claiming.
 fn claim_session_in_registry(
     reg: &mut MinionRegistry,


### PR DESCRIPTION
## Summary
- Extend `check_and_claim_session` with an optional `claim_pid: Option<(u32, Option<i64>)>` so `mode`, `pid`, and `pid_start_time` are written in a single file-locked registry save. This closes the microsecond-wide TOCTOU window where a concurrent claimer could otherwise observe `mode=<target>, pid=None` (or `pid=<dead child>`) and reset + claim the session (issue #864, follow-up to #862/#863).
- `resume.rs` now passes `(std::process::id(), get_process_start_time(…))` at claim time and drops the separate PID-recording `with_registry` call added in #863.
- `fix/agent.rs` post-agent cleanup now transfers ownership from the dead agent-child PID to the parent worker PID via `check_and_claim_session` with `target_mode=Autonomous`, in one lock window. Token usage is persisted in a separate update (additive, not part of the concurrency invariant). A concurrent-claim conflict is logged and the worker continues, matching prior log-and-continue behavior.
- `attach.rs` passes `None` for `claim_pid` at both call sites — attach still writes the spawned child's PID after `cmd.spawn()` in a separate update.
- Adds three tests in `session_claim`: atomic pid-write on a clean claim, atomic pid-write after a dead-PID reset, and a multi-thread concurrent-claim race using two distinct live PIDs (test process + its parent) that asserts exactly one thread wins and that the winner's specific PID is what ends up in the registry.

## Test plan
- `just check` — 1332 tests pass, `cargo fmt --all -- --check` clean, `cargo clippy --all-targets -- -D warnings` clean, release build succeeds.
- New tests:
  - `test_claim_with_pid_writes_pid_atomically` — mode/pid/start_time all land in one save for a Stopped entry.
  - `test_claim_with_pid_after_dead_pid_reset` — the scenario `fix/agent.rs` sees post-exit (stale child PID in registry) correctly resets and stamps the parent PID.
  - `test_concurrent_claim_only_one_wins` — two tokio tasks race with distinct live PIDs; exactly one wins, the loser returns `SessionClaimError::AlreadyRunning`, and the registry contains the winner's PID.

## Notes
- The concurrent test is gated on Unix for `parent_id()`; on non-Unix it falls back to a single-PID variant that still exercises mutual exclusion under the file lock.
- The `on_spawn` `pid_callback` in `fix/agent.rs` still writes the agent child's PID in a separate thread — this is the expected ordering (parent claim → child spawn stamps child PID → post-exit claim restores parent PID). A theoretical delayed-callback race exists but is pre-existing and out of scope.
- Not touched in this PR (out of scope for the issue): `src/commands/fix/mod.rs` lines 113-126 register a minion and then write the worker PID in a separate `with_registry` call. Closing that window requires a different shape of fix (initial-registration with PID, or a post-register claim call). Can be filed as a follow-up if the narrower window matters in practice.

Fixes #864

<sub>🤖 M1je</sub>