### PR TITLE
Fixes #900: Need more emojis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,9 +837,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "1.2.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64",
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "1.21", features = ["v4"] }
 fs2 = "0.4"
 tempfile = "3.26"
 which = "8.0.2"
-rmcp = { version = "1.2", features = ["server", "transport-io"] }
+rmcp = { version = "1.4", features = ["server", "transport-io"] }
 schemars = "1.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gru
+# Gru 🍌
 
 [![CI](https://github.com/fotoetienne/gru/actions/workflows/ci.yml/badge.svg)](https://github.com/fotoetienne/gru/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -12,7 +12,7 @@ Point it at an issue and it handles the rest: implementation, PR, code review, C
 
 Gru is **agent-agnostic**. It ships with backends for [Claude Code](https://github.com/anthropics/claude-code) and [OpenAI Codex](https://github.com/openai/codex), and its pluggable architecture makes it straightforward to add more.
 
-## Quick Start
+## 🚀 Quick Start
 
 ```bash
 # Install (macOS Apple Silicon — see Installation for other platforms)
@@ -26,7 +26,7 @@ gru init owner/repo
 gru do 42
 ```
 
-## Installation
+## 📦 Installation
 
 ### Prerequisites
 
@@ -70,7 +70,7 @@ The `gru` binary is installed to `~/.cargo/bin/gru`. Make sure `~/.cargo/bin` is
 
 For a detailed walkthrough, see [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
 
-## Usage
+## 🛠️ Usage
 
 ### Work on Issues
 
@@ -167,7 +167,7 @@ M002     codex    owner/repo   #44    do    -     minion/issue-44-M002  working 
 
 See [docs/AGENTS.md](docs/AGENTS.md) for setup details and feature comparison.
 
-## Lab Mode
+## 🧪 Lab Mode
 
 Run Gru as a daemon that continuously polls for `gru:todo` issues and spawns Minions to work on them:
 
@@ -195,7 +195,7 @@ gru mcp uninstall    # Remove from ~/.claude.json
 
 Once installed, Claude Code sessions can query Minion status and read Gru guides without leaving the conversation.
 
-## Configuration
+## ⚙️ Configuration
 
 All configuration lives in `~/.gru/config.toml`. Everything is optional — Gru works out of the box with sensible defaults.
 
@@ -217,13 +217,13 @@ Key options: default agent backend, polling intervals, concurrency slots, merge 
 6. Review comments are forwarded to the agent for responses
 7. Labels (`gru:todo` → `gru:in-progress` → `gru:done` / `gru:failed`) track state on GitHub
 
-## Roadmap
+## 🗺️ Roadmap
 
 V1 is feature-complete: autonomous issue fixing, worktree isolation, lab mode, CI monitoring, PR lifecycle management, multi-agent backends, and Minion management.
 
 Future plans include multi-Lab coordination (V2), a web UI (V3), issue dependency graphs (V4), and multi-repo orchestration (V5). See [docs/DESIGN.md](docs/DESIGN.md) for the full architecture vision.
 
-## Contributing
+## 🤝 Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, build commands, testing, and PR workflow.
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -248,10 +248,9 @@ pub(crate) fn split_github_url(url: &str) -> Option<GitUrlParts<'_>> {
     }
     let (scheme, rest) = if let Some(r) = url.strip_prefix("https://") {
         (GitUrlScheme::Https, r)
-    } else if let Some(r) = url.strip_prefix("http://") {
-        (GitUrlScheme::Http, r)
     } else {
-        return None;
+        let r = url.strip_prefix("http://")?;
+        (GitUrlScheme::Http, r)
     };
     // The authority runs up to the first path/query/fragment separator.
     let auth_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -192,7 +192,7 @@ impl GruMcpServer {
     }
 }
 
-#[tool_handler]
+#[tool_handler(router = self.tool_router.clone())]
 impl ServerHandler for GruMcpServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(


### PR DESCRIPTION
## Summary
- Added emojis to the README title and section headings (Quick Start, Installation, Usage, Lab Mode, Configuration, Roadmap, Contributing)
- Fixed a pre-existing `clippy::question_mark` lint failure in `src/git.rs` that was blocking commits on this branch (unrelated to the README change, but needed to get past the pre-commit hook)
- Upgraded `rmcp` from 1.2 to 1.4+ (resolves to 1.8.0) to fix RUSTSEC-2026-0189, a high-severity DNS rebinding vulnerability in its Streamable HTTP server transport; updated `src/mcp.rs` to point the `tool_handler` macro at the cached `tool_router` field explicitly, since rmcp 1.8's macro now defaults to reconstructing the router via `Self::tool_router()` instead of reading the stored field

## Test plan
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `just test` (1436 tests passed, 10 skipped)
- Confirmed no docs reference README.md heading anchors, so GitHub's anchor-slug generation (which strips emoji) doesn't break any links

## Notes
- The `git.rs` fix is a small, behavior-preserving refactor (if/else-if/else → `?` operator) required to unblock the pre-commit hook; it's unrelated to issue #900 but was bundled in since it was a hard blocker for any commit on this branch.
- The `rmcp` security upgrade landed on this branch from an automated security-audit fix and is unrelated to issue #900, but is included here since it's already part of this branch's history.

Fixes #900

<sub>🤖 M1qs</sub>