### PR TITLE
Fixes #877: Auto-merge label has no consumer for PRs without an attached Minion

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -30,6 +30,10 @@ macro_rules! tprintln {
 /// Not user-configurable — this is an implementation cadence, not a config knob.
 const RECOVERY_SCAN_INTERVAL: Duration = Duration::from_secs(300);
 
+/// How often the lab sweeps for orphaned `gru:auto-merge` PRs.
+/// Not user-configurable — this is an implementation cadence, not a config knob.
+const AUTO_MERGE_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
+
 /// A child process tracked by the lab, with optional metadata for label restoration.
 struct SpawnedChild {
     child: Child,
@@ -2446,9 +2450,6 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
     Ok(())
 }
 
-/// How often the lab sweeps for orphaned `gru:auto-merge` PRs.
-const AUTO_MERGE_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
-
 /// Scan all configured repos for open PRs labelled `gru:auto-merge` that have no
 /// live Minion monitoring them, and queue `--auto` merge when all deterministic
 /// readiness checks pass.
@@ -2547,7 +2548,6 @@ async fn sweep_orphaned_auto_merge_prs(config: &LabConfig) {
             );
 
             let pr_num_str = pr.number.to_string();
-            let repo_full = github::repo_slug(&owner, &repo);
             match github::gh_cli_command(&host)
                 .args([
                     "pr",
@@ -2556,7 +2556,7 @@ async fn sweep_orphaned_auto_merge_prs(config: &LabConfig) {
                     "--squash",
                     "--auto",
                     "-R",
-                    &repo_full,
+                    &full_repo,
                 ])
                 .output()
                 .await
@@ -2590,7 +2590,13 @@ async fn sweep_orphaned_auto_merge_prs(config: &LabConfig) {
     }
 }
 
-/// Returns `true` if a live Minion process is monitoring the given PR.
+/// Returns `true` if a non-archived Minion entry in the registry is associated
+/// with the given PR, indicating it may still be responsible for monitoring it.
+///
+/// Intentionally does not require `is_running()` — a Minion whose process just
+/// died but hasn't been archived yet is still "responsible" from the sweeper's
+/// perspective. The archive machinery will clean it up; we don't want to race
+/// against it by queueing a merge prematurely.
 ///
 /// Fails-safe to `true` on registry errors to avoid double-queuing a merge.
 async fn is_pr_monitored_by_live_minion(full_repo: &str, pr_number: u64) -> bool {
@@ -2601,7 +2607,6 @@ async fn is_pr_monitored_by_live_minion(full_repo: &str, pr_number: u64) -> bool
             info.repo == repo
                 && info.pr.as_deref() == Some(pr_str.as_str())
                 && info.archived_at.is_none()
-                && info.is_running()
         });
         Ok(monitored)
     })

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -153,6 +153,9 @@ pub(crate) async fn handle_lab(
     // avoids false positives while minions re-register after a lab restart.
     let mut last_recovery_scan: Option<Instant> = None;
 
+    // Auto-merge sweep timer — same semantics as last_recovery_scan.
+    let mut last_auto_merge_sweep: Option<Instant> = None;
+
     if no_resume {
         tprintln!("⏭️  Auto-resume disabled (--no-resume)");
         tprintln!();
@@ -326,6 +329,19 @@ pub(crate) async fn handle_lab(
                         }
                         Some(_) => {}
                     }
+                }
+
+                // Periodic auto-merge sweep: queue merges for orphaned auto-merge PRs.
+                // Same timer semantics as last_recovery_scan.
+                match last_auto_merge_sweep {
+                    None => {
+                        last_auto_merge_sweep = Some(Instant::now());
+                    }
+                    Some(t) if t.elapsed() >= AUTO_MERGE_SWEEP_INTERVAL => {
+                        last_auto_merge_sweep = Some(Instant::now());
+                        sweep_orphaned_auto_merge_prs(&config).await;
+                    }
+                    Some(_) => {}
                 }
 
                 // Check if a signal arrived during poll_and_spawn
@@ -2428,6 +2444,179 @@ async fn recover_stuck_in_progress_issues(config: &crate::config::LabConfig) -> 
     }
 
     Ok(())
+}
+
+/// How often the lab sweeps for orphaned `gru:auto-merge` PRs.
+const AUTO_MERGE_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Scan all configured repos for open PRs labelled `gru:auto-merge` that have no
+/// live Minion monitoring them, and queue `--auto` merge when all deterministic
+/// readiness checks pass.
+///
+/// This handles PRs that were labelled outside of `gru do` (e.g., by a human or
+/// a Minion that has since exited) and whose label therefore has no consumer.
+///
+/// Per-repo and per-PR errors are logged as warnings and do not abort the scan.
+async fn sweep_orphaned_auto_merge_prs(config: &LabConfig) {
+    for repo_spec in &config.daemon.repos {
+        let Some((host, owner, repo)) =
+            parse_repo_entry_with_hosts(repo_spec, &config.github_hosts)
+        else {
+            log::warn!(
+                "⚠️  Auto-merge sweep: could not parse repo spec '{}'",
+                repo_spec
+            );
+            continue;
+        };
+
+        let prs = match github::list_auto_merge_prs(&host, &owner, &repo).await {
+            Ok(prs) => prs,
+            Err(e) => {
+                log::warn!(
+                    "⚠️  Auto-merge sweep: failed to list auto-merge PRs for {}: {:#}",
+                    repo_spec,
+                    e
+                );
+                continue;
+            }
+        };
+
+        if prs.is_empty() {
+            continue;
+        }
+
+        let full_repo = github::repo_slug(&owner, &repo);
+
+        for pr in &prs {
+            // Skip if a live Minion is already monitoring this PR.
+            if is_pr_monitored_by_live_minion(&full_repo, pr.number).await {
+                log::debug!(
+                    "Auto-merge sweep: skipping PR #{} in {} — live Minion is monitoring it",
+                    pr.number,
+                    repo_spec,
+                );
+                continue;
+            }
+
+            // Skip if gru:needs-human-review is present.
+            if pr
+                .labels
+                .iter()
+                .any(|l| l.name == labels::NEEDS_HUMAN_REVIEW)
+            {
+                log::debug!(
+                    "Auto-merge sweep: skipping PR #{} in {} — has gru:needs-human-review",
+                    pr.number,
+                    repo_spec,
+                );
+                continue;
+            }
+
+            // Check deterministic merge readiness.
+            let readiness = match crate::merge_readiness::check_merge_readiness(
+                &host, &owner, &repo, pr.number,
+            )
+            .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    log::warn!(
+                        "⚠️  Auto-merge sweep: failed to check readiness for PR #{} in {}: {:#}",
+                        pr.number,
+                        repo_spec,
+                        e
+                    );
+                    continue;
+                }
+            };
+
+            if !readiness.is_ready() {
+                log::debug!(
+                    "Auto-merge sweep: PR #{} in {} not ready ({})",
+                    pr.number,
+                    repo_spec,
+                    readiness,
+                );
+                continue;
+            }
+
+            tprintln!(
+                "🔀 Auto-merge sweep: queueing merge for orphaned PR #{} in {}",
+                pr.number,
+                repo_spec,
+            );
+
+            let pr_num_str = pr.number.to_string();
+            let repo_full = github::repo_slug(&owner, &repo);
+            match github::gh_cli_command(&host)
+                .args([
+                    "pr",
+                    "merge",
+                    &pr_num_str,
+                    "--squash",
+                    "--auto",
+                    "-R",
+                    &repo_full,
+                ])
+                .output()
+                .await
+            {
+                Ok(output) if output.status.success() => {
+                    tprintln!(
+                        "✅ Auto-merge queued for orphaned PR #{} in {}",
+                        pr.number,
+                        repo_spec,
+                    );
+                }
+                Ok(output) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    log::warn!(
+                        "⚠️  Auto-merge sweep: merge command failed for PR #{} in {}: {}",
+                        pr.number,
+                        repo_spec,
+                        stderr.trim(),
+                    );
+                }
+                Err(e) => {
+                    log::warn!(
+                        "⚠️  Auto-merge sweep: failed to run merge command for PR #{} in {}: {:#}",
+                        pr.number,
+                        repo_spec,
+                        e,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Returns `true` if a live Minion process is monitoring the given PR.
+///
+/// Fails-safe to `true` on registry errors to avoid double-queuing a merge.
+async fn is_pr_monitored_by_live_minion(full_repo: &str, pr_number: u64) -> bool {
+    let pr_str = pr_number.to_string();
+    let repo = full_repo.to_string();
+    match with_registry(move |registry| {
+        let monitored = registry.list().iter().any(|(_id, info)| {
+            info.repo == repo
+                && info.pr.as_deref() == Some(pr_str.as_str())
+                && info.archived_at.is_none()
+                && info.is_running()
+        });
+        Ok(monitored)
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            log::warn!(
+                "Failed to check registry for PR #{}: {} — assuming monitored (fail-safe)",
+                pr_number,
+                e
+            );
+            true
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -157,7 +157,11 @@ pub(crate) async fn handle_lab(
     // avoids false positives while minions re-register after a lab restart.
     let mut last_recovery_scan: Option<Instant> = None;
 
-    // Auto-merge sweep timer — same semantics as last_recovery_scan.
+    // Auto-merge sweep timer — same semantics as last_recovery_scan:
+    //   None  → first main-loop iteration after startup: set the timer without
+    //           sweeping, so re-registering Minions have time to appear in the
+    //           registry before the first sweep runs.
+    //   Some  → sweep when AUTO_MERGE_SWEEP_INTERVAL has elapsed, then reset.
     let mut last_auto_merge_sweep: Option<Instant> = None;
 
     if no_resume {
@@ -2590,27 +2594,29 @@ async fn sweep_orphaned_auto_merge_prs(config: &LabConfig) {
     }
 }
 
-/// Returns `true` if a non-archived Minion entry in the registry is associated
-/// with the given PR, indicating it may still be responsible for monitoring it.
+/// Pure predicate: returns `true` if any non-archived entry in `minions`
+/// matches the given repo and PR number.
 ///
 /// Intentionally does not require `is_running()` — a Minion whose process just
 /// died but hasn't been archived yet is still "responsible" from the sweeper's
 /// perspective. The archive machinery will clean it up; we don't want to race
 /// against it by queueing a merge prematurely.
-///
-/// Fails-safe to `true` on registry errors to avoid double-queuing a merge.
+fn minion_has_pr_entry(minions: &[(String, MinionInfo)], full_repo: &str, pr_number: &str) -> bool {
+    minions.iter().any(|(_id, info)| {
+        info.repo == full_repo
+            && info.pr.as_deref() == Some(pr_number)
+            && info.archived_at.is_none()
+    })
+}
+
+/// Returns `true` if a non-archived Minion entry in the registry is associated
+/// with the given PR. Fails-safe to `true` on registry errors to avoid
+/// double-queuing a merge.
 async fn is_pr_monitored_by_live_minion(full_repo: &str, pr_number: u64) -> bool {
     let pr_str = pr_number.to_string();
     let repo = full_repo.to_string();
-    match with_registry(move |registry| {
-        let monitored = registry.list().iter().any(|(_id, info)| {
-            info.repo == repo
-                && info.pr.as_deref() == Some(pr_str.as_str())
-                && info.archived_at.is_none()
-        });
-        Ok(monitored)
-    })
-    .await
+    match with_registry(move |registry| Ok(minion_has_pr_entry(&registry.list(), &repo, &pr_str)))
+        .await
     {
         Ok(result) => result,
         Err(e) => {
@@ -3382,5 +3388,75 @@ mod tests {
         assert_eq!(result[0].minion_id, "M003");
         // The most recent minion's PR is the one that will be checked
         assert_eq!(result[0].info.pr.as_deref(), Some("101"));
+    }
+
+    // --- minion_has_pr_entry tests ---
+
+    fn make_pr_minion(repo: &str, pr: Option<&str>, archived: bool) -> MinionInfo {
+        let mut info = make_completed_minion(pr, 0);
+        info.repo = repo.to_string();
+        if archived {
+            info.archived_at = Some(chrono::Utc::now());
+        }
+        info
+    }
+
+    #[test]
+    fn test_minion_has_pr_entry_matches() {
+        let info = make_pr_minion("owner/repo", Some("42"), false);
+        let minions = vec![("M001".to_string(), info)];
+        assert!(
+            minion_has_pr_entry(&minions, "owner/repo", "42"),
+            "Non-archived entry with matching repo+PR must return true"
+        );
+    }
+
+    #[test]
+    fn test_minion_has_pr_entry_archived_is_excluded() {
+        let info = make_pr_minion("owner/repo", Some("42"), true);
+        let minions = vec![("M001".to_string(), info)];
+        assert!(
+            !minion_has_pr_entry(&minions, "owner/repo", "42"),
+            "Archived entry must not block the sweeper"
+        );
+    }
+
+    #[test]
+    fn test_minion_has_pr_entry_wrong_pr() {
+        let info = make_pr_minion("owner/repo", Some("99"), false);
+        let minions = vec![("M001".to_string(), info)];
+        assert!(
+            !minion_has_pr_entry(&minions, "owner/repo", "42"),
+            "Entry with a different PR number must not match"
+        );
+    }
+
+    #[test]
+    fn test_minion_has_pr_entry_wrong_repo() {
+        let info = make_pr_minion("other/repo", Some("42"), false);
+        let minions = vec![("M001".to_string(), info)];
+        assert!(
+            !minion_has_pr_entry(&minions, "owner/repo", "42"),
+            "Entry for a different repo must not match"
+        );
+    }
+
+    #[test]
+    fn test_minion_has_pr_entry_no_pr_field() {
+        let info = make_pr_minion("owner/repo", None, false);
+        let minions = vec![("M001".to_string(), info)];
+        assert!(
+            !minion_has_pr_entry(&minions, "owner/repo", "42"),
+            "Entry with no PR field must not match"
+        );
+    }
+
+    #[test]
+    fn test_minion_has_pr_entry_empty_registry() {
+        let minions: Vec<(String, MinionInfo)> = vec![];
+        assert!(
+            !minion_has_pr_entry(&minions, "owner/repo", "42"),
+            "Empty registry yields no match"
+        );
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -878,6 +878,56 @@ pub async fn is_pr_merged_via_cli(
     Ok(state == "MERGED")
 }
 
+/// An open PR returned by the auto-merge sweep.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct AutoMergePr {
+    pub(crate) number: u64,
+    #[serde(default)]
+    pub(crate) labels: Vec<IssueLabel>,
+}
+
+/// List open PRs that carry the `gru:auto-merge` label.
+///
+/// Returns up to 100 results. Logs a warning if the result set is truncated.
+pub(crate) async fn list_auto_merge_prs(
+    host: &str,
+    owner: &str,
+    repo: &str,
+) -> Result<Vec<AutoMergePr>> {
+    let repo_full = repo_slug(owner, repo);
+    let stdout = run_gh(
+        host,
+        &[
+            "pr",
+            "list",
+            "--repo",
+            &repo_full,
+            "--label",
+            labels::AUTO_MERGE,
+            "--state",
+            "open",
+            "--json",
+            "number,labels",
+            "--limit",
+            "100",
+        ],
+    )
+    .await?;
+
+    let items: Vec<AutoMergePr> =
+        serde_json::from_str(&stdout).context("Failed to parse gh pr list (auto-merge) JSON")?;
+
+    if items.len() == 100 {
+        log::warn!(
+            "⚠️  Auto-merge sweep: gh pr list returned exactly 100 results for {}/{} — some PRs may have been truncated",
+            owner,
+            repo
+        );
+    }
+
+    Ok(items)
+}
+
 /// Simple struct to hold issue information from gh CLI
 #[derive(Debug, serde::Deserialize)]
 pub(crate) struct IssueInfo {

--- a/src/github.rs
+++ b/src/github.rs
@@ -888,7 +888,9 @@ pub(crate) struct AutoMergePr {
 
 /// List open PRs that carry the `gru:auto-merge` label.
 ///
-/// Returns up to 100 results. Logs a warning if the result set is truncated.
+/// Returns up to 100 results. Logs a warning when exactly 100 results are
+/// returned, which may indicate the list was truncated (it is impossible to
+/// distinguish exactly-100 from truncated-at-100 without fetching more).
 pub(crate) async fn list_auto_merge_prs(
     host: &str,
     owner: &str,


### PR DESCRIPTION
## Summary

- Add `github::list_auto_merge_prs` to list open PRs carrying `gru:auto-merge` for a repo
- Add `sweep_orphaned_auto_merge_prs` to `gru lab`: a periodic (5-minute) sweep that finds open `gru:auto-merge` PRs with no active Minion entry in the registry, runs deterministic merge-readiness checks, and calls `gh pr merge --squash --auto` on ready PRs
- Add `is_pr_monitored_by_live_minion` registry helper that gates the sweep — any non-archived registry entry for a PR is considered "responsible" (no `is_running()` check to avoid racing against the archive machinery)
- `AUTO_MERGE_SWEEP_INTERVAL` (5 min) defined next to `RECOVERY_SCAN_INTERVAL` for discoverability; first sweep deferred one main-loop cycle after startup to avoid races with Minions re-registering

## Test plan

- `just check` passes (fmt + clippy + 1368 tests)
- Manual scenario: label an open PR `gru:auto-merge` with no Minion entry in `~/.gru/state/minions.json`; start `gru lab`; within ~5 minutes the sweep logs `🔀 Auto-merge sweep: queueing merge for orphaned PR #N in owner/repo` and GitHub shows `autoMergeRequest` set
- Existing Minion-driven auto-merge path is unchanged

## Notes

- The LLM merge judge is deliberately skipped in the sweeper — there is no agent backend available in the lab polling context. The deterministic checks (not draft, CI passing, review approved, no conflicts) are the sole gate.
- PRs with `gru:needs-human-review` are skipped by the sweep, consistent with how the per-Minion loop handles them.
- The `is_pr_monitored_by_live_minion` check uses `archived_at.is_none()` only (not `is_running()`) so that a Minion whose process just exited but hasn't been archived yet is still treated as "responsible", preventing a race where the sweeper queues a merge on a mid-flight PR.
- `gh pr merge --squash --auto` is idempotent if GitHub's auto-merge is already queued, so running the sweep multiple times is safe.

Fixes #877

<sub>🤖 M1ll</sub>