### PR TITLE
Fixes #879: fix::setup_worktree: allocate fresh minion ID on branch collision with a Failed minion instead of reusing its registry row

### DIFF
--- a/src/commands/fix/resolve.rs
+++ b/src/commands/fix/resolve.rs
@@ -96,14 +96,19 @@ fn evaluate_existing_minions(
     let any_running = existing.iter().any(|(_, info)| is_validated_running(info));
 
     if any_running {
-        // A minion is actively running - show error with suggestions
+        // Only show non-terminal entries in the error output — terminal ones
+        // were excluded from any_running and would just confuse the operator.
+        let non_terminal: Vec<_> = existing
+            .iter()
+            .filter(|(_, info)| !info.orchestration_phase.is_terminal())
+            .collect();
         eprintln!(
             "Error: {} existing Minion(s) found for issue {}:\n",
-            existing.len(),
+            non_terminal.len(),
             issue_num
         );
 
-        for (minion_id, info) in &existing {
+        for (minion_id, info) in &non_terminal {
             let actually_running = info.is_running();
             let status_msg = if actually_running {
                 match info.mode {
@@ -117,7 +122,7 @@ fn evaluate_existing_minions(
             eprintln!("  {} - status: {}", minion_id, status_msg);
         }
 
-        let (best_id, _) = existing.first().unwrap();
+        let (best_id, _) = non_terminal.first().unwrap();
         eprintln!("\nOptions:");
         eprintln!("  - Attach interactively: gru attach {}", best_id);
         eprintln!(
@@ -346,6 +351,27 @@ mod tests {
         assert!(
             matches!(result, ExistingMinionCheck::Resumable(ref id, _) if id == "M1ku"),
             "Stopped non-terminal minion with worktree must be Resumable, got: {:?}",
+            result
+        );
+    }
+
+    /// A Failed minion with live PID alongside a genuinely active non-terminal
+    /// minion must still surface AlreadyRunning — the terminal entry must not
+    /// suppress detection of the real running minion.
+    #[test]
+    fn active_minion_not_suppressed_by_failed_sibling_with_live_pid() {
+        let tmp = tempdir().unwrap();
+        let worktree = tmp.path().to_path_buf();
+        let live_pid = std::process::id();
+        let failed = make_info(OrchestrationPhase::Failed, Some(live_pid), worktree.clone());
+        let active = make_info(OrchestrationPhase::RunningAgent, Some(live_pid), worktree);
+        let entries = vec![("M1ku".into(), failed), ("M1lj".into(), active)];
+
+        let result = evaluate_existing_minions("owner", "repo", 329, entries);
+
+        assert!(
+            matches!(result, ExistingMinionCheck::AlreadyRunning),
+            "Active non-terminal sibling must still be detected as AlreadyRunning, got: {:?}",
             result
         );
     }

--- a/src/commands/fix/resolve.rs
+++ b/src/commands/fix/resolve.rs
@@ -45,20 +45,40 @@ pub(super) async fn check_existing_minions(
         return Ok(ExistingMinionCheck::None);
     };
     let repo_for_check = crate::github::repo_slug(owner, repo);
-    let mut existing =
+    let existing =
         with_registry(move |registry| Ok(registry.find_by_issue(&repo_for_check, issue_num)))
             .await?;
 
+    Ok(evaluate_existing_minions(owner, repo, issue_num, existing))
+}
+
+/// Pure core of [`check_existing_minions`], extracted so it can be unit-tested
+/// without a live registry.
+fn evaluate_existing_minions(
+    owner: &str,
+    repo: &str,
+    issue_num: u64,
+    mut existing: Vec<(String, MinionInfo)>,
+) -> ExistingMinionCheck {
     if existing.is_empty() {
-        return Ok(ExistingMinionCheck::None);
+        return ExistingMinionCheck::None;
     }
 
     // On macOS and Linux, `get_process_start_time` returns `Some`, so we can
     // validate that the live PID actually belongs to the recorded process.
     // On other platforms the start time is always `None`, so we fall back to
     // the plain `is_running()` check to avoid ignoring all running minions.
+    //
+    // Terminal entries (Failed/Completed) are intentionally excluded: lab's
+    // try_spawn_for_issue stamps the new gru-do child PID onto all existing
+    // registry entries for the issue (including terminal ones) to close a
+    // race window where gru-do creates its entry after lab reads the pid.
+    // Without this guard a Failed minion would appear "AlreadyRunning" because
+    // the gru-do parent's live PID is sitting on it, causing EXIT_ALREADY_RUNNING
+    // and a thrash loop (issue #879).
     let is_validated_running = |info: &MinionInfo| {
-        info.is_running()
+        !info.orchestration_phase.is_terminal()
+            && info.is_running()
             && (info.pid_start_time.is_some()
                 || !cfg!(any(target_os = "macos", target_os = "linux")))
     };
@@ -105,7 +125,7 @@ pub(super) async fn check_existing_minions(
             owner, repo, issue_num
         );
 
-        return Ok(ExistingMinionCheck::AlreadyRunning);
+        return ExistingMinionCheck::AlreadyRunning;
     }
 
     // All minions are stopped - find the best candidate for resume.
@@ -118,16 +138,13 @@ pub(super) async fn check_existing_minions(
         .find(|(_, info)| !info.orchestration_phase.is_terminal() && info.worktree.exists());
 
     if let Some((minion_id, info)) = resumable {
-        return Ok(ExistingMinionCheck::Resumable(
-            minion_id.clone(),
-            Box::new(info.clone()),
-        ));
+        return ExistingMinionCheck::Resumable(minion_id.clone(), Box::new(info.clone()));
     }
 
     // No running and no resumable minions — allow a fresh attempt. This covers
     // both all-terminal minions (Failed/Completed) and non-terminal ones whose
     // worktrees no longer exist. Lab can automatically retry without --force-new.
-    Ok(ExistingMinionCheck::None)
+    ExistingMinionCheck::None
 }
 
 /// Claims an issue by adding the in-progress label via CLI.
@@ -200,5 +217,136 @@ pub(crate) async fn fetch_issue_details(
             eprintln!("   Fix authentication with: gh auth login");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::minion_registry::{get_process_start_time, MinionMode, OrchestrationPhase};
+    use chrono::Utc;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn make_info(phase: OrchestrationPhase, pid: Option<u32>, worktree: PathBuf) -> MinionInfo {
+        let now = Utc::now();
+        MinionInfo {
+            repo: "owner/repo".to_string(),
+            issue: Some(329),
+            command: "do".to_string(),
+            prompt: "/do 329".to_string(),
+            started_at: now,
+            branch: "minion/issue-329-M1ku".to_string(),
+            worktree,
+            status: "active".to_string(),
+            pr: None,
+            session_id: uuid::Uuid::new_v4().to_string(),
+            pid,
+            pid_start_time: pid.and_then(get_process_start_time),
+            mode: if pid.is_some() {
+                MinionMode::Autonomous
+            } else {
+                MinionMode::Stopped
+            },
+            last_activity: now,
+            orchestration_phase: phase,
+            token_usage: None,
+            agent_name: "claude".to_string(),
+            timeout_deadline: None,
+            attempt_count: 1,
+            no_watch: false,
+            last_review_check_time: None,
+            wake_reason: None,
+            archived_at: None,
+            pending_review_sha: None,
+        }
+    }
+
+    /// A Failed minion with a live PID (from lab's spurious PID stamp) must not
+    /// block a fresh start. Without the is_terminal() guard this would return
+    /// AlreadyRunning, causing EXIT_ALREADY_RUNNING and a thrash loop (#879).
+    #[test]
+    fn failed_minion_with_live_pid_returns_none() {
+        let tmp = tempdir().unwrap();
+        let worktree = tmp.path().to_path_buf();
+        // Simulate lab stamping the new gru-do child PID onto the terminal entry.
+        let live_pid = std::process::id();
+        let info = make_info(OrchestrationPhase::Failed, Some(live_pid), worktree);
+
+        let result = evaluate_existing_minions("owner", "repo", 329, vec![("M1ku".into(), info)]);
+
+        assert!(
+            matches!(result, ExistingMinionCheck::None),
+            "Failed minion with live PID must not block a fresh start, got: {:?}",
+            result
+        );
+    }
+
+    /// A Failed minion with no PID and an existing worktree must also return None
+    /// (not Resumable), so a fresh minion ID is allocated.
+    #[test]
+    fn failed_minion_no_pid_with_worktree_returns_none() {
+        let tmp = tempdir().unwrap();
+        let worktree = tmp.path().to_path_buf();
+        let info = make_info(OrchestrationPhase::Failed, None, worktree);
+
+        let result = evaluate_existing_minions("owner", "repo", 329, vec![("M1ku".into(), info)]);
+
+        assert!(
+            matches!(result, ExistingMinionCheck::None),
+            "Failed minion must not be returned as Resumable, got: {:?}",
+            result
+        );
+    }
+
+    /// A Completed minion with a live PID must also be excluded from AlreadyRunning.
+    #[test]
+    fn completed_minion_with_live_pid_returns_none() {
+        let tmp = tempdir().unwrap();
+        let worktree = tmp.path().to_path_buf();
+        let live_pid = std::process::id();
+        let info = make_info(OrchestrationPhase::Completed, Some(live_pid), worktree);
+
+        let result = evaluate_existing_minions("owner", "repo", 329, vec![("M1ku".into(), info)]);
+
+        assert!(
+            matches!(result, ExistingMinionCheck::None),
+            "Completed minion with live PID must not block a fresh start, got: {:?}",
+            result
+        );
+    }
+
+    /// A non-terminal minion with a live PID and existing worktree must still
+    /// report AlreadyRunning (unchanged behavior for genuinely active minions).
+    #[test]
+    fn active_minion_with_live_pid_returns_already_running() {
+        let tmp = tempdir().unwrap();
+        let worktree = tmp.path().to_path_buf();
+        let live_pid = std::process::id();
+        let info = make_info(OrchestrationPhase::RunningAgent, Some(live_pid), worktree);
+
+        let result = evaluate_existing_minions("owner", "repo", 329, vec![("M1ku".into(), info)]);
+
+        assert!(
+            matches!(result, ExistingMinionCheck::AlreadyRunning),
+            "Active minion with live PID must be detected as AlreadyRunning, got: {:?}",
+            result
+        );
+    }
+
+    /// A non-terminal stopped minion with an existing worktree must be Resumable.
+    #[test]
+    fn stopped_non_terminal_minion_with_worktree_is_resumable() {
+        let tmp = tempdir().unwrap();
+        let worktree = tmp.path().to_path_buf();
+        let info = make_info(OrchestrationPhase::RunningAgent, None, worktree);
+
+        let result = evaluate_existing_minions("owner", "repo", 329, vec![("M1ku".into(), info)]);
+
+        assert!(
+            matches!(result, ExistingMinionCheck::Resumable(ref id, _) if id == "M1ku"),
+            "Stopped non-terminal minion with worktree must be Resumable, got: {:?}",
+            result
+        );
     }
 }

--- a/src/commands/fix/resolve.rs
+++ b/src/commands/fix/resolve.rs
@@ -69,13 +69,13 @@ fn evaluate_existing_minions(
     // On other platforms the start time is always `None`, so we fall back to
     // the plain `is_running()` check to avoid ignoring all running minions.
     //
-    // Terminal entries (Failed/Completed) are intentionally excluded: lab's
-    // try_spawn_for_issue stamps the new gru-do child PID onto all existing
-    // registry entries for the issue (including terminal ones) to close a
-    // race window where gru-do creates its entry after lab reads the pid.
-    // Without this guard a Failed minion would appear "AlreadyRunning" because
-    // the gru-do parent's live PID is sitting on it, causing EXIT_ALREADY_RUNNING
-    // and a thrash loop (issue #879).
+    // Terminal entries (Failed/Completed) are intentionally excluded.
+    // try_spawn_for_issue now skips terminal rows when stamping the new
+    // gru-do child PID onto existing registry entries, but terminal rows may
+    // still carry a spurious live PID from older versions or manual/corrupt
+    // registry state. Without this guard a Failed minion could appear
+    // "AlreadyRunning" because an unrelated live PID is sitting on it,
+    // causing EXIT_ALREADY_RUNNING and a thrash loop (issue #879).
     let is_validated_running = |info: &MinionInfo| {
         !info.orchestration_phase.is_terminal()
             && info.is_running()

--- a/src/commands/fix/types.rs
+++ b/src/commands/fix/types.rs
@@ -74,6 +74,7 @@ pub(crate) struct AgentResult {
 }
 
 /// Result of checking for existing minions on an issue.
+#[derive(Debug)]
 pub(crate) enum ExistingMinionCheck {
     /// No existing minions found, proceed with new session.
     None,

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -405,9 +405,9 @@ async fn handle_failed_exit(
     // Note: this path intentionally does not call `enqueue_failure`. A persistent
     // duplicate-detection loop (e.g. a stuck sibling PID that keeps getting
     // detected) will not advance the retry counter and therefore will not trip
-    // the circuit breaker. The PID-stamping fix in `find_by_issue` should
-    // prevent this in practice; if it ever does recur, the log line below
-    // is the signal.
+    // the circuit breaker. The terminal-entry guards in try_spawn_for_issue and
+    // evaluate_existing_minions should prevent this in practice (issue #879);
+    // if it ever does recur, the log line below is the signal.
     if status.code() == Some(EXIT_ALREADY_RUNNING) {
         log::warn!(
             "⏭️  gru do for issue #{} exited with EXIT_ALREADY_RUNNING (after {:.1}s) — \
@@ -2059,6 +2059,10 @@ async fn is_issue_claimed(repo: &str, issue_number: Option<u64>) -> Result<bool>
             info.repo == repo
                 && info.issue == Some(issue_number)
                 && info.archived_at.is_none()
+                // Terminal entries (Failed/Completed) must never block a new
+                // spawn even if try_spawn_for_issue has already stamped the new
+                // child's PID on them (issue #879).
+                && !info.orchestration_phase.is_terminal()
                 && info.is_running()
                 // Only trust entries with start-time validation on platforms that
                 // support it (macOS, Linux). Legacy entries (pid_start_time = None)

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -2060,8 +2060,9 @@ async fn is_issue_claimed(repo: &str, issue_number: Option<u64>) -> Result<bool>
                 && info.issue == Some(issue_number)
                 && info.archived_at.is_none()
                 // Terminal entries (Failed/Completed) must never block a new
-                // spawn even if try_spawn_for_issue has already stamped the new
-                // child's PID on them (issue #879).
+                // spawn, even if they still carry a PID due to legacy behavior
+                // from older versions or other stale/corrupt registry state
+                // (issue #879).
                 && !info.orchestration_phase.is_terminal()
                 && info.is_running()
                 // Only trust entries with start-time validation on platforms that

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -1504,7 +1504,14 @@ async fn try_spawn_for_issue(
                             issue_number
                         );
                     }
-                    for (mid, _) in entries {
+                    for (mid, entry_info) in entries {
+                        // Skip terminal entries (Failed/Completed): they must
+                        // not be stamped with the new child's PID or their phase
+                        // would appear live to check_existing_minions, causing
+                        // EXIT_ALREADY_RUNNING and a thrash loop (issue #879).
+                        if entry_info.orchestration_phase.is_terminal() {
+                            continue;
+                        }
                         registry.update(&mid, |info| {
                             info.pid = Some(pid);
                             info.pid_start_time =


### PR DESCRIPTION
## Summary

- Fixes a thrash loop where `gru lab` re-trying a Failed issue would produce `EXIT_ALREADY_RUNNING` on every attempt, leaving `gru:in-progress` stuck
- Root cause: `try_spawn_for_issue` stamped the new `gru do` child's PID onto all registry entries for the issue — including terminal (Failed/Completed) ones; `is_validated_running` in `check_existing_minions` then saw the Failed minion with a live PID and returned `AlreadyRunning`
- Two-sided fix: receiver (`evaluate_existing_minions`) adds `!is_terminal()` guard so terminal entries can never be counted as running; sender (`try_spawn_for_issue`) skips terminal entries when stamping the PID so the anomaly never occurs
- Also adds the same guard to `is_issue_claimed` in lab so terminal entries with a spurious PID cannot cause lab itself to skip spawning
- Refactors `check_existing_minions` into a pure `evaluate_existing_minions` helper for direct unit testing; adds 6 unit tests covering the repro case and related scenarios

## Test plan

- `just check` passes (format + lint + 1374 tests)
- New tests in `src/commands/fix/resolve.rs`:
  - `failed_minion_with_live_pid_returns_none` — direct repro case
  - `failed_minion_no_pid_with_worktree_returns_none` — terminal+worktree not resumable
  - `completed_minion_with_live_pid_returns_none` — Completed variant
  - `active_minion_with_live_pid_returns_already_running` — unchanged behavior for genuine running minion
  - `stopped_non_terminal_minion_with_worktree_is_resumable` — unchanged resume behavior
  - `active_minion_not_suppressed_by_failed_sibling_with_live_pid` — mixed entry: terminal sibling must not suppress detection of real running minion

## Notes

- The fix is backward-compatible; all three `ExistingMinionCheck` variants continue to work correctly for non-terminal entries
- The display loop in the `AlreadyRunning` branch now filters to non-terminal entries so a Failed sibling does not appear in the operator-facing "existing Minions" error output

Fixes #879

<sub>🤖 M1lj</sub>