### PR TITLE
Fixes #888: CI fix invokes agent with --max-turns 1, dooming non-trivial fixes

### DIFF
--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -110,7 +110,7 @@
 # installed somewhere other than your $PATH.
 # Can be set without [agent] above if you only need a binary override.
 # binary = "/usr/local/bin/claude"
-
+#
 # Maximum agent turns for CI fix invocations. When unset (the default),
 # there is no turn limit — the 20-minute wall-clock cap is the primary bound.
 # Set to a positive value to impose an explicit turn budget (e.g. 50).

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -111,6 +111,11 @@
 # Can be set without [agent] above if you only need a binary override.
 # binary = "/usr/local/bin/claude"
 
+# Maximum agent turns for CI fix invocations. When unset (the default),
+# there is no turn limit — the 20-minute wall-clock cap is the primary bound.
+# Set to a positive value to impose an explicit turn budget (e.g. 50).
+# ci_fix_max_turns = 50
+
 # ─────────────────────────────────────────────────────────────────────
 # Merge readiness
 # ─────────────────────────────────────────────────────────────────────

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -240,10 +240,14 @@ pub(crate) trait AgentBackend: Send + Sync {
     /// `build_oneshot_command` instead; override this method when the backend
     /// needs a qualitatively different invocation for multi-turn fix cycles.
     ///
-    /// The default implementation delegates to `build_oneshot_command`. Backends
-    /// whose `build_oneshot_command` does not impose a single-turn limit do not
-    /// need to override this method. Backends that do impose such a limit
-    /// (and want CI fix to succeed) must override it here.
+    /// The default implementation delegates to `build_oneshot_command`.
+    ///
+    /// **Implementor note:** If your `build_oneshot_command` imposes a
+    /// single-turn limit (e.g., `--max-turns 1`), you **must** override this
+    /// method — the default delegation will inherit that limit and CI fix
+    /// will always fail to make meaningful progress. Backends whose
+    /// `build_oneshot_command` does not impose such a limit may safely rely
+    /// on the default.
     fn build_ci_fix_command(&self, worktree_path: &Path, prompt_arg: &str) -> TokioCommand {
         self.build_oneshot_command(worktree_path, prompt_arg)
     }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -218,8 +218,8 @@ pub(crate) trait AgentBackend: Send + Sync {
 
     /// Build a command for a one-shot utility task (no session tracking, text output).
     ///
-    /// Used for fire-and-forget invocations like CI fix and merge-readiness judge
-    /// where the caller just needs to run the agent once and capture its text output.
+    /// Used for fire-and-forget invocations like merge-readiness judge where the
+    /// caller just needs a single agent turn and plain-text output.
     ///
     /// `prompt_arg` is passed as a CLI argument to the underlying agent binary.
     /// Callers may either:
@@ -231,6 +231,20 @@ pub(crate) trait AgentBackend: Send + Sync {
     /// Backends must support the `"-"` stdin-sentinel convention.
     /// The command should produce plain-text output on stdout with piped stdio.
     fn build_oneshot_command(&self, worktree_path: &Path, prompt_arg: &str) -> TokioCommand;
+
+    /// Build a command for a CI fix invocation.
+    ///
+    /// Unlike `build_oneshot_command` (which limits to a single turn), CI fix
+    /// requires multiple turns: read failure logs, locate offending code, edit,
+    /// run tests, and commit. The wall-clock timeout (`CI_FIX_TIMEOUT_SECS`) is
+    /// the primary bound.
+    ///
+    /// The default implementation delegates to `build_oneshot_command`, so
+    /// backends that do not distinguish between oneshot and multi-turn CI fix
+    /// invocations do not need to override this method.
+    fn build_ci_fix_command(&self, worktree_path: &Path, prompt_arg: &str) -> TokioCommand {
+        self.build_oneshot_command(worktree_path, prompt_arg)
+    }
 }
 
 #[cfg(test)]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -234,14 +234,16 @@ pub(crate) trait AgentBackend: Send + Sync {
 
     /// Build a command for a CI fix invocation.
     ///
-    /// Unlike `build_oneshot_command` (which limits to a single turn), CI fix
-    /// requires multiple turns: read failure logs, locate offending code, edit,
-    /// run tests, and commit. The wall-clock timeout (`CI_FIX_TIMEOUT_SECS`) is
-    /// the primary bound.
+    /// CI fix requires multiple turns (read failure logs → locate offending
+    /// code → edit → run tests → commit). Backends intended for single-turn
+    /// utility tasks (such as merge-readiness judging) should use
+    /// `build_oneshot_command` instead; override this method when the backend
+    /// needs a qualitatively different invocation for multi-turn fix cycles.
     ///
-    /// The default implementation delegates to `build_oneshot_command`, so
-    /// backends that do not distinguish between oneshot and multi-turn CI fix
-    /// invocations do not need to override this method.
+    /// The default implementation delegates to `build_oneshot_command`. Backends
+    /// whose `build_oneshot_command` does not impose a single-turn limit do not
+    /// need to override this method. Backends that do impose such a limit
+    /// (and want CI fix to succeed) must override it here.
     fn build_ci_fix_command(&self, worktree_path: &Path, prompt_arg: &str) -> TokioCommand {
         self.build_oneshot_command(worktree_path, prompt_arg)
     }

--- a/src/agent_registry.rs
+++ b/src/agent_registry.rs
@@ -18,7 +18,11 @@ pub(crate) const DEFAULT_AGENT: &str = "claude";
 /// Returns an error with available agents listed if the name is unknown.
 pub(crate) fn resolve_backend(agent_name: &str) -> anyhow::Result<Box<dyn AgentBackend>> {
     match agent_name {
-        "claude" => Ok(Box::new(ClaudeBackend::default())),
+        "claude" => {
+            let ci_fix_max_turns =
+                crate::config::try_load_config().and_then(|c| c.agent.claude.ci_fix_max_turns);
+            Ok(Box::new(ClaudeBackend::new(ci_fix_max_turns)))
+        }
         "codex" => Ok(Box::new(CodexBackend)),
         unknown => {
             let available = AVAILABLE_AGENTS.join(", ");

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -716,7 +716,7 @@ pub(crate) async fn invoke_ci_fix(
     let prompt = build_ci_fix_prompt(failed_checks, attempt);
 
     let child = backend
-        .build_oneshot_command(worktree_path, &prompt)
+        .build_ci_fix_command(worktree_path, &prompt)
         .spawn()
         .with_context(|| format!("Agent backend '{}' failed to start", backend.name()))?;
 

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -715,8 +715,11 @@ pub(crate) async fn invoke_ci_fix(
 ) -> Result<i32> {
     let prompt = build_ci_fix_prompt(failed_checks, attempt);
 
-    let child = backend
-        .build_ci_fix_command(worktree_path, &prompt)
+    let mut cmd = backend.build_ci_fix_command(worktree_path, &prompt);
+    // Ensure the agent process is killed if the wall-clock timeout fires;
+    // without this the child keeps running after wait_with_output is dropped.
+    cmd.kill_on_drop(true);
+    let child = cmd
         .spawn()
         .with_context(|| format!("Agent backend '{}' failed to start", backend.name()))?;
 

--- a/src/claude_backend.rs
+++ b/src/claude_backend.rs
@@ -208,6 +208,29 @@ impl AgentBackend for ClaudeBackend {
             .env_remove(crate::labels::GRU_RETRY_PARENT_ENV);
         cmd
     }
+
+    fn build_ci_fix_command(&self, worktree_path: &Path, prompt_arg: &str) -> TokioCommand {
+        let mut cmd = TokioCommand::new("claude");
+        cmd.arg("--print")
+            .arg("--output-format")
+            .arg("text")
+            .arg("--dangerously-skip-permissions");
+
+        // Apply a configurable turn limit if set; otherwise run unbounded,
+        // relying on the CI_FIX_TIMEOUT_SECS wall-clock cap as the primary bound.
+        let max_turns =
+            crate::config::try_load_config().and_then(|c| c.agent.claude.ci_fix_max_turns);
+        if let Some(turns) = max_turns {
+            cmd.arg("--max-turns").arg(turns.to_string());
+        }
+
+        cmd.arg(prompt_arg)
+            .current_dir(worktree_path)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit())
+            .env_remove(crate::labels::GRU_RETRY_PARENT_ENV);
+        cmd
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -416,6 +439,60 @@ mod tests {
         assert!(!args.contains(&"--session-id".as_ref()));
         assert!(!args.contains(&"--verbose".as_ref()));
         assert!(!args.contains(&"stream-json".as_ref()));
+    }
+
+    #[test]
+    fn test_build_ci_fix_command_no_max_turns_by_default() {
+        // Without config, ci_fix_max_turns is None so --max-turns should NOT appear.
+        let b = backend();
+        let path = std::path::PathBuf::from("/tmp/worktree");
+        let cmd = b.build_ci_fix_command(&path, "fix ci");
+        let inner = cmd.as_std();
+
+        assert_eq!(inner.get_program(), "claude");
+        let args: Vec<&std::ffi::OsStr> = inner.get_args().collect();
+        assert!(args.contains(&"--print".as_ref()));
+        assert!(args.contains(&"--dangerously-skip-permissions".as_ref()));
+        assert!(args.contains(&"fix ci".as_ref()));
+        // No --max-turns limit — CI fix needs multiple turns
+        assert!(!args.contains(&"--max-turns".as_ref()));
+    }
+
+    #[test]
+    fn test_build_ci_fix_command_respects_configured_max_turns() {
+        use crate::config::{set_test_config_path, LabConfig};
+        use std::io::Write;
+
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "[agent.claude]\nci_fix_max_turns = 42").unwrap();
+
+        let _guard = set_test_config_path(tmp.path().to_path_buf());
+
+        // Verify the config parses correctly
+        let config = LabConfig::load_partial(tmp.path()).unwrap();
+        assert_eq!(config.agent.claude.ci_fix_max_turns, Some(42));
+
+        let b = backend();
+        let path = std::path::PathBuf::from("/tmp/worktree");
+        let cmd = b.build_ci_fix_command(&path, "fix ci");
+        let inner = cmd.as_std();
+
+        let args: Vec<&std::ffi::OsStr> = inner.get_args().collect();
+        assert!(args.contains(&"--max-turns".as_ref()));
+        assert!(args.contains(&"42".as_ref()));
+    }
+
+    #[test]
+    fn test_build_ci_fix_command_oneshot_still_has_max_turns_1() {
+        // build_oneshot_command must still use --max-turns 1 (merge-readiness judge).
+        let b = backend();
+        let path = std::path::PathBuf::from("/tmp/worktree");
+        let cmd = b.build_oneshot_command(&path, "judge");
+        let inner = cmd.as_std();
+
+        let args: Vec<&std::ffi::OsStr> = inner.get_args().collect();
+        assert!(args.contains(&"--max-turns".as_ref()));
+        assert!(args.contains(&"1".as_ref()));
     }
 
     // ---- parse_event tests ----

--- a/src/claude_backend.rs
+++ b/src/claude_backend.rs
@@ -38,6 +38,22 @@ pub(crate) struct ClaudeBackend {
 }
 
 impl ClaudeBackend {
+    /// Returns a command pre-configured with the flags common to all
+    /// non-interactive Claude invocations (print, text output, no permissions
+    /// prompt, piped stdio). Callers add turn limits and the prompt argument.
+    fn base_noninteractive_cmd(worktree_path: &Path) -> TokioCommand {
+        let mut cmd = TokioCommand::new("claude");
+        cmd.arg("--print")
+            .arg("--output-format")
+            .arg("text")
+            .arg("--dangerously-skip-permissions")
+            .current_dir(worktree_path)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit())
+            .env_remove(crate::labels::GRU_RETRY_PARENT_ENV);
+        cmd
+    }
+
     /// Map a `ClaudeEvent` to an `AgentEvent`, using internal state to buffer
     /// tool invocations until their input JSON is complete.
     fn map_event(&self, event: &ClaudeEvent) -> Option<AgentEvent> {
@@ -194,41 +210,27 @@ impl AgentBackend for ClaudeBackend {
     }
 
     fn build_oneshot_command(&self, worktree_path: &Path, prompt_arg: &str) -> TokioCommand {
-        let mut cmd = TokioCommand::new("claude");
-        cmd.arg("--print")
-            .arg("--output-format")
-            .arg("text")
-            .arg("--max-turns")
-            .arg("1")
-            .arg("--dangerously-skip-permissions")
-            .arg(prompt_arg)
-            .current_dir(worktree_path)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::inherit())
-            .env_remove(crate::labels::GRU_RETRY_PARENT_ENV);
+        let mut cmd = ClaudeBackend::base_noninteractive_cmd(worktree_path);
+        cmd.arg("--max-turns").arg("1").arg(prompt_arg);
         cmd
     }
 
     fn build_ci_fix_command(&self, worktree_path: &Path, prompt_arg: &str) -> TokioCommand {
-        let mut cmd = TokioCommand::new("claude");
-        cmd.arg("--print")
-            .arg("--output-format")
-            .arg("text")
-            .arg("--dangerously-skip-permissions");
+        let mut cmd = ClaudeBackend::base_noninteractive_cmd(worktree_path);
 
         // Apply a configurable turn limit if set; otherwise run unbounded,
         // relying on the CI_FIX_TIMEOUT_SECS wall-clock cap as the primary bound.
+        //
+        // TODO: tech debt — reading config from disk inside a command builder
+        // couples ClaudeBackend to the filesystem. Ideally ci_fix_max_turns would
+        // be injected at construction time (see issue #888 review comments).
         let max_turns =
             crate::config::try_load_config().and_then(|c| c.agent.claude.ci_fix_max_turns);
         if let Some(turns) = max_turns {
             cmd.arg("--max-turns").arg(turns.to_string());
         }
 
-        cmd.arg(prompt_arg)
-            .current_dir(worktree_path)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::inherit())
-            .env_remove(crate::labels::GRU_RETRY_PARENT_ENV);
+        cmd.arg(prompt_arg);
         cmd
     }
 }

--- a/src/claude_backend.rs
+++ b/src/claude_backend.rs
@@ -32,12 +32,29 @@ struct ToolBuffer {
 /// internally, emitting a single `AgentEvent::ToolUse` with a populated
 /// `input_summary` when `ContentBlockStop` arrives. This eliminates the UX
 /// regression of showing "Tool: Bash" instead of "Run: git status".
-#[derive(Default)]
 pub(crate) struct ClaudeBackend {
     tool_buffer: Mutex<Option<ToolBuffer>>,
+    /// Maximum agent turns for CI fix invocations. `None` means no limit.
+    ci_fix_max_turns: Option<u32>,
+}
+
+impl Default for ClaudeBackend {
+    fn default() -> Self {
+        Self {
+            tool_buffer: Mutex::new(None),
+            ci_fix_max_turns: None,
+        }
+    }
 }
 
 impl ClaudeBackend {
+    pub(crate) fn new(ci_fix_max_turns: Option<u32>) -> Self {
+        Self {
+            tool_buffer: Mutex::new(None),
+            ci_fix_max_turns,
+        }
+    }
+
     /// Returns a command pre-configured with the flags common to all
     /// non-interactive Claude invocations (print, text output, no permissions
     /// prompt, piped stdio). Callers add turn limits and the prompt argument.
@@ -220,13 +237,7 @@ impl AgentBackend for ClaudeBackend {
 
         // Apply a configurable turn limit if set; otherwise run unbounded,
         // relying on the CI_FIX_TIMEOUT_SECS wall-clock cap as the primary bound.
-        //
-        // TODO: tech debt — reading config from disk inside a command builder
-        // couples ClaudeBackend to the filesystem. Ideally ci_fix_max_turns would
-        // be injected at construction time (see issue #888 review comments).
-        let max_turns =
-            crate::config::try_load_config().and_then(|c| c.agent.claude.ci_fix_max_turns);
-        if let Some(turns) = max_turns {
+        if let Some(turns) = self.ci_fix_max_turns {
             cmd.arg("--max-turns").arg(turns.to_string());
         }
 
@@ -445,8 +456,9 @@ mod tests {
 
     #[test]
     fn test_build_ci_fix_command_no_max_turns_by_default() {
-        // Without config, ci_fix_max_turns is None so --max-turns should NOT appear.
-        let b = backend();
+        // ClaudeBackend::default() has ci_fix_max_turns = None, so --max-turns
+        // must not appear. Hermetic: no ambient config is consulted.
+        let b = ClaudeBackend::default();
         let path = std::path::PathBuf::from("/tmp/worktree");
         let cmd = b.build_ci_fix_command(&path, "fix ci");
         let inner = cmd.as_std();
@@ -462,19 +474,8 @@ mod tests {
 
     #[test]
     fn test_build_ci_fix_command_respects_configured_max_turns() {
-        use crate::config::{set_test_config_path, LabConfig};
-        use std::io::Write;
-
-        let mut tmp = tempfile::NamedTempFile::new().unwrap();
-        writeln!(tmp, "[agent.claude]\nci_fix_max_turns = 42").unwrap();
-
-        let _guard = set_test_config_path(tmp.path().to_path_buf());
-
-        // Verify the config parses correctly
-        let config = LabConfig::load_partial(tmp.path()).unwrap();
-        assert_eq!(config.agent.claude.ci_fix_max_turns, Some(42));
-
-        let b = backend();
+        // Construct the backend directly with a turn limit — no filesystem I/O.
+        let b = ClaudeBackend::new(Some(42));
         let path = std::path::PathBuf::from("/tmp/worktree");
         let cmd = b.build_ci_fix_command(&path, "fix ci");
         let inner = cmd.as_std();

--- a/src/config.rs
+++ b/src/config.rs
@@ -738,6 +738,13 @@ impl LabConfig {
 
         config.validate_github_hosts()?;
 
+        if config.agent.claude.ci_fix_max_turns == Some(0) {
+            anyhow::bail!(
+                "agent.claude.ci_fix_max_turns must be a positive integer (got 0). \
+                 Remove the field to use no limit, or set it to a positive value."
+            );
+        }
+
         Ok(config)
     }
 
@@ -1202,6 +1209,39 @@ default = "aider"
         // Parsing succeeds (validation happens in AgentRegistry, not config parsing)
         let config = LabConfig::load(temp_file.path()).unwrap();
         assert_eq!(config.agent.default, "aider");
+    }
+
+    #[test]
+    fn test_ci_fix_max_turns_parses() {
+        let config_toml = "[agent.claude]\nci_fix_max_turns = 50\n";
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(config_toml.as_bytes()).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = LabConfig::load_partial(temp_file.path()).unwrap();
+        assert_eq!(config.agent.claude.ci_fix_max_turns, Some(50));
+    }
+
+    #[test]
+    fn test_ci_fix_max_turns_default_is_none() {
+        let config = LabConfig::default();
+        assert!(config.agent.claude.ci_fix_max_turns.is_none());
+    }
+
+    #[test]
+    fn test_ci_fix_max_turns_zero_is_rejected() {
+        let config_toml = "[agent.claude]\nci_fix_max_turns = 0\n";
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(config_toml.as_bytes()).unwrap();
+        temp_file.flush().unwrap();
+
+        let result = LabConfig::load_partial(temp_file.path());
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("ci_fix_max_turns"),
+            "error should mention the field: {msg}"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,13 @@ pub(crate) struct ClaudeAgentConfig {
     /// Override the binary path for Claude Code CLI
     #[serde(default)]
     pub(crate) binary: Option<String>,
+
+    /// Maximum agent turns for CI fix invocations.
+    /// `None` (the default) means no limit — the 20-minute wall-clock cap
+    /// (`CI_FIX_TIMEOUT_SECS`) is the primary bound. Set to a positive value
+    /// to impose an explicit turn limit (e.g., 50).
+    #[serde(default)]
+    pub(crate) ci_fix_max_turns: Option<u32>,
 }
 
 fn default_agent_name() -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -737,13 +737,7 @@ impl LabConfig {
             .with_context(|| format!("Failed to parse config file: {}", path.display()))?;
 
         config.validate_github_hosts()?;
-
-        if config.agent.claude.ci_fix_max_turns == Some(0) {
-            anyhow::bail!(
-                "agent.claude.ci_fix_max_turns must be a positive integer (got 0). \
-                 Remove the field to use no limit, or set it to a positive value."
-            );
-        }
+        config.validate_agent()?;
 
         Ok(config)
     }
@@ -791,6 +785,7 @@ impl LabConfig {
         }
 
         self.validate_github_hosts()?;
+        self.validate_agent()?;
 
         // Validate repo format and host name references
         for repo in &self.daemon.repos {
@@ -824,6 +819,20 @@ impl LabConfig {
             }
         }
 
+        Ok(())
+    }
+
+    /// Validate agent configuration.
+    ///
+    /// Runs in both `load()` and `load_partial()` because agent settings are
+    /// used by all commands, not just the daemon.
+    fn validate_agent(&self) -> Result<()> {
+        if self.agent.claude.ci_fix_max_turns == Some(0) {
+            anyhow::bail!(
+                "agent.claude.ci_fix_max_turns must be a positive integer (got 0). \
+                 Remove the field to use no limit, or set it to a positive value."
+            );
+        }
         Ok(())
     }
 
@@ -1229,13 +1238,31 @@ default = "aider"
     }
 
     #[test]
-    fn test_ci_fix_max_turns_zero_is_rejected() {
+    fn test_ci_fix_max_turns_zero_is_rejected_by_load_partial() {
         let config_toml = "[agent.claude]\nci_fix_max_turns = 0\n";
         let mut temp_file = NamedTempFile::new().unwrap();
         temp_file.write_all(config_toml.as_bytes()).unwrap();
         temp_file.flush().unwrap();
 
         let result = LabConfig::load_partial(temp_file.path());
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("ci_fix_max_turns"),
+            "error should mention the field: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_ci_fix_max_turns_zero_is_rejected_by_load() {
+        // gru lab uses LabConfig::load() — ensure it also rejects ci_fix_max_turns = 0.
+        let config_toml =
+            "[daemon]\nrepos = [\"owner/repo\"]\n\n[agent.claude]\nci_fix_max_turns = 0\n";
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(config_toml.as_bytes()).unwrap();
+        temp_file.flush().unwrap();
+
+        let result = LabConfig::load(temp_file.path());
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(


### PR DESCRIPTION
## Summary

- `invoke_ci_fix` was calling `backend.build_oneshot_command()`, which hardcodes `--max-turns 1` — giving the agent one turn to read CI logs, locate the bug, edit code, run tests, and commit. That's impossible in one turn.
- Added `AgentBackend::build_ci_fix_command` as a new trait method with a default impl that delegates to `build_oneshot_command` (backward compatible — Codex and test mocks inherit this without change).
- `ClaudeBackend` overrides `build_ci_fix_command` to omit `--max-turns`, so the existing 20-minute wall-clock cap (`CI_FIX_TIMEOUT_SECS`) is the sole bound.
- Added `agent.claude.ci_fix_max_turns: Option<u32>` config field (default `None` = unlimited) for operators who want an explicit turn budget.
- `invoke_ci_fix` now calls `build_ci_fix_command` instead of `build_oneshot_command`. The merge-readiness judge (the other oneshot caller) is unaffected and keeps its single-turn constraint.
- `ci_fix_max_turns = 0` is rejected at config load time with a clear error message.

## Test plan

- `test_build_ci_fix_command_no_max_turns_by_default` — verifies `--max-turns` is absent when no config is set
- `test_build_ci_fix_command_respects_configured_max_turns` — sets `ci_fix_max_turns = 42` via test config override and verifies `--max-turns 42` appears in the built command
- `test_build_ci_fix_command_oneshot_still_has_max_turns_1` — regression guard that `build_oneshot_command` still produces `--max-turns 1`
- `test_ci_fix_max_turns_parses` — config field round-trips correctly
- `test_ci_fix_max_turns_default_is_none` — default is `None`
- `test_ci_fix_max_turns_zero_is_rejected` — `load_partial` rejects `ci_fix_max_turns = 0`
- `just check` — 1399 tests pass, no clippy warnings, formatted

Commands run: `just check`

## Notes

- The `binary` field in `ClaudeAgentConfig` is declared but not consumed by any command builder — that's a pre-existing gap unrelated to this issue, affecting all four command builders equally.
- The Codex backend inherits the default `build_ci_fix_command → build_oneshot_command` delegation. Codex's `build_oneshot_command` does not add `--max-turns`, so the default is already safe for multi-turn use there.

Fixes #888

<sub>🤖 M1mj</sub>