### PR TITLE
Fixes #873: Auto-rebase agent runs without /rebase skill available, silently no-ops

### DIFF
--- a/src/commands/fix/monitor.rs
+++ b/src/commands/fix/monitor.rs
@@ -121,7 +121,13 @@ enum AutoRebaseResult {
 }
 
 /// Attempts to auto-rebase the worktree branch onto its base branch.
-async fn auto_rebase_pr(worktree_path: &Path) -> Result<AutoRebaseResult> {
+///
+/// `checkout_path` is the git worktree where all git operations and the
+/// conflict-resolution agent run. `minion_dir` is the parent metadata
+/// directory where `events.jsonl` is written — passing it explicitly keeps
+/// the rebase agent's stream events co-located with the main agent's
+/// events instead of landing inside the checkout.
+async fn auto_rebase_pr(checkout_path: &Path, minion_dir: &Path) -> Result<AutoRebaseResult> {
     use super::super::rebase::{
         abort_rebase, attempt_rebase, check_clean_worktree, detect_base_branch, ensure_on_branch,
         fetch_base_branch, force_push, get_current_branch, is_rebase_in_progress, is_up_to_date,
@@ -131,28 +137,28 @@ async fn auto_rebase_pr(worktree_path: &Path) -> Result<AutoRebaseResult> {
     // Abort any stale in-progress rebase left by a previous crashed attempt.
     // This must happen before check_clean_worktree because UU files from a
     // stale rebase would otherwise cause a false "uncommitted changes" error.
-    if is_rebase_in_progress(worktree_path) {
+    if is_rebase_in_progress(checkout_path) {
         log::warn!("⚠️  Stale in-progress rebase detected; aborting before retrying");
         println!("⚠️  Aborting stale in-progress rebase...");
-        abort_rebase(worktree_path).await?;
+        abort_rebase(checkout_path).await?;
     }
 
     // Bail early if worktree has uncommitted changes (e.g., agent crashed mid-edit)
-    check_clean_worktree(worktree_path)
+    check_clean_worktree(checkout_path)
         .await
         .context("Cannot auto-rebase: worktree has uncommitted changes")?;
 
     // Detect the base branch first so we can fetch only what we need
-    let base_branch = detect_base_branch(worktree_path).await?;
+    let base_branch = detect_base_branch(checkout_path).await?;
 
     // Fetch only the base branch to avoid conflicts with other worktrees that
     // have different branches checked out on the same repo
     println!("📡 Fetching latest changes from origin...");
-    fetch_base_branch(worktree_path, &base_branch).await?;
+    fetch_base_branch(checkout_path, &base_branch).await?;
 
     // Short-circuit if already up-to-date (avoids no-op rebase + force-push
     // that would reset GitHub's mergeable cache timer)
-    if is_up_to_date(worktree_path, &base_branch).await? {
+    if is_up_to_date(checkout_path, &base_branch).await? {
         println!(
             "✅ Already up-to-date with origin/{}, skipping rebase",
             base_branch
@@ -163,7 +169,7 @@ async fn auto_rebase_pr(worktree_path: &Path) -> Result<AutoRebaseResult> {
     println!("🔄 Rebasing onto origin/{}...", base_branch);
 
     // Attempt the rebase
-    match attempt_rebase(worktree_path, &base_branch).await? {
+    match attempt_rebase(checkout_path, &base_branch).await? {
         RebaseOutcome::Clean { commit_count } => {
             println!(
                 "✅ Clean rebase: {} commit{} replayed",
@@ -171,26 +177,26 @@ async fn auto_rebase_pr(worktree_path: &Path) -> Result<AutoRebaseResult> {
                 if commit_count == 1 { "" } else { "s" }
             );
             log::info!("Auto force-pushing rebased branch (autonomous mode, --force-with-lease)");
-            force_push(worktree_path).await?;
+            force_push(checkout_path).await?;
             println!("🚀 Force-pushed rebased branch");
             Ok(AutoRebaseResult::RebasedAndPushed)
         }
         RebaseOutcome::Conflicts => {
             println!("⚠️  Conflicts detected, launching agent to resolve...");
-            abort_rebase(worktree_path).await?;
+            abort_rebase(checkout_path).await?;
 
             // Capture local branch name now (abort_rebase restores it) so we can
             // recover if the agent leaves the worktree in detached HEAD state.
-            let local_branch = get_current_branch(worktree_path).await?;
+            let local_branch = get_current_branch(checkout_path).await?;
 
             // None uses the 30m default inside run_agent_rebase
-            let exit_code = run_agent_rebase(worktree_path, None).await?;
+            let exit_code = run_agent_rebase(checkout_path, minion_dir, &base_branch, None).await?;
 
             // Defensive check: agent may have checked out a remote tracking ref
             // (e.g. `origin/<branch>`) leaving the worktree in detached HEAD.
             // Treat a recovery failure as ConflictUnresolved rather than an
             // unexpected error so the caller receives an actionable escalation.
-            if let Err(err) = ensure_on_branch(worktree_path, &local_branch).await {
+            if let Err(err) = ensure_on_branch(checkout_path, &local_branch).await {
                 log::warn!(
                     "Agent rebase finished but failed to restore local branch '{}': {}",
                     local_branch,
@@ -212,7 +218,7 @@ async fn auto_rebase_pr(worktree_path: &Path) -> Result<AutoRebaseResult> {
                 // incomplete rebase.
                 let tracked_status = TokioCommand::new("git")
                     .arg("-C")
-                    .arg(worktree_path)
+                    .arg(checkout_path)
                     .args(["status", "--porcelain", "--untracked-files=no"])
                     .output()
                     .await
@@ -235,16 +241,16 @@ async fn auto_rebase_pr(worktree_path: &Path) -> Result<AutoRebaseResult> {
                 }
                 // is_up_to_date checks that origin/<base_branch> is an ancestor of HEAD,
                 // which is the canonical proof that the rebase actually happened.
-                if !is_up_to_date(worktree_path, &base_branch).await? {
+                if !is_up_to_date(checkout_path, &base_branch).await? {
                     log::warn!(
                         "Agent rebase exited 0 but origin/{} is not an ancestor of HEAD — rebase did not complete",
                         base_branch
                     );
                     return Ok(AutoRebaseResult::ConflictUnresolved);
                 }
-                // Defensively force push in case the /rebase skill didn't push
+                // Defensively force push in case the rebase agent didn't push.
                 log::info!("Auto force-pushing after conflict resolution (autonomous mode, --force-with-lease)");
-                force_push(worktree_path).await?;
+                force_push(checkout_path).await?;
                 println!("🚀 Force-pushed rebased branch");
                 Ok(AutoRebaseResult::RebasedAndPushed)
             } else {
@@ -1279,7 +1285,7 @@ async fn handle_merge_conflict(
         ctx.pr_number, state.rebase_attempts, MAX_REBASE_ATTEMPTS
     );
 
-    match auto_rebase_pr(&ctx.wt_ctx.checkout_path).await {
+    match auto_rebase_pr(&ctx.wt_ctx.checkout_path, &ctx.wt_ctx.minion_dir).await {
         Ok(AutoRebaseResult::RebasedAndPushed) => {
             // Reset counter on success — GitHub may still report
             // mergeable: false for a few poll cycles after force-push

--- a/src/commands/rebase.rs
+++ b/src/commands/rebase.rs
@@ -82,8 +82,15 @@ pub(crate) async fn handle_rebase(
             // recover if the agent leaves the worktree in detached HEAD state.
             let local_branch = get_current_branch(&worktree_path).await?;
 
-            // Spawn Claude Code with /rebase command
-            let exit_code = run_agent_rebase(&worktree_path, timeout).await?;
+            // Spawn Claude Code with inlined rebase instructions.
+            //
+            // events.jsonl lives in the minion metadata directory
+            // (<minion_dir>/events.jsonl), not inside the git checkout. For
+            // the CLI path we derive it from the worktree path so the rebase
+            // session's events land next to the main agent's events.
+            let events_dir = derive_events_dir(&worktree_path);
+            let exit_code =
+                run_agent_rebase(&worktree_path, &events_dir, &base_branch, timeout).await?;
 
             if exit_code == 0 {
                 // Agent succeeded: enforce branch recovery (any failure is a real error).
@@ -749,21 +756,64 @@ pub(crate) async fn force_push(worktree_path: &Path) -> Result<()> {
 /// Default timeout for agent conflict resolution (30 minutes).
 const DEFAULT_CONFLICT_TIMEOUT: &str = "30m";
 
-/// Spawns the agent with the `/rebase` command to resolve conflicts.
+/// Inlined rebase instructions sent to the agent as the prompt.
+///
+/// Passing an explicit prompt (rather than `/rebase`) makes the rebase agent
+/// independent of slash-command / skill discovery from the target project's
+/// `.claude/` directory. Without this, the agent silently no-ops on any repo
+/// that isn't the Gru source tree itself (see issue #873).
+///
+/// The `<BASE_BRANCH>` marker is substituted with the resolved base branch
+/// at runtime.
+const REBASE_PROMPT_TEMPLATE: &str = include_str!("rebase_prompt.md");
+
+/// Derives the minion metadata directory from a git checkout path.
+///
+/// New-layout worktrees live in `<minion_dir>/checkout/`, so the parent of
+/// the checkout path is the minion directory where `events.jsonl` and other
+/// metadata live. Legacy-layout worktrees put the checkout directly at the
+/// minion directory, in which case we return the checkout path itself.
+///
+/// The parent lookup is gated on the directory name being literally
+/// `checkout` to avoid accidentally climbing one level too high on legacy
+/// layouts where the checkout directory happens to have a `.git` marker
+/// but is not named `checkout`.
+pub(crate) fn derive_events_dir(checkout_path: &Path) -> PathBuf {
+    if checkout_path.file_name().and_then(|s| s.to_str()) == Some("checkout") {
+        if let Some(parent) = checkout_path.parent() {
+            return parent.to_path_buf();
+        }
+    }
+    checkout_path.to_path_buf()
+}
+
+/// Spawns the agent with inlined rebase instructions to resolve conflicts.
+///
+/// `checkout_path` is the git worktree where the agent runs (its `cwd`).
+/// `events_dir` is the directory where `events.jsonl` is written; this is
+/// typically the minion metadata directory (one level above `checkout/`)
+/// so the rebase session's events sit alongside the main agent's events.
 ///
 /// Uses a 30-minute default timeout if none is provided.
 /// Returns the agent's exit code.
-pub(crate) async fn run_agent_rebase(worktree_path: &Path, timeout: Option<&str>) -> Result<i32> {
+pub(crate) async fn run_agent_rebase(
+    checkout_path: &Path,
+    events_dir: &Path,
+    base_branch: &str,
+    timeout: Option<&str>,
+) -> Result<i32> {
     let backend = agent_registry::resolve_backend(agent_registry::DEFAULT_AGENT)?;
     let session_id = Uuid::new_v4();
-    let github_host = super::resume::resolve_host_from_worktree(worktree_path, "").await;
-    let cmd = backend.build_command(worktree_path, &session_id, "/rebase", &github_host);
+    let github_host = super::resume::resolve_host_from_worktree(checkout_path, "").await;
+
+    let prompt = REBASE_PROMPT_TEMPLATE.replace("<BASE_BRANCH>", base_branch);
+    let cmd = backend.build_command(checkout_path, &session_id, &prompt, &github_host);
 
     let effective_timeout = Some(timeout.unwrap_or(DEFAULT_CONFLICT_TIMEOUT));
     let result = run_agent_with_stream_monitoring(
         cmd,
         &*backend,
-        worktree_path,
+        events_dir,
         effective_timeout,
         None::<fn(&AgentEvent)>, // no output callback
         None,                    // no on_spawn callback
@@ -785,6 +835,85 @@ mod tests {
         let dir = tempfile::tempdir().expect("create temp dir");
         fs::create_dir_all(dir.path().join(".git")).expect("create .git dir");
         dir
+    }
+
+    #[test]
+    fn test_rebase_prompt_template_substitutes_base_branch() {
+        let prompt = REBASE_PROMPT_TEMPLATE.replace("<BASE_BRANCH>", "main");
+        assert!(
+            !prompt.contains("<BASE_BRANCH>"),
+            "every occurrence of the placeholder must be substituted"
+        );
+        assert!(
+            prompt.contains("origin/main"),
+            "substitution must produce origin/<base_branch>"
+        );
+
+        // Sanity-check with a non-trivial branch name (slashes, case).
+        let prompt_release = REBASE_PROMPT_TEMPLATE.replace("<BASE_BRANCH>", "release/1.0");
+        assert!(prompt_release.contains("origin/release/1.0"));
+    }
+
+    #[test]
+    fn test_rebase_prompt_template_has_post_condition() {
+        // The prompt must include an explicit post-condition that the agent
+        // MUST verify before exiting successfully. Without this, an agent
+        // that sees a clean worktree post-abort and does nothing will exit 0
+        // and silently fail the rebase.
+        assert!(
+            REBASE_PROMPT_TEMPLATE.contains("git merge-base --is-ancestor"),
+            "prompt must include the ancestor post-condition check"
+        );
+        // Must also instruct the agent to abort cleanly on inability to finish,
+        // so the caller's recovery logic isn't left with a half-rebased worktree.
+        assert!(
+            REBASE_PROMPT_TEMPLATE.contains("git rebase --abort"),
+            "prompt must instruct the agent to abort cleanly on failure"
+        );
+    }
+
+    #[test]
+    fn test_rebase_prompt_is_not_a_slash_command() {
+        // Guard against regression to the pre-#873 bug where `/rebase` was
+        // passed as the prompt. The agent must receive an inline instruction
+        // rather than a slash command reference, because target-repo
+        // worktrees don't have Gru's .claude/ skills available.
+        assert!(
+            !REBASE_PROMPT_TEMPLATE.trim_start().starts_with('/'),
+            "prompt must be inline instructions, not a slash command"
+        );
+    }
+
+    #[test]
+    fn test_derive_events_dir_new_layout() {
+        let minion_dir = PathBuf::from("/some/work/minion/issue-42-M001");
+        let checkout = minion_dir.join("checkout");
+        assert_eq!(derive_events_dir(&checkout), minion_dir);
+    }
+
+    #[test]
+    fn test_derive_events_dir_legacy_layout() {
+        // Legacy worktrees put the git checkout directly at the minion dir
+        // (no `checkout/` subdir). derive_events_dir must return the path
+        // unchanged so events.jsonl lands next to the legacy worktree.
+        let legacy = PathBuf::from("/some/work/minion/issue-42-M001");
+        assert_eq!(derive_events_dir(&legacy), legacy);
+    }
+
+    #[test]
+    fn test_derive_events_dir_root_path() {
+        // Defensive: if someone passes "/" as the entire path, we must not
+        // panic. The fallback returns the input path unchanged.
+        let root = PathBuf::from("/");
+        assert_eq!(derive_events_dir(&root), root);
+    }
+
+    #[test]
+    fn test_derive_events_dir_bare_checkout_does_not_panic() {
+        // A bare "checkout" path (no parent components) should not panic;
+        // it returns the empty-path parent that Path::parent() yields.
+        let bare = PathBuf::from("checkout");
+        let _ = derive_events_dir(&bare);
     }
 
     #[test]

--- a/src/commands/rebase.rs
+++ b/src/commands/rebase.rs
@@ -778,10 +778,18 @@ const REBASE_PROMPT_TEMPLATE: &str = include_str!("rebase_prompt.md");
 /// `checkout` to avoid accidentally climbing one level too high on legacy
 /// layouts where the checkout directory happens to have a `.git` marker
 /// but is not named `checkout`.
+///
+/// The empty-path guard protects the pathological `"checkout"` relative-
+/// path case: `Path::parent()` returns `Some("")` for a bare `"checkout"`,
+/// and returning that would silently resolve to the process CWD. Production
+/// callers always pass absolute paths from `workspace.work_dir()`, so this
+/// guard only matters for defensive robustness.
 pub(crate) fn derive_events_dir(checkout_path: &Path) -> PathBuf {
     if checkout_path.file_name().and_then(|s| s.to_str()) == Some("checkout") {
         if let Some(parent) = checkout_path.parent() {
-            return parent.to_path_buf();
+            if !parent.as_os_str().is_empty() {
+                return parent.to_path_buf();
+            }
         }
     }
     checkout_path.to_path_buf()
@@ -909,11 +917,13 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_events_dir_bare_checkout_does_not_panic() {
-        // A bare "checkout" path (no parent components) should not panic;
-        // it returns the empty-path parent that Path::parent() yields.
+    fn test_derive_events_dir_bare_checkout_returns_input() {
+        // A bare "checkout" path has an empty-path parent (`Some("")`).
+        // Returning that would silently resolve to the process CWD at
+        // runtime, so the empty-path guard must fall through and return
+        // the input unchanged.
         let bare = PathBuf::from("checkout");
-        let _ = derive_events_dir(&bare);
+        assert_eq!(derive_events_dir(&bare), bare);
     }
 
     #[test]

--- a/src/commands/rebase_prompt.md
+++ b/src/commands/rebase_prompt.md
@@ -1,0 +1,74 @@
+You are a git rebase assistant. Your job is to rebase the current branch onto
+`origin/<BASE_BRANCH>` and intelligently resolve any merge conflicts that
+arise. The repository has already been fetched and the base branch is
+`<BASE_BRANCH>`; you may assume `origin/<BASE_BRANCH>` is up-to-date.
+
+## Your task
+
+Run `git rebase origin/<BASE_BRANCH>` and drive it to completion.
+
+If conflicts occur, resolve them using the workflow below. When every
+conflict is resolved and the rebase is complete, verify the post-condition
+and exit. Do not force-push — the caller will handle pushing.
+
+## Conflict resolution workflow
+
+1. Identify the conflicted files with `git status`.
+2. For each conflicted file:
+   - Read the file to see the `<<<<<<< HEAD` / `=======` / `>>>>>>>` markers.
+   - Gather context as needed: `git log --oneline origin/<BASE_BRANCH>..HEAD`
+     for your branch commits, `git log --oneline -10 origin/<BASE_BRANCH>`
+     for recent base-branch changes, and `gh pr view --json baseRefName,title,body`
+     for PR intent (if a PR exists for this branch).
+   - Edit the file to remove conflict markers and produce a coherent
+     resolution. Prefer these strategies:
+     - Independent changes (different regions): keep both.
+     - Refactoring on the base branch (rename, move): adapt your changes to
+       the new structure.
+     - Import/dependency conflicts: merge both sets, deduplicated.
+     - Both sides fixed the same bug: keep the base-branch version.
+     - Logic conflict in the same code path, especially around security or
+       architecture: abort (see below) rather than guess.
+   - `git add <file>` and proceed to the next conflicted file.
+3. When all conflicts in the current step are resolved, run
+   `git rebase --continue`. Repeat until the rebase completes or you hit a
+   conflict you cannot resolve confidently.
+
+## Post-condition (MUST verify before exiting successfully)
+
+Before you exit, run:
+
+```
+git merge-base --is-ancestor origin/<BASE_BRANCH> HEAD
+```
+
+This command must exit 0 — it is the canonical proof that the rebase
+completed and your branch now sits on top of `origin/<BASE_BRANCH>`. If it
+exits non-zero, the rebase is NOT complete and you must NOT signal success.
+
+Also check `git status`: the working tree must be clean (no `UU`, `AA`,
+`DU`, or other unmerged paths) and `git rebase` must not be in progress
+(no `rebase-merge/` or `rebase-apply/` inside `.git/`).
+
+## If you cannot complete the rebase
+
+If you encounter conflicts you cannot resolve with confidence (ambiguous
+logic changes, conflicting security decisions, architectural disagreements):
+
+1. Run `git rebase --abort` so the working tree is returned to a clean
+   state. Leaving a half-finished rebase behind breaks the caller's
+   recovery logic.
+2. Print a clear summary explaining what was unresolvable, which files
+   were affected, and what options exist for a human reviewer.
+3. Exit the conversation. The caller interprets a non-complete rebase
+   (post-condition failing) as an escalation signal regardless of your
+   exit code.
+
+## Do NOT
+
+- Do NOT force-push. The caller will push after verifying the rebase.
+- Do NOT commit files that were not part of the conflict resolution.
+- Do NOT leave conflict markers in any file.
+- Do NOT exit claiming success unless the post-condition above holds.
+- Do NOT switch branches or check out remote tracking refs
+  (`origin/<branch>`). Stay on the local branch you started on.


### PR DESCRIPTION
## Summary
- Inline the rebase instructions as `src/commands/rebase_prompt.md` and
  include them at compile time via `include_str!`. The prompt carries an
  explicit post-condition (`git merge-base --is-ancestor origin/<base>
  HEAD` must exit 0) and a `git rebase --abort` on-failure contract so
  the agent cannot silently exit 0 without having completed the rebase.
- Change `run_agent_rebase` to take `checkout_path`, `events_dir`, and
  `base_branch` explicitly. `events_dir` points at the minion metadata
  directory so `events.jsonl` sits next to the main agent's events
  instead of being dropped inside the git checkout.
- Add `derive_events_dir()` to map the CLI path's worktree to the
  metadata directory (parent when the path ends in `checkout/`,
  unchanged for legacy layouts). Empty-path parent is guarded to avoid
  ever resolving to the process CWD.
- Thread `minion_dir` through `auto_rebase_pr` in
  `src/commands/fix/monitor.rs`.

## Test plan
- `just check` — all 1365 tests pass; formatting and clippy clean.
- New unit tests:
  - `test_rebase_prompt_template_substitutes_base_branch` — verifies the
    `<BASE_BRANCH>` token is substituted (including branch names with
    slashes).
  - `test_rebase_prompt_template_has_post_condition` — guards that the
    prompt contains both the ancestor check and the `git rebase --abort`
    instruction.
  - `test_rebase_prompt_is_not_a_slash_command` — direct regression test
    for issue #873.
  - `test_derive_events_dir_new_layout` / `_legacy_layout` /
    `_root_path` / `_bare_checkout_returns_input` — path-derivation
    coverage.
- Commands run: `just check`, `cargo test commands::rebase`.

## Notes
- The Rust-side ancestor guard at `src/commands/fix/monitor.rs:244-250`
  stays as defense-in-depth. The agent-side post-condition and the
  Rust-side post-condition are now aligned: both check
  `git merge-base --is-ancestor origin/<base> HEAD`.
- The existing `.claude/skills/git-rebase/SKILL.md` in the Gru source
  tree is still kept for users running the interactive `/rebase` slash
  command via Claude Code directly — that codepath is unaffected.
- Fixes all four acceptance criteria in #873:
  - Skill is reachable (inlined into prompt).
  - Prompt has explicit post-condition.
  - Agent completes end-to-end without the "exited 0 but not ancestor"
    warning (when the agent actually runs; still gated by real conflict
    resolvability).
  - `events.jsonl` for the rebase agent session is written to the
    minion metadata directory.

Fixes #873

<sub>🤖 M1k0</sub>