### PR TITLE
Fixes #865: Per-minion advisory lockfile for defence-in-depth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,7 +322,9 @@ When making changes, keep docs in sync:
 ├── state/              # Local state
 │   ├── next_id.txt     # Minion ID counter
 │   ├── minions.json    # Persistent Minion registry
-│   └── minions.json.lock  # Registry file lock
+│   ├── minions.json.lock  # Registry file lock
+│   └── minions/        # Per-Minion advisory lockfiles (issue #865)
+│       └── <minion_id>.lock  # Held for lifetime of owning worker/resume/attach process
 └── archive/            # Completed work (future)
 ```
 

--- a/src/commands/attach.rs
+++ b/src/commands/attach.rs
@@ -194,16 +194,18 @@ pub(crate) async fn handle_attach(
     // exit and release its own lock fd.
     let _minion_lock = match MinionLock::try_acquire(&minion.minion_id) {
         Ok(lock) => lock,
+        Err(e) if e.downcast_ref::<SessionClaimError>().is_some() => {
+            // Lock contention: the true owner holds the registry state. Do NOT
+            // call `revert_to_stopped` — clobbering their mode to Stopped would
+            // briefly misreport a running minion as idle to observers (lab
+            // polling, `gru status`). The lock-holder's own exit cleanup is
+            // responsible for the registry; we just surface the typed error
+            // so `handle_attach`'s caller (main) can report it. See PR #872
+            // review feedback from M1jj.
+            return Err(e);
+        }
         Err(e) => {
             revert_to_stopped(&minion.minion_id).await;
-            if let Some(SessionClaimError::AlreadyRunning { minion_id, .. }) = e.downcast_ref() {
-                anyhow::bail!(
-                    "Minion {} already has a live owner (advisory lock held). \
-                     Stop it first with: gru stop {}",
-                    minion_id,
-                    minion_id
-                );
-            }
             return Err(e);
         }
     };

--- a/src/commands/attach.rs
+++ b/src/commands/attach.rs
@@ -1,4 +1,5 @@
 use crate::agent_registry;
+use crate::minion_lock::MinionLock;
 use crate::minion_registry::{
     is_process_alive_with_start_time, revert_to_stopped, with_registry, MinionMode,
 };
@@ -182,6 +183,31 @@ pub(crate) async fn handle_attach(
         cmd.arg("--dangerously-skip-permissions");
     }
 
+    // Acquire the per-minion advisory lock just before spawning. This is the
+    // defence-in-depth layer for issue #865: even if the registry claim above
+    // silently races (stale PID not detected, mode transition bug, concurrent
+    // write), the kernel-level lock makes a second live agent structurally
+    // impossible. Held until this function returns (normal exit or panic).
+    //
+    // Placed after the auto-stop retry path so that, when `check_and_claim_session`
+    // dislodged a running autonomous minion, the child process has had time to
+    // exit and release its own lock fd.
+    let _minion_lock = match MinionLock::try_acquire(&minion.minion_id) {
+        Ok(lock) => lock,
+        Err(e) => {
+            revert_to_stopped(&minion.minion_id).await;
+            if let Some(SessionClaimError::AlreadyRunning { minion_id, .. }) = e.downcast_ref() {
+                anyhow::bail!(
+                    "Minion {} already has a live owner (advisory lock held). \
+                     Stop it first with: gru stop {}",
+                    minion_id,
+                    minion_id
+                );
+            }
+            return Err(e);
+        }
+    };
+
     // Spawn agent process (not exec - we need to update registry after exit)
     let mut child = match cmd.spawn() {
         Ok(child) => child,
@@ -231,6 +257,11 @@ pub(crate) async fn handle_attach(
     // On successful exit, offer to resume autonomous monitoring
     if status.success() && !no_auto_resume && !quiet && prompt_auto_resume().await {
         println!("Resuming autonomous monitoring...");
+        // Release our advisory lock before handing off to the resume pipeline;
+        // `handle_resume` acquires its own lock on the same minion and would
+        // otherwise deadlock against this process's fd (fs2 locks are
+        // per-fd — reopening the same path in the same process still blocks).
+        drop(_minion_lock);
         return crate::commands::resume::handle_resume(minion.minion_id, None, None, quiet).await;
     }
 

--- a/src/commands/attach.rs
+++ b/src/commands/attach.rs
@@ -215,17 +215,20 @@ pub(crate) async fn handle_attach(
     // exit and release its own lock fd.
     let _minion_lock = match MinionLock::try_acquire(&minion.minion_id) {
         Ok(lock) => lock,
-        Err(e) if e.downcast_ref::<SessionClaimError>().is_some() => {
-            // Lock contention: the true owner holds the registry state. Do NOT
-            // call `revert_to_stopped` — clobbering their mode to Stopped would
-            // briefly misreport a running minion as idle to observers (lab
-            // polling, `gru status`). The lock-holder's own exit cleanup is
-            // responsible for the registry; we just surface the typed error
-            // so `handle_attach`'s caller (main) can report it. See PR #872
-            // review feedback from M1jj.
-            return Err(e);
-        }
         Err(e) => {
+            // Unified error path: if we mutated the registry to Interactive
+            // during `check_and_claim_session` above, we must roll that claim
+            // back — otherwise the registry reports mode=Interactive for a
+            // minion no agent will actually run.
+            //
+            // `revert_if_claimed` is a no-op when `claimed_registry == false`
+            // (graceful `Ok(None)` from the initial claim), which covers the
+            // case where another live process owns the minion and we never
+            // wrote anything to clobber. When we *did* claim, reverting to
+            // Stopped is strictly better than leaving a stale Interactive
+            // entry — the true lock-holder's `pid_callback` during agent
+            // spawn rewrites the authoritative mode/PID, so the brief
+            // Stopped window self-heals. See PR #872 Copilot review.
             revert_if_claimed().await;
             return Err(e);
         }

--- a/src/commands/attach.rs
+++ b/src/commands/attach.rs
@@ -37,7 +37,11 @@ use uuid::Uuid;
 /// - During attach: updates registry with PID after spawn
 /// - After exit: updates registry with mode=Stopped and clears PID
 /// - Signal handling: Ctrl-C is caught to ensure registry cleanup runs
-/// - On error: registry is reverted to Stopped via [`revert_to_stopped`]
+/// - On error: registry is reverted to Stopped via [`revert_to_stopped`],
+///   but only when we actually claimed the registry. Under `graceful=true`,
+///   `check_and_claim_session` returns `Ok(None)` for both "not in registry"
+///   and "transient registry failure" — in either case no write happened, so
+///   reverting could clobber another live process's entry.
 pub(crate) async fn handle_attach(
     id: String,
     yolo: bool,
@@ -96,6 +100,23 @@ pub(crate) async fn handle_attach(
         }
     };
 
+    // Track whether we actually claimed the registry. `Ok(None)` from
+    // check_and_claim_session can mean either "minion not in registry" or
+    // (because `graceful=true`) "transient registry failure". In both cases
+    // no write happened, so we must NOT call revert_to_stopped on a later
+    // error — doing so could clobber the entry of a live process that owns
+    // the minion, briefly misreporting it as Stopped to observers (lab
+    // polling, gru status). See PR #872 Copilot review.
+    let claimed_registry = registry_data.is_some();
+    let revert_if_claimed = || {
+        let mid = minion.minion_id.clone();
+        async move {
+            if claimed_registry {
+                revert_to_stopped(&mid).await;
+            }
+        }
+    };
+
     // Extract session_id, agent_name, and repo; default to "claude" when not in registry
     let (session_id, agent_name, repo_str) = match registry_data {
         Some(info) => (Some(info.session_id), info.agent_name, Some(info.repo)),
@@ -106,7 +127,7 @@ pub(crate) async fn handle_attach(
     let backend = match agent_registry::resolve_backend(&agent_name) {
         Ok(b) => b,
         Err(e) => {
-            revert_to_stopped(&minion.minion_id).await;
+            revert_if_claimed().await;
             return Err(e).context(format!(
                 "Failed to resolve agent backend '{}' for attach",
                 agent_name
@@ -137,7 +158,7 @@ pub(crate) async fn handle_attach(
             let session_uuid = match Uuid::parse_str(sid) {
                 Ok(uuid) => uuid,
                 Err(e) => {
-                    revert_to_stopped(&minion.minion_id).await;
+                    revert_if_claimed().await;
                     return Err(
                         anyhow::anyhow!(e).context("Failed to parse session ID from registry")
                     );
@@ -150,7 +171,7 @@ pub(crate) async fn handle_attach(
             ) {
                 Some(c) => c,
                 None => {
-                    revert_to_stopped(&minion.minion_id).await;
+                    revert_if_claimed().await;
                     anyhow::bail!(
                         "Agent backend '{}' does not support interactive mode. \
                          Use 'gru resume {}' for autonomous mode instead.",
@@ -205,7 +226,7 @@ pub(crate) async fn handle_attach(
             return Err(e);
         }
         Err(e) => {
-            revert_to_stopped(&minion.minion_id).await;
+            revert_if_claimed().await;
             return Err(e);
         }
     };
@@ -214,7 +235,7 @@ pub(crate) async fn handle_attach(
     let mut child = match cmd.spawn() {
         Ok(child) => child,
         Err(e) => {
-            revert_to_stopped(&minion.minion_id).await;
+            revert_if_claimed().await;
             return Err(e).context(format!(
                 "Failed to start agent '{}'. Is the CLI installed and in your PATH?",
                 agent_name

--- a/src/commands/fix/mod.rs
+++ b/src/commands/fix/mod.rs
@@ -21,7 +21,9 @@ use crate::agent_registry;
 use crate::agent_runner::{
     is_stuck_or_timeout_error, parse_timeout, EXIT_ALREADY_RUNNING, EXIT_CODE_SIGNAL_TERMINATED,
 };
+use crate::minion_lock::MinionLock;
 use crate::minion_registry::{with_registry, MinionMode, OrchestrationPhase};
+use crate::session_claim::SessionClaimError;
 use crate::tmux::TmuxGuard;
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
@@ -133,6 +135,26 @@ async fn spawn_worker(
 /// Looks up the minion in the registry by ID, resolves the agent backend,
 /// and runs the agent session, PR creation, and monitoring phases.
 async fn run_worker(minion_id: &str, issue: &str, opts: FixOptions) -> Result<i32> {
+    // Defence-in-depth against duplicate agent subprocesses (issue #865).
+    // Held for the lifetime of this function; released on drop (normal exit,
+    // panic, or SIGKILL via kernel fd close). The registry check in
+    // `check_and_claim_session` is the primary barrier — this advisory lock
+    // is a second layer so a registry bug (stale PID, mode mismatch) cannot
+    // produce two live agents against the same minion.
+    let _minion_lock = match MinionLock::try_acquire(minion_id) {
+        Ok(lock) => lock,
+        Err(e) => {
+            if e.downcast_ref::<SessionClaimError>().is_some() {
+                log::error!(
+                    "Minion {} already has a live owner (advisory lock held); refusing to start worker",
+                    minion_id
+                );
+                return Ok(EXIT_ALREADY_RUNNING);
+            }
+            return Err(e);
+        }
+    };
+
     let FixOptions {
         timeout: timeout_opt,
         review_timeout: review_timeout_opt,

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -5,11 +5,12 @@ use crate::commands::fix::{
     agent_exit_code, create_pr_phase, fetch_issue_details, monitor_pr_phase, run_agent_phase,
     update_orchestration_phase, IssueContext, WorktreeContext,
 };
+use crate::minion_lock::MinionLock;
 use crate::minion_registry::{
     mark_minion_failed, revert_to_stopped, with_registry, MinionMode, OrchestrationPhase,
 };
 use crate::minion_resolver;
-use crate::session_claim;
+use crate::session_claim::{self, SessionClaimError};
 use crate::tmux::TmuxGuard;
 use anyhow::{bail, Result};
 use chrono::{DateTime, Utc};
@@ -27,6 +28,10 @@ struct ResumeContext {
     no_watch: bool,
     /// The command that originally created this minion (e.g., "do", "prompt", "review").
     command: String,
+    /// Advisory lock held for the lifetime of the resume pipeline. Prevents
+    /// concurrent `gru resume` / `gru attach` from spawning a second agent
+    /// against the same minion (issue #865). Released on drop.
+    _minion_lock: MinionLock,
 }
 
 /// Handles the resume command: resumes a stopped Minion in autonomous mode.
@@ -72,6 +77,25 @@ async fn check_resumption_preconditions(
             minion.worktree_path.display()
         );
     }
+
+    // Acquire the per-minion advisory lock before touching the registry so
+    // that if another process already owns this minion we bail out without
+    // mutating any shared state. Held for the lifetime of the resume
+    // pipeline; released on drop (issue #865).
+    let minion_lock = match MinionLock::try_acquire(&minion.minion_id) {
+        Ok(lock) => lock,
+        Err(e) => {
+            if let Some(SessionClaimError::AlreadyRunning { minion_id, .. }) = e.downcast_ref() {
+                bail!(
+                    "Minion {} already has a live owner (advisory lock held). \
+                     Stop it first with: gru stop {}",
+                    minion_id,
+                    minion_id
+                );
+            }
+            return Err(e);
+        }
+    };
 
     // Atomically check registry state and claim as Autonomous with our own
     // PID in a single file-locked write. Passing `claim_pid` here closes the
@@ -264,6 +288,7 @@ async fn check_resumption_preconditions(
         effective_timeout,
         no_watch,
         command,
+        _minion_lock: minion_lock,
     })
 }
 
@@ -281,6 +306,7 @@ async fn run_resume_pipeline(ctx: ResumeContext, quiet: bool) -> Result<i32> {
         effective_timeout,
         no_watch,
         command,
+        _minion_lock,
     } = ctx;
 
     // Non-"do" minions (e.g., "prompt", "review") only run the agent phase —

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -1,6 +1,8 @@
 use crate::agent::AgentBackend;
 use crate::agent_registry;
-use crate::agent_runner::{is_stuck_or_timeout_error, EXIT_CODE_SIGNAL_TERMINATED};
+use crate::agent_runner::{
+    is_stuck_or_timeout_error, EXIT_ALREADY_RUNNING, EXIT_CODE_SIGNAL_TERMINATED,
+};
 use crate::commands::fix::{
     agent_exit_code, create_pr_phase, fetch_issue_details, monitor_pr_phase, run_agent_phase,
     update_orchestration_phase, IssueContext, WorktreeContext,
@@ -53,7 +55,16 @@ pub(crate) async fn handle_resume(
     timeout_opt: Option<String>,
     quiet: bool,
 ) -> Result<i32> {
-    let ctx = check_resumption_preconditions(id, additional_prompt, timeout_opt).await?;
+    let ctx = match check_resumption_preconditions(id, additional_prompt, timeout_opt).await {
+        Ok(ctx) => ctx,
+        Err(e) if e.downcast_ref::<SessionClaimError>().is_some() => {
+            // `gru do` returns EXIT_ALREADY_RUNNING on the same condition so
+            // lab can short-circuit retries; keep resume's contract aligned.
+            eprintln!("{:#}", e);
+            return Ok(EXIT_ALREADY_RUNNING);
+        }
+        Err(e) => return Err(e),
+    };
     run_resume_pipeline(ctx, quiet).await
 }
 
@@ -82,20 +93,10 @@ async fn check_resumption_preconditions(
     // that if another process already owns this minion we bail out without
     // mutating any shared state. Held for the lifetime of the resume
     // pipeline; released on drop (issue #865).
-    let minion_lock = match MinionLock::try_acquire(&minion.minion_id) {
-        Ok(lock) => lock,
-        Err(e) => {
-            if let Some(SessionClaimError::AlreadyRunning { minion_id, .. }) = e.downcast_ref() {
-                bail!(
-                    "Minion {} already has a live owner (advisory lock held). \
-                     Stop it first with: gru stop {}",
-                    minion_id,
-                    minion_id
-                );
-            }
-            return Err(e);
-        }
-    };
+    //
+    // On contention the error is a `SessionClaimError::AlreadyRunning` —
+    // `handle_resume` downcasts this to exit with `EXIT_ALREADY_RUNNING`.
+    let minion_lock = MinionLock::try_acquire(&minion.minion_id)?;
 
     // Atomically check registry state and claim as Autonomous with our own
     // PID in a single file-locked write. Passing `claim_pid` here closes the

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -94,8 +94,10 @@ async fn check_resumption_preconditions(
     // mutating any shared state. Held for the lifetime of the resume
     // pipeline; released on drop (issue #865).
     //
-    // On contention the error is a `SessionClaimError::AlreadyRunning` —
-    // `handle_resume` downcasts this to exit with `EXIT_ALREADY_RUNNING`.
+    // On contention the error is `SessionClaimError::LockContention`;
+    // `handle_resume` downcasts any `SessionClaimError` variant (lock or
+    // registry) to exit with `EXIT_ALREADY_RUNNING`, keeping the retry
+    // contract uniform across both barriers.
     let minion_lock = MinionLock::try_acquire(&minion.minion_id)?;
 
     // Atomically check registry state and claim as Autonomous with our own

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod mcp;
 mod merge_judge;
 mod merge_readiness;
 mod minion;
+mod minion_lock;
 mod minion_registry;
 mod minion_resolver;
 mod pr_monitor;

--- a/src/minion_lock.rs
+++ b/src/minion_lock.rs
@@ -55,10 +55,19 @@ impl MinionLock {
     /// Attempts to acquire an exclusive non-blocking lock on
     /// `~/.gru/state/minions/<minion_id>.lock`.
     ///
-    /// Returns [`SessionClaimError::AlreadyRunning`] (with mode unknown, set
-    /// to [`MinionMode::Autonomous`](crate::minion_registry::MinionMode::Autonomous))
-    /// if another process already holds the lock. Other IO failures propagate
-    /// as [`anyhow::Error`].
+    /// Returns [`SessionClaimError::AlreadyRunning`] if another process
+    /// already holds the lock. Other IO failures propagate as
+    /// [`anyhow::Error`].
+    ///
+    /// **Important:** the `mode` field of the returned error is set to
+    /// [`MinionMode::Autonomous`] as a placeholder — we cannot read the
+    /// registry for the actual mode without re-entering registry code. The
+    /// value is only meaningful for the error's `Display` message. Callers
+    /// (specifically `handle_attach`) that branch on `mode == Autonomous`
+    /// to decide whether to auto-stop a running minion MUST acquire the
+    /// advisory lock **after** the registry-level
+    /// `check_and_claim_session` — never before — or the hardcoded mode
+    /// will route a kernel-lock contention into the auto-stop path.
     pub(crate) fn try_acquire(minion_id: &str) -> Result<Self> {
         let ws = Workspace::global().context("Failed to initialize workspace for minion lock")?;
         Self::try_acquire_in_dir(ws.state(), minion_id)

--- a/src/minion_lock.rs
+++ b/src/minion_lock.rs
@@ -55,19 +55,12 @@ impl MinionLock {
     /// Attempts to acquire an exclusive non-blocking lock on
     /// `~/.gru/state/minions/<minion_id>.lock`.
     ///
-    /// Returns [`SessionClaimError::AlreadyRunning`] if another process
-    /// already holds the lock. Other IO failures propagate as
-    /// [`anyhow::Error`].
-    ///
-    /// **Important:** the `mode` field of the returned error is set to
-    /// [`MinionMode::Autonomous`] as a placeholder — we cannot read the
-    /// registry for the actual mode without re-entering registry code. The
-    /// value is only meaningful for the error's `Display` message. Callers
-    /// (specifically `handle_attach`) that branch on `mode == Autonomous`
-    /// to decide whether to auto-stop a running minion MUST acquire the
-    /// advisory lock **after** the registry-level
-    /// `check_and_claim_session` — never before — or the hardcoded mode
-    /// will route a kernel-lock contention into the auto-stop path.
+    /// Returns [`SessionClaimError::LockContention`] if another process
+    /// already holds the lock. The separate variant (distinct from
+    /// [`SessionClaimError::AlreadyRunning`]) avoids fabricating a
+    /// registry mode we don't know, and keeps the `mode == Autonomous`
+    /// branching in `handle_attach` bound strictly to the registry-level
+    /// claim. Other IO failures propagate as [`anyhow::Error`].
     pub(crate) fn try_acquire(minion_id: &str) -> Result<Self> {
         let ws = Workspace::global().context("Failed to initialize workspace for minion lock")?;
         Self::try_acquire_in_dir(ws.state(), minion_id)
@@ -98,9 +91,8 @@ impl MinionLock {
                 minion_id: minion_id.to_string(),
                 path,
             }),
-            Err(e) if is_lock_contention(&e) => Err(SessionClaimError::AlreadyRunning {
+            Err(e) if is_lock_contention(&e) => Err(SessionClaimError::LockContention {
                 minion_id: minion_id.to_string(),
-                mode: crate::minion_registry::MinionMode::Autonomous,
             }
             .into()),
             Err(e) => Err(anyhow::Error::new(e)
@@ -165,16 +157,21 @@ mod tests {
     }
 
     #[test]
-    fn second_acquire_fails_with_already_running() {
+    fn second_acquire_fails_with_lock_contention() {
         let tmp = tempdir().unwrap();
         let _first = MinionLock::try_acquire_in_dir(tmp.path(), "M001").unwrap();
 
         let err = MinionLock::try_acquire_in_dir(tmp.path(), "M001").unwrap_err();
         let claim = err
             .downcast_ref::<SessionClaimError>()
-            .expect("second acquire must surface SessionClaimError::AlreadyRunning");
-        let SessionClaimError::AlreadyRunning { minion_id, .. } = claim;
-        assert_eq!(minion_id, "M001");
+            .expect("second acquire must surface SessionClaimError::LockContention");
+        match claim {
+            SessionClaimError::LockContention { minion_id } => assert_eq!(minion_id, "M001"),
+            other => panic!("expected LockContention, got {other:?}"),
+        }
+        // The Display message must not fabricate a registry mode (review feedback on #872).
+        let msg = format!("{:#}", err);
+        assert!(!msg.contains("mode:"), "unexpected mode in message: {msg}");
     }
 
     #[test]
@@ -238,7 +235,7 @@ mod tests {
     /// Integration-style test (acceptance criterion for issue #865): spawn
     /// multiple concurrent workers against the same minion and confirm
     /// exactly one acquires the lock while the others fail with
-    /// `SessionClaimError::AlreadyRunning`.
+    /// `SessionClaimError::LockContention`.
     ///
     /// Uses real OS threads rather than tokio tasks so each acquisition
     /// runs in parallel on distinct file descriptors (fs2 uses flock(2) on
@@ -266,7 +263,7 @@ mod tests {
             .collect();
 
         let mut acquired = 0;
-        let mut already_running = 0;
+        let mut contended = 0;
         let mut other_err = 0;
 
         // Keep the winning lock alive until all contenders have been inspected
@@ -279,8 +276,13 @@ mod tests {
                     winners.push(lock);
                     acquired += 1;
                 }
-                Err(e) if e.downcast_ref::<SessionClaimError>().is_some() => {
-                    already_running += 1;
+                Err(e)
+                    if matches!(
+                        e.downcast_ref::<SessionClaimError>(),
+                        Some(SessionClaimError::LockContention { .. })
+                    ) =>
+                {
+                    contended += 1;
                 }
                 Err(_) => other_err += 1,
             }
@@ -291,9 +293,9 @@ mod tests {
             "exactly one worker must acquire the lock (got {acquired})"
         );
         assert_eq!(
-            already_running,
+            contended,
             WORKERS - 1,
-            "the remaining workers must surface AlreadyRunning (got {already_running})"
+            "the remaining workers must surface LockContention (got {contended})"
         );
         assert_eq!(
             other_err, 0,

--- a/src/minion_lock.rs
+++ b/src/minion_lock.rs
@@ -31,11 +31,53 @@ use crate::workspace::Workspace;
 /// Subdirectory under `~/.gru/state/` holding per-minion lockfiles.
 const MINION_LOCKS_SUBDIR: &str = "minions";
 
+/// Rejects minion IDs containing characters that could escape the lock directory.
+///
+/// Any `/`, `\`, or `..` in an ID would let a caller (corrupt registry entry,
+/// hand-passed `--worker` flag) write a lockfile outside `<state>/minions/`.
+/// Mirrors the same defence applied to minion IDs in `workspace::archive_dir`.
+fn validate_minion_id(minion_id: &str) -> io::Result<()> {
+    if minion_id.is_empty()
+        || minion_id.contains('/')
+        || minion_id.contains('\\')
+        || minion_id.contains("..")
+        || minion_id.contains('\0')
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Minion ID '{minion_id}' contains invalid characters"),
+        ));
+    }
+    Ok(())
+}
+
 /// Computes the lockfile path `<state>/minions/<minion_id>.lock`.
-fn lock_path(state_dir: &Path, minion_id: &str) -> PathBuf {
-    state_dir
-        .join(MINION_LOCKS_SUBDIR)
-        .join(format!("{minion_id}.lock"))
+///
+/// Callers must have validated `minion_id` via [`validate_minion_id`] first —
+/// this function performs a final containment check but does not re-validate
+/// characters.
+fn lock_path(state_dir: &Path, minion_id: &str) -> io::Result<PathBuf> {
+    let minions_dir = state_dir.join(MINION_LOCKS_SUBDIR);
+    let path = minions_dir.join(format!("{minion_id}.lock"));
+
+    // Belt-and-braces containment check: refuse any joined path whose components
+    // include `..`, since a lexical `starts_with` alone would accept
+    // `minions/../escape.lock`. Done on the constructed path (no filesystem
+    // touch) so traversal is caught before we open anything.
+    use std::path::Component;
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Minion lock path would escape {}", minions_dir.display()),
+        ));
+    }
+    if !path.starts_with(&minions_dir) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Minion lock path would escape {}", minions_dir.display()),
+        ));
+    }
+    Ok(path)
 }
 
 /// RAII guard holding an exclusive advisory lock on a per-minion lockfile.
@@ -70,7 +112,10 @@ impl MinionLock {
     /// directory rather than the global workspace. Used by unit tests to
     /// avoid clashing with the real `~/.gru/state/minions/`.
     pub(crate) fn try_acquire_in_dir(state_dir: &Path, minion_id: &str) -> Result<Self> {
-        let path = lock_path(state_dir, minion_id);
+        validate_minion_id(minion_id)
+            .with_context(|| format!("Invalid minion ID for lock: {minion_id:?}"))?;
+        let path = lock_path(state_dir, minion_id)
+            .with_context(|| format!("Failed to resolve lock path for {minion_id:?}"))?;
 
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
@@ -157,6 +202,66 @@ mod tests {
     }
 
     #[test]
+    fn rejects_minion_ids_that_could_escape_state_dir() {
+        let tmp = tempdir().unwrap();
+        let minions_dir = tmp.path().join(MINION_LOCKS_SUBDIR);
+
+        // Each of these would either traverse out of minions/ or drop a lockfile
+        // at an attacker-chosen path. All must be rejected before open(2).
+        let bad_ids = [
+            "",                     // empty
+            "..",                   // parent dir
+            "../escape",            // traversal
+            "foo/../../etc/passwd", // embedded traversal
+            "a/b",                  // forward slash
+            r"a\b",                 // backslash (Windows separator)
+            "null\0byte",           // NUL byte
+        ];
+
+        for id in bad_ids {
+            let err = MinionLock::try_acquire_in_dir(tmp.path(), id).unwrap_err_or_else(id);
+            let msg = format!("{:#}", err);
+            assert!(
+                msg.contains("invalid characters") || msg.contains("escape"),
+                "expected rejection for {id:?}, got: {msg}"
+            );
+        }
+
+        // The minions/ directory should never have been written to since every
+        // input was rejected before create_dir_all ran.
+        assert!(
+            !minions_dir.exists(),
+            "no lockfiles should have been created for invalid IDs"
+        );
+    }
+
+    /// Test helper: like `Result::unwrap_err`, but annotates the panic with the
+    /// input that was expected to fail.
+    trait UnwrapErrOrElse {
+        type Err;
+        fn unwrap_err_or_else(self, label: &str) -> Self::Err;
+    }
+    impl<T: std::fmt::Debug, E> UnwrapErrOrElse for std::result::Result<T, E> {
+        type Err = E;
+        fn unwrap_err_or_else(self, label: &str) -> E {
+            match self {
+                Ok(v) => panic!("expected error for input {label:?}, got Ok({v:?})"),
+                Err(e) => e,
+            }
+        }
+    }
+
+    #[test]
+    fn lock_path_rejects_traversal_even_if_validation_skipped() {
+        let tmp = tempdir().unwrap();
+        // Direct call into lock_path with a pathological ID — simulates a future
+        // refactor that accidentally skips `validate_minion_id`. The containment
+        // check must still catch the traversal.
+        let err = lock_path(tmp.path(), "../escape").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
     fn second_acquire_fails_with_lock_contention() {
         let tmp = tempdir().unwrap();
         let _first = MinionLock::try_acquire_in_dir(tmp.path(), "M001").unwrap();
@@ -219,7 +324,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let _holder = MinionLock::try_acquire_in_dir(tmp.path(), "M077").unwrap();
 
-        let path = lock_path(tmp.path(), "M077");
+        let path = lock_path(tmp.path(), "M077").unwrap();
         let contender = OpenOptions::new()
             .read(true)
             .write(true)

--- a/src/minion_lock.rs
+++ b/src/minion_lock.rs
@@ -1,0 +1,294 @@
+//! Per-minion advisory lockfile for defence-in-depth against duplicate agent
+//! subprocesses.
+//!
+//! The registry-level check in `session_claim::check_and_claim_session` is the
+//! primary mechanism that prevents two processes from running an agent against
+//! the same minion session. This module adds a kernel-enforced advisory lock
+//! that holds for the lifetime of the owning process, so any future registry
+//! bug (bad mode transition, stale PID not detected, concurrent write race in
+//! the JSON file) still cannot produce two live agent subprocesses for the
+//! same minion.
+//!
+//! Acquire the lock in the three process entry points that spawn an agent:
+//!   - `fix::run_worker` (the background worker for `gru do`).
+//!   - `resume::run_resume_pipeline` (for `gru resume`).
+//!   - `attach::handle_attach`, just before spawning the interactive agent.
+//!
+//! The lock is released automatically on normal exit, panic, or SIGKILL — the
+//! kernel drops the file lock when the fd is closed, so no shutdown handler is
+//! required.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use fs2::FileExt;
+
+use crate::session_claim::SessionClaimError;
+use crate::workspace::Workspace;
+
+/// Subdirectory under `~/.gru/state/` holding per-minion lockfiles.
+const MINION_LOCKS_SUBDIR: &str = "minions";
+
+/// Computes the lockfile path `<state>/minions/<minion_id>.lock`.
+fn lock_path(state_dir: &Path, minion_id: &str) -> PathBuf {
+    state_dir
+        .join(MINION_LOCKS_SUBDIR)
+        .join(format!("{minion_id}.lock"))
+}
+
+/// RAII guard holding an exclusive advisory lock on a per-minion lockfile.
+///
+/// When this guard is dropped the kernel releases the lock (via fd close).
+/// Holding the fd is what enforces the lock — callers should keep this guard
+/// alive for as long as they own the minion's agent process.
+pub(crate) struct MinionLock {
+    // Held only for its Drop impl / underlying fd; not otherwise accessed.
+    #[allow(dead_code)]
+    file: File,
+    minion_id: String,
+    path: PathBuf,
+}
+
+impl MinionLock {
+    /// Attempts to acquire an exclusive non-blocking lock on
+    /// `~/.gru/state/minions/<minion_id>.lock`.
+    ///
+    /// Returns [`SessionClaimError::AlreadyRunning`] (with mode unknown, set
+    /// to [`MinionMode::Autonomous`](crate::minion_registry::MinionMode::Autonomous))
+    /// if another process already holds the lock. Other IO failures propagate
+    /// as [`anyhow::Error`].
+    pub(crate) fn try_acquire(minion_id: &str) -> Result<Self> {
+        let ws = Workspace::global().context("Failed to initialize workspace for minion lock")?;
+        Self::try_acquire_in_dir(ws.state(), minion_id)
+    }
+
+    /// Test-friendly variant that acquires the lock under an explicit state
+    /// directory rather than the global workspace. Used by unit tests to
+    /// avoid clashing with the real `~/.gru/state/minions/`.
+    pub(crate) fn try_acquire_in_dir(state_dir: &Path, minion_id: &str) -> Result<Self> {
+        let path = lock_path(state_dir, minion_id);
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create lock directory {}", parent.display()))?;
+        }
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .with_context(|| format!("Failed to open minion lock file {}", path.display()))?;
+
+        match file.try_lock_exclusive() {
+            Ok(()) => Ok(MinionLock {
+                file,
+                minion_id: minion_id.to_string(),
+                path,
+            }),
+            Err(e) if is_lock_contention(&e) => Err(SessionClaimError::AlreadyRunning {
+                minion_id: minion_id.to_string(),
+                mode: crate::minion_registry::MinionMode::Autonomous,
+            }
+            .into()),
+            Err(e) => Err(anyhow::Error::new(e)
+                .context(format!("Failed to acquire minion lock {}", path.display()))),
+        }
+    }
+
+    /// The minion ID associated with this lock (for diagnostics / tests).
+    #[cfg(test)]
+    pub(crate) fn minion_id(&self) -> &str {
+        &self.minion_id
+    }
+
+    /// The path of the lockfile (for diagnostics / tests).
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl std::fmt::Debug for MinionLock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MinionLock")
+            .field("minion_id", &self.minion_id)
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+/// Returns true if the error represents lock contention (file already locked).
+///
+/// Mirrors the detection logic in [`crate::file_lock`] — kept local so this
+/// module can be used without pulling in the registry-level locking helpers.
+fn is_lock_contention(e: &io::Error) -> bool {
+    if matches!(e.kind(), io::ErrorKind::WouldBlock) {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        if e.raw_os_error() == Some(libc::EAGAIN) || e.raw_os_error() == Some(libc::EWOULDBLOCK) {
+            return true;
+        }
+    }
+    #[cfg(windows)]
+    if e.kind() == io::ErrorKind::PermissionDenied {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn acquire_succeeds_on_first_call() {
+        let tmp = tempdir().unwrap();
+        let lock = MinionLock::try_acquire_in_dir(tmp.path(), "M001").unwrap();
+        assert_eq!(lock.minion_id(), "M001");
+        assert!(lock.path().exists(), "lockfile should be created on disk");
+    }
+
+    #[test]
+    fn second_acquire_fails_with_already_running() {
+        let tmp = tempdir().unwrap();
+        let _first = MinionLock::try_acquire_in_dir(tmp.path(), "M001").unwrap();
+
+        let err = MinionLock::try_acquire_in_dir(tmp.path(), "M001").unwrap_err();
+        let claim = err
+            .downcast_ref::<SessionClaimError>()
+            .expect("second acquire must surface SessionClaimError::AlreadyRunning");
+        let SessionClaimError::AlreadyRunning { minion_id, .. } = claim;
+        assert_eq!(minion_id, "M001");
+    }
+
+    #[test]
+    fn drop_releases_lock() {
+        let tmp = tempdir().unwrap();
+        {
+            let _lock = MinionLock::try_acquire_in_dir(tmp.path(), "M001").unwrap();
+            // Lock held inside this scope.
+        }
+        // After drop, a fresh acquire should succeed.
+        let _lock2 = MinionLock::try_acquire_in_dir(tmp.path(), "M001")
+            .expect("lock should be reacquirable after drop");
+    }
+
+    #[test]
+    fn different_minions_do_not_conflict() {
+        let tmp = tempdir().unwrap();
+        let _a = MinionLock::try_acquire_in_dir(tmp.path(), "M001").unwrap();
+        // A different minion ID must not be blocked by M001's lock.
+        let _b = MinionLock::try_acquire_in_dir(tmp.path(), "M002").unwrap();
+    }
+
+    #[test]
+    fn lock_directory_is_created_lazily() {
+        let tmp = tempdir().unwrap();
+        let minions_dir = tmp.path().join(MINION_LOCKS_SUBDIR);
+        assert!(
+            !minions_dir.exists(),
+            "precondition: minions/ does not yet exist"
+        );
+
+        let _lock = MinionLock::try_acquire_in_dir(tmp.path(), "M042").unwrap();
+        assert!(
+            minions_dir.is_dir(),
+            "minions/ must be created on first acquire"
+        );
+    }
+
+    #[test]
+    fn lock_across_processes_is_simulated_by_separate_fds() {
+        // fs2 file locks are per-fd on the OS, so reopening the same path and
+        // calling try_lock_exclusive is equivalent to another process trying
+        // to take the lock. This exercises the same code path as the
+        // "concurrent worker" integration test at a unit-test level.
+        let tmp = tempdir().unwrap();
+        let _holder = MinionLock::try_acquire_in_dir(tmp.path(), "M077").unwrap();
+
+        let path = lock_path(tmp.path(), "M077");
+        let contender = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+
+        let err = contender
+            .try_lock_exclusive()
+            .expect_err("contender must not be able to lock held file");
+        assert!(is_lock_contention(&err), "unexpected error kind: {err}");
+    }
+
+    /// Integration-style test (acceptance criterion for issue #865): spawn
+    /// multiple concurrent workers against the same minion and confirm
+    /// exactly one acquires the lock while the others fail with
+    /// `SessionClaimError::AlreadyRunning`.
+    ///
+    /// Uses real OS threads rather than tokio tasks so each acquisition
+    /// runs in parallel on distinct file descriptors (fs2 uses flock(2) on
+    /// Unix, which is per-OFD — two opens from the same process still
+    /// contend, so this models real cross-process behaviour).
+    #[test]
+    fn concurrent_workers_only_one_proceeds() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let tmp = tempdir().unwrap();
+        let state_dir = tmp.path().to_path_buf();
+        const WORKERS: usize = 8;
+        let barrier = Arc::new(Barrier::new(WORKERS));
+
+        let handles: Vec<_> = (0..WORKERS)
+            .map(|_| {
+                let state_dir = state_dir.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || -> Result<MinionLock> {
+                    barrier.wait();
+                    MinionLock::try_acquire_in_dir(&state_dir, "M100")
+                })
+            })
+            .collect();
+
+        let mut acquired = 0;
+        let mut already_running = 0;
+        let mut other_err = 0;
+
+        // Keep the winning lock alive until all contenders have been inspected
+        // so that a slow thread doesn't racily succeed after the winner drops.
+        let mut winners: Vec<MinionLock> = Vec::new();
+
+        for h in handles {
+            match h.join().expect("worker thread panicked") {
+                Ok(lock) => {
+                    winners.push(lock);
+                    acquired += 1;
+                }
+                Err(e) if e.downcast_ref::<SessionClaimError>().is_some() => {
+                    already_running += 1;
+                }
+                Err(_) => other_err += 1,
+            }
+        }
+
+        assert_eq!(
+            acquired, 1,
+            "exactly one worker must acquire the lock (got {acquired})"
+        );
+        assert_eq!(
+            already_running,
+            WORKERS - 1,
+            "the remaining workers must surface AlreadyRunning (got {already_running})"
+        );
+        assert_eq!(
+            other_err, 0,
+            "no worker should fail with an unexpected error"
+        );
+    }
+}

--- a/src/minion_lock.rs
+++ b/src/minion_lock.rs
@@ -10,9 +10,16 @@
 //! same minion.
 //!
 //! Acquire the lock in the three process entry points that spawn an agent:
-//!   - `fix::run_worker` (the background worker for `gru do`).
-//!   - `resume::run_resume_pipeline` (for `gru resume`).
-//!   - `attach::handle_attach`, just before spawning the interactive agent.
+//!   - `fix::run_worker` (the background worker for `gru do`) — acquired at
+//!     the top of the worker function, *before* any registry interaction, so
+//!     contention short-circuits with `EXIT_ALREADY_RUNNING` without mutating
+//!     any shared state.
+//!   - `resume::check_resumption_preconditions` (for `gru resume`) — acquired
+//!     *before* the registry claim, then carried through `ResumeContext` into
+//!     `run_resume_pipeline` so the guard lives for the full pipeline.
+//!   - `attach::handle_attach`, just before spawning the interactive agent —
+//!     acquired *after* the registry claim (so the `mode == Autonomous`
+//!     auto-stop branch can dislodge a running owner before retrying).
 //!
 //! The lock is released automatically on normal exit, panic, or SIGKILL — the
 //! kernel drops the file lock when the fd is closed, so no shutdown handler is

--- a/src/session_claim.rs
+++ b/src/session_claim.rs
@@ -5,8 +5,16 @@ use chrono::Utc;
 /// Typed errors from session-claim operations (shared by attach and resume).
 #[derive(Debug)]
 pub(crate) enum SessionClaimError {
-    /// The minion has a live process — user must stop it first.
+    /// The registry says the minion has a live process — user must stop it first.
+    /// Carries the registry-recorded mode so callers (`gru attach`) can decide
+    /// whether to auto-stop an autonomous owner before taking over.
     AlreadyRunning { minion_id: String, mode: MinionMode },
+    /// Another process holds the per-minion advisory lockfile (issue #865).
+    /// Surfaced from [`MinionLock::try_acquire`](crate::minion_lock::MinionLock::try_acquire).
+    /// Distinct from [`AlreadyRunning`](Self::AlreadyRunning) because the registry
+    /// mode is unknown at the point of contention — the lock-holder owns both
+    /// the file lock and the authoritative registry state.
+    LockContention { minion_id: String },
 }
 
 impl std::fmt::Display for SessionClaimError {
@@ -17,6 +25,14 @@ impl std::fmt::Display for SessionClaimError {
                     f,
                     "Minion {} is already running (mode: {}). Stop it first with: gru stop {}",
                     minion_id, mode, minion_id
+                )
+            }
+            SessionClaimError::LockContention { minion_id } => {
+                write!(
+                    f,
+                    "Minion {} already has a live owner (advisory lock held). \
+                     Stop it first with: gru stop {}",
+                    minion_id, minion_id
                 )
             }
         }
@@ -266,6 +282,27 @@ mod tests {
         assert!(err.downcast_ref::<SessionClaimError>().is_some());
     }
 
+    #[test]
+    fn test_session_claim_error_display_lock_contention() {
+        let err = SessionClaimError::LockContention {
+            minion_id: "M042".to_string(),
+        };
+        let msg = format!("{}", err);
+        // Must NOT include a fabricated registry mode (issue #865 review feedback).
+        assert!(!msg.contains("mode:"), "unexpected mode in message: {msg}");
+        assert!(msg.contains("advisory lock held"));
+        assert!(msg.contains("gru stop M042"));
+    }
+
+    #[test]
+    fn test_session_claim_error_lock_contention_downcastable() {
+        let err: anyhow::Error = SessionClaimError::LockContention {
+            minion_id: "M042".to_string(),
+        }
+        .into();
+        assert!(err.downcast_ref::<SessionClaimError>().is_some());
+    }
+
     // --- Async tests for check_and_claim_session ---
 
     /// Helper: register a minion directly in a temp-dir registry.
@@ -329,9 +366,13 @@ mod tests {
         .unwrap_err();
 
         let claim_err = err.downcast_ref::<SessionClaimError>().unwrap();
-        let SessionClaimError::AlreadyRunning { minion_id, mode } = claim_err;
-        assert_eq!(minion_id, "M001");
-        assert_eq!(*mode, MinionMode::Autonomous);
+        match claim_err {
+            SessionClaimError::AlreadyRunning { minion_id, mode } => {
+                assert_eq!(minion_id, "M001");
+                assert_eq!(*mode, MinionMode::Autonomous);
+            }
+            other => panic!("expected AlreadyRunning, got {:?}", other),
+        }
 
         // Registry should be unchanged
         let unchanged = read_minion(tmp.path(), "M001").unwrap();


### PR DESCRIPTION
## Summary
- Adds `src/minion_lock.rs`, a per-minion advisory lockfile at `~/.gru/state/minions/<minion_id>.lock` acquired via `fs2`/`flock` and held for the lifetime of the owning process. The kernel releases it automatically on normal exit, panic, or SIGKILL (fd close).
- Acquires the lock in the three entry points that spawn an agent:
  - `fix::run_worker` (background worker for `gru do`) — early, before any registry interaction.
  - `resume::check_resumption_preconditions` (carried through `ResumeContext` into `run_resume_pipeline`).
  - `attach::handle_attach`, just before spawning the agent (after the auto-stop retry path so a killed autonomous minion has released its own fd).
- On contention, surfaces a new `SessionClaimError::LockContention { minion_id }` variant (distinct from the existing `SessionClaimError::AlreadyRunning` emitted by the registry-level claim, so the two layers keep separate error taxonomies). `gru do` and `gru resume` both downcast any `SessionClaimError` and exit `EXIT_ALREADY_RUNNING` (3), letting lab short-circuit retries consistently regardless of whether the registry check or the advisory lock caught it.
- `handle_attach` explicitly drops the lock before handing off to `handle_resume` for auto-resume, since `fs2`'s flock is per-OFD — a same-process re-open on the same file still blocks.
- Minion IDs are validated before being used in the lockfile path (rejects `/`, `\`, `..`, NUL, empty), mirroring `workspace::archive_dir`. `lock_path` additionally walks the joined path's components and rejects any `ParentDir`, so a refactor that skips `validate_minion_id` still can't escape `<state>/minions/`.
- `handle_attach` tracks `claimed_registry` across its error paths: `revert_to_stopped` only runs when `check_and_claim_session` actually wrote to the registry (skipped under `graceful=true` `Ok(None)`, covering both "not in registry" and "transient registry failure"). Applied uniformly to every post-claim error arm, including advisory-lock acquisition failure.

This is the defence-in-depth layer called for in #862 on top of the primary registry fix (#863 / c902ec2). Any future registry bug (bad mode transition, stale PID not detected, concurrent write race in `minions.json`) is still caught by the kernel-level lock, so duplicate agent subprocesses against the same minion become structurally impossible.

## Test plan
- `just check` passes (1358 tests, fmt, clippy, build).
- New tests in `src/minion_lock.rs`:
  - `acquire_succeeds_on_first_call`
  - `second_acquire_fails_with_lock_contention` (downcast to `SessionClaimError::LockContention`; asserts no fabricated `mode:` in Display)
  - `drop_releases_lock`
  - `different_minions_do_not_conflict`
  - `lock_directory_is_created_lazily`
  - `lock_across_processes_is_simulated_by_separate_fds` (same-OFD contention)
  - `rejects_minion_ids_that_could_escape_state_dir` — seven malicious IDs; asserts the `minions/` directory is never created
  - `lock_path_rejects_traversal_even_if_validation_skipped` — proves the component-walk containment is a real second line of defence
  - `concurrent_workers_only_one_proceeds` — the acceptance test from the issue: 8 OS threads synchronize on a `Barrier` and race `try_acquire_in_dir` against the same minion ID; exactly one acquires, the other seven fail with `SessionClaimError::LockContention`.
- New tests in `src/session_claim.rs`:
  - `test_session_claim_error_display_lock_contention` — asserts the message does NOT contain `mode:` (no fabricated registry mode).
  - `test_session_claim_error_lock_contention_downcastable`.

## Notes
- CLAUDE.md's Filesystem Layout section is updated to document the new `state/minions/<minion_id>.lock` directory, per the project's Documentation Maintenance rule.
- Error taxonomy: `SessionClaimError::AlreadyRunning { minion_id, mode }` is emitted by the registry-level claim and carries the recorded mode so `attach`'s auto-stop branch can read it. `SessionClaimError::LockContention { minion_id }` is emitted only by `MinionLock::try_acquire` and intentionally omits a mode field — the advisory lock doesn't know the registry mode, and fabricating one would mislead the `Display` message and risk routing kernel-lock contention into the auto-stop path.
- Acceptance criteria from the issue:
  - [x] Lock acquired at process startup, held for the lifetime of the worker/resume/attach process.
  - [x] Lock released automatically on normal exit, panic, or SIGKILL (kernel releases on fd close).
  - [x] Concurrent `gru resume` / `gru attach` on the same minion fails fast with a clear error.
  - [x] Integration test confirms exactly one of several simultaneous workers proceeds.

Fixes #865

<sub>🤖 M1jd</sub>