### PR TITLE
Fixes #880: lab auto-recovery: detect repeated resets on the same issue and escalate to gru:blocked instead of looping

### DIFF
--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -83,7 +83,8 @@
 
 # Auto-recovery escalation: when an issue is reset too many times without
 # making forward progress, escalate it to gru:blocked instead of resetting.
-# Remove gru:blocked manually to re-enable automatic retries.
+# Remove gru:blocked and re-add the daemon pickup label (for example
+# gru:todo) manually to re-enable automatic retries.
 #
 # [daemon.auto_recovery]
 # Maximum resets within the window before escalation (0 = disabled, i.e.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -81,6 +81,18 @@
 # machine may hold the issue).
 # recovery_threshold_mins = 30
 
+# Auto-recovery escalation: when an issue is reset too many times without
+# making forward progress, escalate it to gru:blocked instead of resetting.
+# Remove gru:blocked manually to re-enable automatic retries.
+#
+# [daemon.auto_recovery]
+# Maximum resets within the window before escalation (0 = disabled, i.e.
+# reset indefinitely).
+# max_resets = 2
+#
+# Sliding window in hours within which repeated resets are counted.
+# window_hours = 2
+
 # ─────────────────────────────────────────────────────────────────────
 # Agent backend
 # ─────────────────────────────────────────────────────────────────────

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -56,6 +56,59 @@ struct SpawnMeta {
     retry_attempt: u32,
 }
 
+/// Tracks auto-recovery resets per issue to detect thrashing loops.
+///
+/// When the same issue is reset repeatedly within a sliding window, the tracker
+/// signals that it should be escalated to `gru:blocked` instead of being reset
+/// again. Once an issue is escalated, it is remembered until a recovery scan
+/// sees it back in `gru:in-progress` (meaning a human cleared `gru:blocked`
+/// and it was picked up again), at which point its history is cleared.
+struct RecoveryTracker {
+    /// Per-issue timestamps of auto-recovery resets within the tracking window.
+    /// Key: `(full_repo_slug, issue_number)`.
+    resets: HashMap<(String, u64), Vec<Instant>>,
+    /// Issues that were escalated to `gru:blocked` by this tracker.
+    /// Cleared when the issue re-enters `gru:in-progress` (human intervention).
+    escalated: HashSet<(String, u64)>,
+}
+
+impl RecoveryTracker {
+    fn new() -> Self {
+        Self {
+            resets: HashMap::new(),
+            escalated: HashSet::new(),
+        }
+    }
+
+    /// Record a reset for `(repo, issue)` and return the total reset count
+    /// within `window`. Timestamps older than `window` are pruned first.
+    fn record_reset(&mut self, repo: &str, issue: u64, window: Duration) -> usize {
+        let key = (repo.to_string(), issue);
+        let entry = self.resets.entry(key).or_default();
+        let cutoff = Instant::now() - window;
+        entry.retain(|&t| t > cutoff);
+        entry.push(Instant::now());
+        entry.len()
+    }
+
+    /// Mark an issue as escalated to `gru:blocked`.
+    fn mark_escalated(&mut self, repo: &str, issue: u64) {
+        self.escalated.insert((repo.to_string(), issue));
+    }
+
+    /// Returns true if this issue was previously escalated by the tracker.
+    fn is_escalated(&self, repo: &str, issue: u64) -> bool {
+        self.escalated.contains(&(repo.to_string(), issue))
+    }
+
+    /// Clear history and escalation state for an issue (human cleared gru:blocked).
+    fn clear(&mut self, repo: &str, issue: u64) {
+        let key = (repo.to_string(), issue);
+        self.resets.remove(&key);
+        self.escalated.remove(&key);
+    }
+}
+
 /// Handles the lab daemon command
 pub(crate) async fn handle_lab(
     config_path: Option<PathBuf>,
@@ -156,6 +209,7 @@ pub(crate) async fn handle_lab(
     // Skipping a scan on the first main-loop iteration (after the initial startup poll)
     // avoids false positives while minions re-register after a lab restart.
     let mut last_recovery_scan: Option<Instant> = None;
+    let mut recovery_tracker = RecoveryTracker::new();
 
     // Auto-merge sweep timer — same semantics as last_recovery_scan:
     //   None  → first main-loop iteration after startup: set the timer without
@@ -331,7 +385,12 @@ pub(crate) async fn handle_lab(
                         }
                         Some(t) if t.elapsed() >= RECOVERY_SCAN_INTERVAL => {
                             last_recovery_scan = Some(Instant::now());
-                            if let Err(e) = recover_stuck_in_progress_issues(&config).await {
+                            if let Err(e) = recover_stuck_in_progress_issues(
+                                &config,
+                                &mut recovery_tracker,
+                            )
+                            .await
+                            {
                                 log::warn!("⚠️  Recovery scan error: {:#}", e);
                             }
                         }
@@ -2338,11 +2397,22 @@ async fn fallback_list_issues(
 /// configured daemon pickup label (`daemon.label`) with an explanatory comment so
 /// the lab can retry them.
 ///
+/// When an issue has been reset N or more times within the configured window it is
+/// escalated to `gru:blocked` instead, preventing infinite thrash loops. When the
+/// tracker sees a previously-escalated issue back in `gru:in-progress` (indicating
+/// a human cleared `gru:blocked`), the history for that issue is reset.
+///
 /// Per-repo and per-issue errors are logged as warnings and do not abort the scan.
-async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> Result<()> {
+async fn recover_stuck_in_progress_issues(
+    config: &crate::config::LabConfig,
+    tracker: &mut RecoveryTracker,
+) -> Result<()> {
     let threshold_mins = i64::try_from(config.daemon.recovery_threshold_mins)
         .context("daemon.recovery_threshold_mins exceeds the maximum supported value")?;
     let threshold = chrono::Duration::minutes(threshold_mins);
+
+    let max_resets = config.daemon.auto_recovery.max_resets;
+    let window = Duration::from_secs(config.daemon.auto_recovery.window_hours * 3600);
 
     for repo_spec in &config.daemon.repos {
         let Some((host, owner, repo)) =
@@ -2371,6 +2441,19 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
         };
 
         for issue in in_progress {
+            // If this issue was previously escalated to gru:blocked but is now back
+            // in gru:in-progress, a human cleared gru:blocked and it was picked up
+            // again. Clear the history so it gets a fresh slate.
+            if tracker.is_escalated(&full_repo, issue.number) {
+                tprintln!(
+                    "♻️  Recovery: issue #{} in {} is back in-progress after escalation — \
+                     clearing reset history",
+                    issue.number,
+                    repo_spec,
+                );
+                tracker.clear(&full_repo, issue.number);
+            }
+
             // Only reset if the issue has been in-progress for longer than the threshold.
             let age = chrono::Utc::now().signed_duration_since(issue.updated_at);
             if age < threshold {
@@ -2403,50 +2486,119 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
                 }
             }
 
-            // Orphaned issue — reset to the configured pickup label and leave a comment.
-            let ready_label = &config.daemon.label;
-            tprintln!(
-                "🔄 Recovery: resetting orphaned in-progress issue #{} in {} to {} \
-                 (stuck for {}m)",
-                issue.number,
-                repo_spec,
-                ready_label,
-                age.num_minutes(),
-            );
+            // Record this reset and check whether we've exceeded the threshold.
+            // When max_resets == 0, escalation is disabled — always reset.
+            let reset_count = if max_resets > 0 {
+                tracker.record_reset(&full_repo, issue.number, window)
+            } else {
+                0
+            };
 
-            if let Err(e) = github::edit_labels_via_cli(
-                &host,
-                &owner,
-                &repo,
-                issue.number,
-                &[ready_label.as_str()],
-                &[labels::IN_PROGRESS],
-            )
-            .await
-            {
-                log::warn!(
-                    "⚠️  Recovery scan: failed to reset labels for {}/issues/{}: {:#}",
-                    repo_spec,
+            if max_resets > 0 && reset_count > usize::try_from(max_resets).unwrap_or(usize::MAX) {
+                // Too many resets within the window — escalate to gru:blocked.
+                tprintln!(
+                    "🚫 Recovery: escalating issue #{} in {} to {} after {} resets in {}h \
+                     (stuck for {}m)",
                     issue.number,
-                    e
+                    repo_spec,
+                    labels::BLOCKED,
+                    reset_count,
+                    config.daemon.auto_recovery.window_hours,
+                    age.num_minutes(),
                 );
-                continue;
-            }
 
-            let comment = format!(
-                "⚠️ Gru auto-recovery: issue was stuck at `gru:in-progress` with no live \
-                 Minion process. Resetting to `{}` so it can be retried.",
-                ready_label
-            );
-            if let Err(e) =
-                github::post_comment_via_cli(&host, &owner, &repo, issue.number, &comment).await
-            {
-                log::warn!(
-                    "⚠️  Recovery scan: failed to post comment on {}/issues/{}: {:#}",
-                    repo_spec,
+                if let Err(e) = github::edit_labels_via_cli(
+                    &host,
+                    &owner,
+                    &repo,
                     issue.number,
-                    e
+                    &[labels::BLOCKED],
+                    &[labels::IN_PROGRESS],
+                )
+                .await
+                {
+                    log::warn!(
+                        "⚠️  Recovery scan: failed to escalate labels for {}/issues/{}: {:#}",
+                        repo_spec,
+                        issue.number,
+                        e
+                    );
+                    continue;
+                }
+
+                tracker.mark_escalated(&full_repo, issue.number);
+
+                let comment = format!(
+                    "🚫 Gru auto-recovery: issue has been reset {} times within {}h and \
+                     is still not making forward progress. Escalating to `{}` — \
+                     human review needed.\n\n\
+                     To re-enable automatic retries, remove the `{}` label. \
+                     The reset counter will clear once the issue is picked up again.",
+                    reset_count,
+                    config.daemon.auto_recovery.window_hours,
+                    labels::BLOCKED,
+                    labels::BLOCKED,
                 );
+                if let Err(e) =
+                    github::post_comment_via_cli(&host, &owner, &repo, issue.number, &comment).await
+                {
+                    log::warn!(
+                        "⚠️  Recovery scan: failed to post escalation comment on \
+                         {}/issues/{}: {:#}",
+                        repo_spec,
+                        issue.number,
+                        e
+                    );
+                }
+            } else {
+                // Within limit — reset to the configured pickup label.
+                let ready_label = &config.daemon.label;
+                tprintln!(
+                    "🔄 Recovery: resetting orphaned in-progress issue #{} in {} to {} \
+                     (stuck for {}m, reset #{} of {})",
+                    issue.number,
+                    repo_spec,
+                    ready_label,
+                    age.num_minutes(),
+                    reset_count,
+                    max_resets,
+                );
+
+                if let Err(e) = github::edit_labels_via_cli(
+                    &host,
+                    &owner,
+                    &repo,
+                    issue.number,
+                    &[ready_label.as_str()],
+                    &[labels::IN_PROGRESS],
+                )
+                .await
+                {
+                    log::warn!(
+                        "⚠️  Recovery scan: failed to reset labels for {}/issues/{}: {:#}",
+                        repo_spec,
+                        issue.number,
+                        e
+                    );
+                    continue;
+                }
+
+                let comment = format!(
+                    "⚠️ Gru auto-recovery: issue was stuck at `gru:in-progress` with no live \
+                     Minion process. Resetting to `{}` so it can be retried \
+                     (reset #{} of {}).",
+                    ready_label, reset_count, max_resets,
+                );
+                if let Err(e) =
+                    github::post_comment_via_cli(&host, &owner, &repo, issue.number, &comment).await
+                {
+                    log::warn!(
+                        "⚠️  Recovery scan: failed to post comment on {}/issues/{}: {:#}",
+                        repo_spec,
+                        issue.number,
+                        e
+                    );
+                }
             }
         }
     }
@@ -3458,5 +3610,75 @@ mod tests {
             !minion_has_pr_entry(&minions, "owner/repo", "42"),
             "Empty registry yields no match"
         );
+    }
+
+    // --- RecoveryTracker tests ---
+
+    #[test]
+    fn test_recovery_tracker_counts_resets() {
+        let mut tracker = RecoveryTracker::new();
+        let window = Duration::from_secs(3600);
+        assert_eq!(tracker.record_reset("owner/repo", 42, window), 1);
+        assert_eq!(tracker.record_reset("owner/repo", 42, window), 2);
+        assert_eq!(tracker.record_reset("owner/repo", 42, window), 3);
+    }
+
+    #[test]
+    fn test_recovery_tracker_counts_independent_per_issue() {
+        let mut tracker = RecoveryTracker::new();
+        let window = Duration::from_secs(3600);
+        tracker.record_reset("owner/repo", 1, window);
+        tracker.record_reset("owner/repo", 1, window);
+        assert_eq!(tracker.record_reset("owner/repo", 2, window), 1);
+    }
+
+    #[test]
+    fn test_recovery_tracker_clear_resets_history() {
+        let mut tracker = RecoveryTracker::new();
+        let window = Duration::from_secs(3600);
+        tracker.record_reset("owner/repo", 42, window);
+        tracker.record_reset("owner/repo", 42, window);
+        tracker.clear("owner/repo", 42);
+        assert_eq!(tracker.record_reset("owner/repo", 42, window), 1);
+    }
+
+    #[test]
+    fn test_recovery_tracker_escalated_flag() {
+        let mut tracker = RecoveryTracker::new();
+        assert!(!tracker.is_escalated("owner/repo", 42));
+        tracker.mark_escalated("owner/repo", 42);
+        assert!(tracker.is_escalated("owner/repo", 42));
+        tracker.clear("owner/repo", 42);
+        assert!(!tracker.is_escalated("owner/repo", 42));
+    }
+
+    #[test]
+    fn test_recovery_tracker_prunes_old_timestamps() {
+        let mut tracker = RecoveryTracker::new();
+        // Use a zero-duration window so any existing entry is immediately stale.
+        let tiny_window = Duration::from_nanos(0);
+        tracker.record_reset("owner/repo", 42, Duration::from_secs(3600));
+        // Recording with a zero window prunes the previous entry.
+        let count = tracker.record_reset("owner/repo", 42, tiny_window);
+        assert_eq!(count, 1, "stale entries should be pruned before counting");
+    }
+
+    #[test]
+    fn test_recovery_tracker_escalation_threshold() {
+        // Simulate the decision logic: escalate when count > max_resets.
+        let mut tracker = RecoveryTracker::new();
+        let window = Duration::from_secs(3600);
+        let max_resets: u32 = 2;
+
+        // First two resets: within limit.
+        let c1 = tracker.record_reset("owner/repo", 42, window);
+        assert!(c1 <= usize::try_from(max_resets).unwrap());
+
+        let c2 = tracker.record_reset("owner/repo", 42, window);
+        assert!(c2 <= usize::try_from(max_resets).unwrap());
+
+        // Third reset: exceeds max_resets → should escalate.
+        let c3 = tracker.record_reset("owner/repo", 42, window);
+        assert!(c3 > usize::try_from(max_resets).unwrap());
     }
 }

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -65,10 +65,13 @@ struct SpawnMeta {
 /// and it was picked up again), at which point its history is cleared.
 struct RecoveryTracker {
     /// Per-issue timestamps of auto-recovery resets within the tracking window.
-    /// Key: `(full_repo_slug, issue_number)`.
+    /// Key: `(host_qualified_repo, issue_number)` where `host_qualified_repo`
+    /// is `host/owner/repo` — includes the GitHub host so multi-host daemons
+    /// cannot collide across hosts with the same `owner/repo` slug.
     resets: HashMap<(String, u64), Vec<Instant>>,
     /// Issues that were escalated to `gru:blocked` by this tracker.
     /// Cleared when the issue re-enters `gru:in-progress` (human intervention).
+    /// Keyed by the same canonical `(host/owner/repo, issue_number)` tuple.
     escalated: HashSet<(String, u64)>,
 }
 
@@ -85,9 +88,11 @@ impl RecoveryTracker {
     fn record_reset(&mut self, repo: &str, issue: u64, window: Duration) -> usize {
         let key = (repo.to_string(), issue);
         let entry = self.resets.entry(key).or_default();
-        let cutoff = Instant::now() - window;
-        entry.retain(|&t| t > cutoff);
-        entry.push(Instant::now());
+        let now = Instant::now();
+        if let Some(cutoff) = now.checked_sub(window) {
+            entry.retain(|&t| t > cutoff);
+        }
+        entry.push(now);
         entry.len()
     }
 
@@ -106,6 +111,20 @@ impl RecoveryTracker {
         let key = (repo.to_string(), issue);
         self.resets.remove(&key);
         self.escalated.remove(&key);
+    }
+
+    /// Remove entries whose entire timestamp history has expired outside `window`.
+    /// Call once per scan to prevent unbounded memory growth in long-running daemons.
+    fn prune(&mut self, window: Duration) {
+        let cutoff = Instant::now().checked_sub(window);
+        self.resets.retain(|_, timestamps| {
+            if let Some(cutoff) = cutoff {
+                timestamps.retain(|&t| t > cutoff);
+                !timestamps.is_empty()
+            } else {
+                true
+            }
+        });
     }
 }
 
@@ -2397,10 +2416,11 @@ async fn fallback_list_issues(
 /// configured daemon pickup label (`daemon.label`) with an explanatory comment so
 /// the lab can retry them.
 ///
-/// When an issue has been reset N or more times within the configured window it is
-/// escalated to `gru:blocked` instead, preventing infinite thrash loops. When the
-/// tracker sees a previously-escalated issue back in `gru:in-progress` (indicating
-/// a human cleared `gru:blocked`), the history for that issue is reset.
+/// When an issue has already been reset `max_resets` times within the configured
+/// window, the next qualifying detection escalates it to `gru:blocked` instead,
+/// preventing infinite thrash loops. When the tracker sees a previously-escalated
+/// issue back in `gru:in-progress` (indicating a human cleared `gru:blocked`),
+/// the history for that issue is reset.
 ///
 /// Per-repo and per-issue errors are logged as warnings and do not abort the scan.
 async fn recover_stuck_in_progress_issues(
@@ -2420,6 +2440,11 @@ async fn recover_stuck_in_progress_issues(
         .context("auto_recovery.window_hours overflow")?;
     let window = Duration::from_secs(window_secs);
 
+    // Prune stale tracker entries once per scan to bound in-memory state.
+    if max_resets > 0 {
+        tracker.prune(window);
+    }
+
     for repo_spec in &config.daemon.repos {
         let Some((host, owner, repo)) =
             crate::config::parse_repo_entry_with_hosts(repo_spec, &config.github_hosts)
@@ -2432,6 +2457,9 @@ async fn recover_stuck_in_progress_issues(
         };
 
         let full_repo = crate::github::repo_slug(&owner, &repo);
+        // Include the host in the tracker key so multi-host daemons don't
+        // collide across instances with the same owner/repo slug.
+        let tracker_key = format!("{}/{}", host, full_repo);
 
         let in_progress = match github::list_in_progress_issues_via_cli(&host, &owner, &repo).await
         {
@@ -2450,14 +2478,14 @@ async fn recover_stuck_in_progress_issues(
             // If this issue was previously escalated to gru:blocked but is now back
             // in gru:in-progress, a human cleared gru:blocked and it was picked up
             // again. Clear the history so it gets a fresh slate.
-            if tracker.is_escalated(&full_repo, issue.number) {
+            if tracker.is_escalated(&tracker_key, issue.number) {
                 tprintln!(
                     "♻️  Recovery: issue #{} in {} is back in-progress after escalation — \
                      clearing reset history",
                     issue.number,
                     repo_spec,
                 );
-                tracker.clear(&full_repo, issue.number);
+                tracker.clear(&tracker_key, issue.number);
             }
 
             // Only reset if the issue has been in-progress for longer than the threshold.
@@ -2495,7 +2523,7 @@ async fn recover_stuck_in_progress_issues(
             // Record this reset and check whether we've exceeded the threshold.
             // When max_resets == 0, escalation is disabled — always reset.
             let reset_count = if max_resets > 0 {
-                tracker.record_reset(&full_repo, issue.number, window)
+                tracker.record_reset(&tracker_key, issue.number, window)
             } else {
                 0
             };
@@ -2503,8 +2531,8 @@ async fn recover_stuck_in_progress_issues(
             if max_resets > 0 && reset_count > max_resets as usize {
                 // Too many resets within the window — escalate to gru:blocked.
                 tprintln!(
-                    "🚫 Recovery: escalating issue #{} in {} to {} after {} resets in {}h \
-                     (stuck for {}m)",
+                    "🚫 Recovery: escalating issue #{} in {} to {} after {} stuck detections \
+                     in {}h (stuck for {}m)",
                     issue.number,
                     repo_spec,
                     labels::BLOCKED,
@@ -2532,12 +2560,12 @@ async fn recover_stuck_in_progress_issues(
                     continue;
                 }
 
-                tracker.mark_escalated(&full_repo, issue.number);
+                tracker.mark_escalated(&tracker_key, issue.number);
 
                 let ready_label = &config.daemon.label;
                 let comment = format!(
-                    "🚫 Gru auto-recovery: issue has been reset {} times within {}h and \
-                     is still not making forward progress. Escalating to `{}` — \
+                    "🚫 Gru auto-recovery: issue has been detected stuck {} time(s) within \
+                     {}h and is still not making forward progress. Escalating to `{}` — \
                      human review needed.\n\n\
                      To re-enable automatic retries: remove the `{}` label and \
                      re-add `{}`. The reset counter will clear once the issue \

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -113,8 +113,24 @@ impl RecoveryTracker {
         self.escalated.remove(&key);
     }
 
+    /// Undo the most recently recorded reset for `(repo, issue)`.
+    ///
+    /// Called when the label-edit that a `record_reset` was paired with fails,
+    /// so that a transient GitHub API error does not permanently increment the
+    /// counter and cause premature escalation on the next scan.
+    fn remove_last_reset(&mut self, repo: &str, issue: u64) {
+        let key = (repo.to_string(), issue);
+        if let Some(entry) = self.resets.get_mut(&key) {
+            entry.pop();
+            if entry.is_empty() {
+                self.resets.remove(&key);
+            }
+        }
+    }
+
     /// Remove entries whose entire timestamp history has expired outside `window`.
-    /// Call once per scan to prevent unbounded memory growth in long-running daemons.
+    /// Also prunes `escalated` entries for issues that have no remaining reset
+    /// history (e.g., closed while blocked). Call once per scan.
     fn prune(&mut self, window: Duration) {
         let cutoff = Instant::now().checked_sub(window);
         self.resets.retain(|_, timestamps| {
@@ -125,6 +141,11 @@ impl RecoveryTracker {
                 true
             }
         });
+        // Drop escalated entries whose reset history has fully expired.
+        // Uses a local reference to avoid a simultaneous mutable + immutable
+        // borrow of `self` through the closure.
+        let resets = &self.resets;
+        self.escalated.retain(|key| resets.contains_key(key));
     }
 }
 
@@ -2557,6 +2578,9 @@ async fn recover_stuck_in_progress_issues(
                         issue.number,
                         e
                     );
+                    // Undo the counter increment so a transient API failure does
+                    // not permanently advance the reset count.
+                    tracker.remove_last_reset(&tracker_key, issue.number);
                     continue;
                 }
 
@@ -2621,6 +2645,9 @@ async fn recover_stuck_in_progress_issues(
                         issue.number,
                         e
                     );
+                    // Undo the counter increment so a transient API failure does
+                    // not permanently advance the reset count.
+                    tracker.remove_last_reset(&tracker_key, issue.number);
                     continue;
                 }
 

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -2412,7 +2412,13 @@ async fn recover_stuck_in_progress_issues(
     let threshold = chrono::Duration::minutes(threshold_mins);
 
     let max_resets = config.daemon.auto_recovery.max_resets;
-    let window = Duration::from_secs(config.daemon.auto_recovery.window_hours * 3600);
+    let window_secs = config
+        .daemon
+        .auto_recovery
+        .window_hours
+        .checked_mul(3600)
+        .context("auto_recovery.window_hours overflow")?;
+    let window = Duration::from_secs(window_secs);
 
     for repo_spec in &config.daemon.repos {
         let Some((host, owner, repo)) =
@@ -2494,7 +2500,7 @@ async fn recover_stuck_in_progress_issues(
                 0
             };
 
-            if max_resets > 0 && reset_count > usize::try_from(max_resets).unwrap_or(usize::MAX) {
+            if max_resets > 0 && reset_count > max_resets as usize {
                 // Too many resets within the window — escalate to gru:blocked.
                 tprintln!(
                     "🚫 Recovery: escalating issue #{} in {} to {} after {} resets in {}h \

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -2534,16 +2534,19 @@ async fn recover_stuck_in_progress_issues(
 
                 tracker.mark_escalated(&full_repo, issue.number);
 
+                let ready_label = &config.daemon.label;
                 let comment = format!(
                     "🚫 Gru auto-recovery: issue has been reset {} times within {}h and \
                      is still not making forward progress. Escalating to `{}` — \
                      human review needed.\n\n\
-                     To re-enable automatic retries, remove the `{}` label. \
-                     The reset counter will clear once the issue is picked up again.",
+                     To re-enable automatic retries: remove the `{}` label and \
+                     re-add `{}`. The reset counter will clear once the issue \
+                     is picked up again.",
                     reset_count,
                     config.daemon.auto_recovery.window_hours,
                     labels::BLOCKED,
                     labels::BLOCKED,
+                    ready_label,
                 );
                 if let Err(e) =
                     github::post_comment_via_cli(&host, &owner, &repo, issue.number, &comment).await
@@ -2559,15 +2562,19 @@ async fn recover_stuck_in_progress_issues(
             } else {
                 // Within limit — reset to the configured pickup label.
                 let ready_label = &config.daemon.label;
+                let reset_suffix = if max_resets > 0 {
+                    format!(" (reset #{} of {})", reset_count, max_resets)
+                } else {
+                    String::new()
+                };
                 tprintln!(
                     "🔄 Recovery: resetting orphaned in-progress issue #{} in {} to {} \
-                     (stuck for {}m, reset #{} of {})",
+                     (stuck for {}m{})",
                     issue.number,
                     repo_spec,
                     ready_label,
                     age.num_minutes(),
-                    reset_count,
-                    max_resets,
+                    reset_suffix,
                 );
 
                 if let Err(e) = github::edit_labels_via_cli(
@@ -2591,9 +2598,8 @@ async fn recover_stuck_in_progress_issues(
 
                 let comment = format!(
                     "⚠️ Gru auto-recovery: issue was stuck at `gru:in-progress` with no live \
-                     Minion process. Resetting to `{}` so it can be retried \
-                     (reset #{} of {}).",
-                    ready_label, reset_count, max_resets,
+                     Minion process. Resetting to `{}` so it can be retried{}.",
+                    ready_label, reset_suffix,
                 );
                 if let Err(e) =
                     github::post_comment_via_cli(&host, &owner, &repo, issue.number, &comment).await

--- a/src/config.rs
+++ b/src/config.rs
@@ -576,6 +576,14 @@ impl LabConfig {
 # # Hours before a stopped Minion with no signal is auto-archived (default: 24)
 # archive_ttl_hours = 24
 
+# [daemon.auto_recovery]
+# # Maximum resets within the window before escalating to gru:blocked (0 = disabled).
+# # After max_resets resets, the next stuck detection escalates instead of resetting.
+# max_resets = 2
+#
+# # Sliding window in hours within which resets are counted (default: 2).
+# window_hours = 2
+
 # [agent]
 # # Which agent backend to use (default: "claude")
 # default = "claude"
@@ -763,8 +771,8 @@ impl LabConfig {
         if self.daemon.auto_recovery.max_resets > 0 && self.daemon.auto_recovery.window_hours == 0 {
             anyhow::bail!(
                 "daemon.auto_recovery.window_hours must be at least 1 when \
-                 auto_recovery.max_resets > 0 (a zero-duration window disables \
-                 effective reset tracking)"
+                 daemon.auto_recovery.max_resets > 0 (a zero-duration window \
+                 disables effective reset tracking)"
             );
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,8 +151,8 @@ pub(crate) struct DaemonConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct AutoRecoveryConfig {
     /// Maximum number of times an issue can be auto-recovered within the tracking
-    /// window. After exactly this many resets the issue is reset once more, and on
-    /// the (N+1)th stuck detection it is escalated to `gru:blocked` instead.
+    /// window. Once this many resets have already occurred, the next stuck
+    /// detection is escalated to `gru:blocked` instead of performing another reset.
     /// Set to 0 to disable escalation (issues reset indefinitely). Default: 2
     /// (two resets are logged as "reset #1 of 2" and "reset #2 of 2"; the third
     /// stuck detection triggers escalation).

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,8 +151,11 @@ pub(crate) struct DaemonConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct AutoRecoveryConfig {
     /// Maximum number of times an issue can be auto-recovered within the tracking
-    /// window before it is escalated to `gru:blocked` instead. Set to 0 to disable
-    /// escalation (issues will be reset indefinitely). Default: 2.
+    /// window. After exactly this many resets the issue is reset once more, and on
+    /// the (N+1)th stuck detection it is escalated to `gru:blocked` instead.
+    /// Set to 0 to disable escalation (issues reset indefinitely). Default: 2
+    /// (two resets are logged as "reset #1 of 2" and "reset #2 of 2"; the third
+    /// stuck detection triggers escalation).
     #[serde(default = "default_auto_recovery_max_resets")]
     pub(crate) max_resets: u32,
 
@@ -755,6 +758,14 @@ impl LabConfig {
 
         if self.daemon.max_resume_attempts == 0 {
             anyhow::bail!("max_resume_attempts must be at least 1");
+        }
+
+        if self.daemon.auto_recovery.max_resets > 0 && self.daemon.auto_recovery.window_hours == 0 {
+            anyhow::bail!(
+                "daemon.auto_recovery.window_hours must be at least 1 when \
+                 auto_recovery.max_resets > 0 (a zero-duration window disables \
+                 effective reset tracking)"
+            );
         }
 
         self.validate_github_hosts()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,6 +140,26 @@ pub(crate) struct DaemonConfig {
     /// clock and delay auto-recovery by the threshold duration.
     #[serde(default = "default_recovery_threshold_mins")]
     pub(crate) recovery_threshold_mins: u64,
+
+    /// Auto-recovery escalation settings — tracks repeated resets and escalates
+    /// to gru:blocked when an issue loops too many times.
+    #[serde(default)]
+    pub(crate) auto_recovery: AutoRecoveryConfig,
+}
+
+/// Configuration for auto-recovery escalation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AutoRecoveryConfig {
+    /// Maximum number of times an issue can be auto-recovered within the tracking
+    /// window before it is escalated to `gru:blocked` instead. Set to 0 to disable
+    /// escalation (issues will be reset indefinitely). Default: 2.
+    #[serde(default = "default_auto_recovery_max_resets")]
+    pub(crate) max_resets: u32,
+
+    /// Sliding window in hours within which repeated resets are counted. Resets
+    /// older than this window are forgotten. Default: 2 hours.
+    #[serde(default = "default_auto_recovery_window_hours")]
+    pub(crate) window_hours: u64,
 }
 
 impl Default for DaemonConfig {
@@ -155,6 +175,16 @@ impl Default for DaemonConfig {
             poll_interval_max_secs: default_poll_interval_max(),
             archive_ttl_hours: default_archive_ttl_hours(),
             recovery_threshold_mins: default_recovery_threshold_mins(),
+            auto_recovery: AutoRecoveryConfig::default(),
+        }
+    }
+}
+
+impl Default for AutoRecoveryConfig {
+    fn default() -> Self {
+        Self {
+            max_resets: default_auto_recovery_max_resets(),
+            window_hours: default_auto_recovery_window_hours(),
         }
     }
 }
@@ -299,6 +329,20 @@ pub(crate) const DEFAULT_RECOVERY_THRESHOLD_MINS: u64 = 30;
 
 fn default_recovery_threshold_mins() -> u64 {
     DEFAULT_RECOVERY_THRESHOLD_MINS
+}
+
+/// Default maximum times an issue can be auto-recovered before escalation.
+pub(crate) const DEFAULT_AUTO_RECOVERY_MAX_RESETS: u32 = 2;
+
+fn default_auto_recovery_max_resets() -> u32 {
+    DEFAULT_AUTO_RECOVERY_MAX_RESETS
+}
+
+/// Default sliding window in hours for tracking auto-recovery resets.
+pub(crate) const DEFAULT_AUTO_RECOVERY_WINDOW_HOURS: u64 = 2;
+
+fn default_auto_recovery_window_hours() -> u64 {
+    DEFAULT_AUTO_RECOVERY_WINDOW_HOURS
 }
 
 /// Parse a repo entry from the config into `(host, owner, repo)`.


### PR DESCRIPTION
## Summary

- Add `RecoveryTracker` (in-memory, per-lab-session) that counts auto-recovery resets per issue within a configurable sliding window
- Modify `recover_stuck_in_progress_issues` to escalate to `gru:blocked` instead of `gru:todo` when an issue is reset more than `max_resets` times within `window_hours`; posts an explanatory comment with reset count, window, and instructions to re-enable retries by removing `gru:blocked`
- Clear reset history when a previously-escalated issue re-enters `gru:in-progress` (human cleared `gru:blocked`, issue was picked up again)
- Add `[daemon.auto_recovery]` config section with `max_resets` (default 2) and `window_hours` (default 2h); document in `docs/config.example.toml`
- Add validation: `window_hours` must be ≥ 1 when `max_resets > 0`

## Test plan

- `just check` — all 1374 tests pass, including 6 new unit tests for `RecoveryTracker`
- New tests cover: incremental counting, per-issue independence, `clear` resets history, `mark_escalated`/`is_escalated`/`clear` lifecycle, stale-timestamp pruning, and the exact escalation boundary (`max_resets=2` → resets #1 and #2 allowed, #3 escalates)

## Notes

- The tracker is in-memory only (resets on lab restart). This is intentional: the window is short enough that a lab restart mid-window is acceptable — the worst case is N additional resets before re-escalation, not a bypass of the protection
- Escalation semantics: `max_resets=2` means exactly 2 resets are allowed (logged as "reset #1 of 2" and "reset #2 of 2"); the 3rd stuck detection triggers escalation. This matches the issue's suggested `N=2` default
- `max_resets=0` disables escalation entirely (issues reset indefinitely, preserving old behavior)

Fixes #880

<sub>🤖 M1li</sub>